### PR TITLE
Implement std::fmt::Debug for all public types

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -1,7 +1,9 @@
 use std::io::Read;
 use std::fs::File;
+use std::fmt;
 
 /// Body type for a request.
+#[derive(Debug)]
 pub struct Body {
     reader: Kind,
 }
@@ -67,6 +69,15 @@ impl From<File> for Body {
         let len = f.metadata().map(|m| m.len()).ok();
         Body {
             reader: Kind::Reader(Box::new(f), len),
+        }
+    }
+}
+
+impl fmt::Debug for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &Kind::Reader(_, ref v) => f.debug_tuple("Kind::Reader").field(&"_").field(v).finish(),
+            &Kind::Bytes(ref v) => f.debug_tuple("Kind::Bytes").field(v).finish(),
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,6 +22,7 @@ static DEFAULT_USER_AGENT: &'static str = concat!(env!("CARGO_PKG_NAME"), "/", e
 ///
 /// The `Client` holds a connection pool internally, so it is advised that
 /// you create one and reuse it.
+#[derive(Debug)]
 pub struct Client {
     inner: ::hyper::Client,
 }
@@ -81,6 +82,7 @@ fn new_hyper_client() -> ::Result<::hyper::Client> {
 
 
 /// A builder to construct the properties of a `Request`.
+#[derive(Debug)]
 pub struct RequestBuilder<'a> {
     client: &'a Client,
 
@@ -253,6 +255,7 @@ impl<'a> RequestBuilder<'a> {
 }
 
 /// A Response to a submitted `Request`.
+#[derive(Debug)]
 pub struct Response {
     inner: ::hyper::client::Response,
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub struct RedirectPolicy {
     inner: ()
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Read, Write};
 use std::net::SocketAddr;
 use std::time::Duration;
+use std::fmt;
 
 use hyper::net::{SslClient, HttpStream, NetworkStream};
 use native_tls::{TlsConnector, TlsStream as NativeTlsStream, HandshakeError};
@@ -34,6 +35,13 @@ impl SslClient for TlsClient {
     }
 }
 
+impl fmt::Debug for TlsClient {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("TlsClient").field(&"_").finish()
+    }
+}
+
+#[derive(Debug)]
 pub struct TlsStream(NativeTlsStream<HttpStream>);
 
 impl Read for TlsStream {


### PR DESCRIPTION
Makes it easier for applications, they can just #[derive(Debug)] on their types without having to implement Debug manually