### PR TITLE
export hyper::Error for use in custom types implementing Header

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ extern crate serde_urlencoded;
 extern crate url;
 
 pub use hyper::client::IntoUrl;
+pub use hyper::Error as HyperError;
 pub use hyper::header;
 pub use hyper::method::Method;
 pub use hyper::status::StatusCode;


### PR DESCRIPTION
Hi! I'm writing an application using reqwest, and I've come across the need to implement a custom type implementing the `Header` trait. Since `Header` is defined in hyper, this requires using the `Error` type defined in hyper rather the one from reqwest. Unfortunately, I'm unable to add hyper as a dependency, as  the versions of `openssl-sys` depended on by cookie (a dependency of hyper) and native-tls (a dependency of reqwest) conflict, and Cargo understandably refuses to link to the same native library twice. (This makes perfect sense, but somehow I had never run into this issue in Rust before).

Rather than trying to constantly keep all the versions of openssl in sync (I've already seen at least one issue related to this from digging through the repo), it seems like the easiest solution is just to export `hyper::Error` (with a name alias to avoid collision with request::Error), which bypasses the need to add hyper as a direct dependency (which also seems desirable from a usability standpoint).