### PR TITLE
Implement `Body::sized`

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -27,11 +27,17 @@ impl Body {
         }
     }
 
-    /*
-    pub fn sized(reader: (), len: u64) -> Body {
-        unimplemented!()
+    /// Create a `Body` from a `Reader` where we can predict the size in
+    /// advance, but where we don't want to load the data in memory.  This
+    /// is useful if we need to ensure `Content-Length` is passed with the
+    /// request.
+    pub fn sized<R: Read + Send + 'static>(reader: R, len: u64) -> Body {
+        Body {
+            reader: Kind::Reader(Box::new(reader), Some(len)),
+        }
     }
 
+    /*
     pub fn chunked(reader: ()) -> Body {
         unimplemented!()
     }


### PR DESCRIPTION
This is necessary for APIs such as BigML's, where we may need to send extremely large request bodies, but chunked transfer encoding is not supported.

This is a partial fix for seanmonstar/reqwest#49.