### PR TITLE
Export Body and RequestBuilder for client wrappers

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -1,10 +1,12 @@
 use std::io::Read;
 
+/// Body type for a request.
 pub struct Body {
     reader: Kind,
 }
 
 impl Body {
+    /// Instantiate a `Body` from a reader.
     pub fn new<R: Read + 'static>(reader: R) -> Body {
         Body {
             reader: Kind::Reader(Box::new(reader), None),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,9 @@ pub use hyper::version::HttpVersion;
 pub use hyper::Url;
 pub use url::ParseError as UrlError;
 
-pub use self::client::{Client, Response};
+pub use self::client::{Client, Response, RequestBuilder};
 pub use self::error::{Error, Result};
+pub use self::body::Body;
 
 mod body;
 mod client;


### PR DESCRIPTION
I was tinkering with converting a project from hyper to reqwest to experiment with the native-tls bits, and definitely found myself needing `RequestBuilder` and `Body` exported. Of course I have no expectations here, but thought I'd throw the change in a PR in case it fit into your current plans.

That said, I don't exactly love the `Body::new` that I ended up exposing. Hyper's `Body` made it easier to create APIs that accept strings, byte arrays, and readers via `Into<Body>`. Sadly `impl <R: Read + 'static> From<R> for Body` is a conflicting implementation (until specialization stabilizes?). In current form, I'd be tempted to wrap `Body` in my API client just to provide the blanket reader conversion for convenience at the loss of knowing the size upfront for types like `Vec<u8>`. But overall, I'm really looking forward to this crate.
