### PR TITLE
redirect and error reform

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,7 @@ use serde_json;
 use serde_urlencoded;
 
 use ::body::{self, Body};
-use ::redirect::{RedirectPolicy, check_redirect};
+use ::redirect::{self, RedirectPolicy, check_redirect};
 use ::response::Response;
 
 static DEFAULT_USER_AGENT: &'static str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
@@ -36,7 +36,7 @@ pub struct Client {
 impl Client {
     /// Constructs a new `Client`.
     pub fn new() -> ::Result<Client> {
-        let mut client = try!(new_hyper_client());
+        let mut client = try_!(new_hyper_client());
         client.set_redirect_policy(::hyper::client::RedirectPolicy::FollowNone);
         Ok(Client {
             inner: Arc::new(ClientRef {
@@ -133,7 +133,7 @@ fn new_hyper_client() -> ::Result<::hyper::Client> {
         ::hyper::client::Pool::with_connector(
             Default::default(),
             ::hyper::net::HttpsConnector::new(
-                try!(NativeTlsClient::new()
+                try_!(NativeTlsClient::new()
                      .map_err(|e| ::hyper::Error::Ssl(Box::new(e)))))
         )
     ))
@@ -198,7 +198,7 @@ impl RequestBuilder {
     ///     .send();
     /// ```
     pub fn form<T: Serialize>(mut self, form: &T) -> RequestBuilder {
-        let body = serde_urlencoded::to_string(form).map_err(::Error::from);
+        let body = serde_urlencoded::to_string(form).map_err(::error::from);
         self.headers.set(ContentType::form_url_encoded());
         self.body = Some(body.map(|b| b.into()));
         self
@@ -242,10 +242,10 @@ impl RequestBuilder {
         }
         let client = self.client;
         let mut method = self.method;
-        let mut url = try!(self.url);
+        let mut url = try_!(self.url);
         let mut headers = self.headers;
         let mut body = match self.body {
-            Some(b) => Some(try!(b)),
+            Some(b) => Some(try_!(b)),
             None => None,
         };
 
@@ -263,7 +263,7 @@ impl RequestBuilder {
                     req = req.body(body);
                 }
 
-                try!(req.send())
+                try_!(req.send(), &url)
             };
 
             let should_redirect = match res.status {
@@ -304,12 +304,20 @@ impl RequestBuilder {
                     Ok(loc) => {
                         headers.set(Referer(url.to_string()));
                         urls.push(url);
-                        if check_redirect(&client.redirect_policy.lock().unwrap(), &loc, &urls)? {
-                            loc
-                        } else {
-                            debug!("redirect_policy disallowed redirection to '{}'", loc);
+                        let action = check_redirect(&client.redirect_policy.lock().unwrap(), &loc, &urls);
+                        match action {
+                            redirect::Action::Follow => loc,
+                            redirect::Action::Stop => {
+                                debug!("redirect_policy disallowed redirection to '{}'", loc);
 
-                            return Ok(::response::new(res, client.auto_ungzip.load(Ordering::Relaxed)));
+                                return Ok(::response::new(res, client.auto_ungzip.load(Ordering::Relaxed)));
+                            },
+                            redirect::Action::LoopDetected => {
+                                return Err(::error::loop_detected(res.url.clone()));
+                            },
+                            redirect::Action::TooManyRedirects => {
+                                return Err(::error::too_many_redirects(res.url.clone()));
+                            }
                         }
                     },
                     Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,9 +124,9 @@ pub use self::body::Body;
 pub use self::redirect::RedirectPolicy;
 pub use self::response::Response;
 
+#[macro_use] mod error;
 mod body;
 mod client;
-mod error;
 mod redirect;
 mod response;
 
@@ -161,4 +161,8 @@ fn _assert_impls() {
 
     assert_send::<RequestBuilder>();
     assert_send::<Response>();
+
+
+    assert_send::<Error>();
+    assert_sync::<Error>();
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -89,7 +89,7 @@ impl Response {
     /// Try and deserialize the response body as JSON.
     #[inline]
     pub fn json<T: Deserialize>(&mut self) -> ::Result<T> {
-        serde_json::from_reader(self).map_err(::Error::from)
+        serde_json::from_reader(self).map_err(::error::from)
     }
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -207,10 +207,7 @@ fn test_redirect_policy_can_return_errors() {
     };
 
     let err = reqwest::get(&format!("http://{}/loop", server.addr())).unwrap_err();
-    match err {
-        reqwest::Error::RedirectLoop => (),
-        e => panic!("wrong error received: {:?}", e),
-    }
+    assert!(err.is_redirect());
 }
 
 #[test]


### PR DESCRIPTION
- `Error` has been made an opaque struct.
- `RedirectPolicy` now makes use of `RedirectAttempt` and `RedirectAction`.