### PR TITLE
Modify Content-Encoding, Content-Length, and Accept-Encoding for gzip

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use hyper::client::IntoUrl;
 use hyper::header::{Headers, ContentType, Location, Referer, UserAgent, Accept, ContentEncoding, Encoding, ContentLength,
-    TransferEncoding};
+    TransferEncoding, AcceptEncoding, Range, qitem};
 use hyper::method::Method;
 use hyper::status::StatusCode;
 use hyper::version::HttpVersion;
@@ -226,7 +226,11 @@ impl RequestBuilder {
         if !self.headers.has::<Accept>() {
             self.headers.set(Accept::star());
         }
-
+        if self.client.auto_ungzip.load(Ordering::Relaxed) &&
+            !self.headers.has::<AcceptEncoding>() &&
+            !self.headers.has::<Range>() {
+            self.headers.set(AcceptEncoding(vec![qitem(Encoding::Gzip)]));
+        }
         let client = self.client;
         let mut method = self.method;
         let mut url = try!(self.url);
@@ -411,18 +415,23 @@ impl Decoder {
     /// how to decode the content body of the request.
     ///
     /// Uses the correct variant by inspecting the Content-Encoding header.
-    fn from_hyper_response(res: ::hyper::client::Response, check_gzip: bool) -> Self {
+    fn from_hyper_response(mut res: ::hyper::client::Response, check_gzip: bool) -> Self {
         if !check_gzip {
             return Decoder::PlainText(res);
         }
+        let content_encoding_gzip: bool;
         let mut is_gzip = {
-            res.headers.get::<ContentEncoding>().map_or(false, |encs|{
+            content_encoding_gzip = res.headers.get::<ContentEncoding>().map_or(false, |encs|{
                 encs.contains(&Encoding::Gzip)
-            }) ||
-            res.headers.get::<TransferEncoding>().map_or(false, |encs|{
+            });
+            content_encoding_gzip || res.headers.get::<TransferEncoding>().map_or(false, |encs|{
                 encs.contains(&Encoding::Gzip)
             })
         };
+        if content_encoding_gzip {
+            res.headers.remove::<ContentEncoding>();
+            res.headers.remove::<ContentLength>();
+        }
         if is_gzip {
             if let Some(content_length) = res.headers.get::<ContentLength>() {
                 if content_length.0 == 0 {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -14,6 +14,7 @@ fn test_get() {
             Host: $HOST\r\n\
             User-Agent: $USERAGENT\r\n\
             Accept: */*\r\n\
+            Accept-Encoding: gzip\r\n\
             \r\n\
             ",
         response: b"\
@@ -47,6 +48,7 @@ fn test_redirect_301_and_302_and_303_changes_post_to_get() {
                 Host: $HOST\r\n\
                 User-Agent: $USERAGENT\r\n\
                 Accept: */*\r\n\
+                Accept-Encoding: gzip\r\n\
                 Content-Length: 0\r\n\
                 \r\n\
                 ", code),
@@ -64,6 +66,7 @@ fn test_redirect_301_and_302_and_303_changes_post_to_get() {
                 Host: $HOST\r\n\
                 User-Agent: $USERAGENT\r\n\
                 Accept: */*\r\n\
+                Accept-Encoding: gzip\r\n\
                 Referer: http://$HOST/{}\r\n\
                 \r\n\
                 ", code),
@@ -94,6 +97,7 @@ fn test_redirect_307_and_308_tries_to_post_again() {
                 Host: $HOST\r\n\
                 User-Agent: $USERAGENT\r\n\
                 Accept: */*\r\n\
+                Accept-Encoding: gzip\r\n\
                 Content-Length: 5\r\n\
                 \r\n\
                 Hello\
@@ -112,6 +116,7 @@ fn test_redirect_307_and_308_tries_to_post_again() {
                 Host: $HOST\r\n\
                 User-Agent: $USERAGENT\r\n\
                 Accept: */*\r\n\
+                Accept-Encoding: gzip\r\n\
                 Referer: http://$HOST/{}\r\n\
                 Content-Length: 5\r\n\
                 \r\n\
@@ -145,6 +150,7 @@ fn test_redirect_307_does_not_try_if_reader_cannot_reset() {
                 Host: $HOST\r\n\
                 User-Agent: $USERAGENT\r\n\
                 Accept: */*\r\n\
+                Accept-Encoding: gzip\r\n\
                 Transfer-Encoding: chunked\r\n\
                 \r\n\
                 5\r\n\
@@ -177,6 +183,7 @@ fn test_redirect_policy_can_return_errors() {
             Host: $HOST\r\n\
             User-Agent: $USERAGENT\r\n\
             Accept: */*\r\n\
+            Accept-Encoding: gzip\r\n\
             \r\n\
             ",
         response: b"\
@@ -203,6 +210,7 @@ fn test_redirect_policy_can_stop_redirects_without_an_error() {
             Host: $HOST\r\n\
             User-Agent: $USERAGENT\r\n\
             Accept: */*\r\n\
+            Accept-Encoding: gzip\r\n\
             \r\n\
             ",
         response: b"\
@@ -232,6 +240,7 @@ fn test_accept_header_is_not_changed_if_set() {
             Host: $HOST\r\n\
             Accept: application/json\r\n\
             User-Agent: $USERAGENT\r\n\
+            Accept-Encoding: gzip\r\n\
             \r\n\
             ",
         response: b"\
@@ -245,6 +254,36 @@ fn test_accept_header_is_not_changed_if_set() {
 
     let res = client.get(&format!("http://{}/accept", server.addr()))
         .header(reqwest::header::Accept::json())
+        .send()
+        .unwrap();
+
+    assert_eq!(res.status(), &reqwest::StatusCode::Ok);
+}
+
+#[test]
+fn test_accept_encoding_header_is_not_changed_if_set() {
+    let server = server! {
+        request: b"\
+            GET /accept-encoding HTTP/1.1\r\n\
+            Host: $HOST\r\n\
+            Accept-Encoding: identity\r\n\
+            User-Agent: $USERAGENT\r\n\
+            Accept: */*\r\n\
+            \r\n\
+            ",
+        response: b"\
+            HTTP/1.1 200 OK\r\n\
+            Server: test-accept-encoding\r\n\
+            Content-Length: 0\r\n\
+            \r\n\
+            "
+    };
+    let client = reqwest::Client::new().unwrap();
+
+    let res = client.get(&format!("http://{}/accept-encoding", server.addr()))
+        .header(reqwest::header::AcceptEncoding(
+            vec![reqwest::header::qitem(reqwest::header::Encoding::Identity)]
+        ))
         .send()
         .unwrap();
 
@@ -276,6 +315,7 @@ fn test_gzip_response() {
             Host: $HOST\r\n\
             User-Agent: $USERAGENT\r\n\
             Accept: */*\r\n\
+            Accept-Encoding: gzip\r\n\
             \r\n\
             ",
         response: response


### PR DESCRIPTION
Remove the Content-Encoding and Content-Length, when implicitly decoding a gzipped response. Set the Accept-Encoding header when auto_ungzip is enabled and no other accept-encoding header is set. This is based off the [golang http client](https://github.com/golang/go/blob/master/src/net/http/transport.go#L1625). 