### PR TITLE
Body conversion for File

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -167,8 +167,8 @@ impl<'a> RequestBuilder<'a> {
                 let mut req = client.inner.request(method.clone(), url.clone())
                     .headers(headers.clone());
 
-                if let Some(ref b) = body {
-                    let body = body::as_hyper_body(&b);
+                if let Some(ref mut b) = body {
+                    let body = body::as_hyper_body(b);
                     req = req.body(body);
                 }
 


### PR DESCRIPTION
This adds a `File` into `Body` conversion (mentioned in #6) and the related implementation for converting to hyper's `Body` type.

(I'm just a bit anxious to move off of hyper to experiment with native-tls.)