### PR TITLE
Upgrade url crate to 1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ native-tls = "0.1"
 serde = "0.8"
 serde_json = "0.8"
 serde_urlencoded = "0.3"
-url = "1.2"
+url = "1.3"
 
 [dev-dependencies]
 env_logger = "0.3"


### PR DESCRIPTION
Gives us the new [parse_with_params](https://docs.rs/url/1.3.0/url/struct.Url.html#method.parse_with_params) method. Very useful for making quick URLs with user-supplied params