### PR TITLE
Refactoring the `RequestBuilder.send()` method

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,10 +22,8 @@ impl fmt::Display for Error {
         match *self {
             Error::Http(ref e) => fmt::Display::fmt(e, f),
             Error::Serialize(ref e) => fmt::Display::fmt(e, f),
-            Error::TooManyRedirects => {
-                f.pad("Too many redirects")
-            },
-            Error::__DontMatchMe => unreachable!()
+            Error::TooManyRedirects => f.pad("Too many redirects"),
+            Error::__DontMatchMe => unreachable!(),
         }
     }
 }
@@ -36,7 +34,7 @@ impl StdError for Error {
             Error::Http(ref e) => e.description(),
             Error::Serialize(ref e) => e.description(),
             Error::TooManyRedirects => "Too many redirects",
-            Error::__DontMatchMe => unreachable!()
+            Error::__DontMatchMe => unreachable!(),
         }
     }
 
@@ -45,14 +43,13 @@ impl StdError for Error {
             Error::Http(ref e) => Some(e),
             Error::Serialize(ref e) => Some(&**e),
             Error::TooManyRedirects => None,
-            Error::__DontMatchMe => unreachable!()
+            Error::__DontMatchMe => unreachable!(),
         }
     }
 }
 
 fn _assert_types() {
-    fn _assert_send<T: Send>() {
-    }
+    fn _assert_send<T: Send>() {}
     _assert_send::<Error>();
 }
 


### PR DESCRIPTION
@seanmonstar, I've started to refactor the `RequestBuilder.send()` method so instead of being one giant method which has to worry about lots of low level things (like setting headers), it uses helper methods so you can focus on the main business logic. Hopefully this'll make it a lot easier later on when you want to add support for a `RedirectPolicy` or other features.

I'm having a couple small issues though. Currently this is what the new `RequestBuilder.send()` method looks like:

- verify the RequestBuilder was valid
- send off the request
- if it was a redirect, try to generate a new request from the response (using `Location` header etc)
- otherwise, return to user.

I'm currently having issues creating the new request though. I don't want to be explicitly passing around all the individual components of a request (url, headers, body, etc) because that kinda defeats the purpose of the refactor, yet the `hyper::client::RequestBuilder` doesn't give me any access to what I need.

@seanmonstar, have you got any idea what I could do to resolve this? This isn't ready to be merged yet, but I thought I'd ask you about the best way to proceed so I can finish the PR.

I added a temporary test which simply goes to a URL I know will be a redirect (in this case, google's http://google.com/) and makes sure we actually got redirected, but other than that I can't guarantee that this refactor won't break everything. Other than the `simple.rs` in the `examples/` directory, would you happen to have any other small programs I can use to test that everything still works after I've completed this refactor?