### PR TITLE
Allow swapping out native-tls for rustls

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,4 +13,5 @@ install:
 build: false
 test_script:
   - cargo build --verbose
+  - cargo build --verbose --no-default-features
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
 
 script:
   - cargo build --verbose
+  - cargo build --verbose --no-default-features
   - cargo test --verbose
 
 notifications:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["web-programming::http-client"]
 
 [dependencies]
 hyper = "0.10.2"
-hyper-native-tls = "0.2"
+hyper-native-tls = { version = "0.2", optional = true }
 log = "0.3"
 serde = "0.9"
 serde_json = "0.9"
@@ -21,3 +21,7 @@ libflate = "0.1.3"
 
 [dev-dependencies]
 env_logger = "0.3"
+
+[features]
+default = ["default-tls"]
+default-tls = ["hyper-native-tls"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,16 +32,23 @@ pub struct Client {
 
 impl Client {
     /// Constructs a new `Client`.
+    #[cfg(feature = "default-tls")]
     pub fn new() -> ::Result<Client> {
         let mut client = try!(new_hyper_client());
         client.set_redirect_policy(::hyper::client::RedirectPolicy::FollowNone);
-        Ok(Client {
+        Ok(Client::with_hyper_client(client))
+    }
+
+    /// Constructs a new `Client` with the provided `::hyper::Client` without
+    /// altering any settings.
+    pub fn with_hyper_client(client: ::hyper::Client) -> Client {
+        Client {
             inner: Arc::new(ClientRef {
                 hyper: client,
                 redirect_policy: Mutex::new(RedirectPolicy::default()),
                 auto_ungzip: AtomicBool::new(true),
             }),
-        })
+        }
     }
 
     /// Enable auto gzip decompression by checking the ContentEncoding response header.
@@ -112,6 +119,7 @@ struct ClientRef {
     auto_ungzip: AtomicBool,
 }
 
+#[cfg(feature = "default-tls")]
 fn new_hyper_client() -> ::Result<::hyper::Client> {
     use hyper_native_tls::NativeTlsClient;
     Ok(::hyper::Client::with_connector(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ extern crate hyper;
 
 #[macro_use] extern crate log;
 extern crate libflate;
+#[cfg(feature = "default-tls")]
 extern crate hyper_native_tls;
 extern crate serde;
 extern crate serde_json;
@@ -143,6 +144,7 @@ mod redirect;
 /// reqwest::get("https://www.rust-lang.org").unwrap()
 ///     .read_to_string(&mut result);
 /// ```
+#[cfg(feature = "default-tls")]
 pub fn get<T: IntoUrl>(url: T) -> ::Result<Response> {
     let client = try!(Client::new());
     client.get(url).send()


### PR DESCRIPTION
As far as I can see, there are three possible approaches to allow swapping out the ssl implementation:

1. Specify features in Cargo.toml that allow consuming users to swap out tls implementations. Advantage: swapping is as simple as `default-features = false, features = ["rustls"]` in Cargo.toml. Disadvantage: requires every possible desired alternative ssl implementation to be a feature (and multiplies features/parameters by `N^2` for the other `hyper::Client` things users might want to tweak before construction).
2. Make a `Client::new_with_tlsclient` function, which takes a `S: SslClient`. Advantage: no hardcoding, still pretty simple to create. Disadvantage: still has the potential of multiplying by `N^2` when users want to tweak other things.
3. Give the user an option to pass in a `hyper::Client` directly. Advantage: most flexible option. Disadvantage: most complex for the user (though they're probably a power user anyway), permits the user to possibly break some assumptions of reqwest (e.g. there's a client pool).

I think my preferred option is 3, but I'm not clear what the implications are of a user passing in a client that doesn't use a pool. Hopefully it'll just be slower?

Anyway, because of the uncertainty I implemented option 1 just to show willing :)