### PR TITLE
Add error_for_status.

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -490,3 +490,61 @@ fn test_gzip_invalid_body() {
     let mut body = ::std::string::String::new();
     res.read_to_string(&mut body).unwrap_err();
 }
+
+/// Calling `Response::error_for_status`` on a response with status in 4xx
+/// returns a error.
+#[test]
+fn test_error_for_status_4xx() {
+    let server = server! {
+        request: b"\
+            GET /1 HTTP/1.1\r\n\
+            Host: $HOST\r\n\
+            User-Agent: $USERAGENT\r\n\
+            Accept: */*\r\n\
+            Accept-Encoding: gzip\r\n\
+            \r\n\
+            ",
+        response: b"\
+            HTTP/1.1 400 OK\r\n\
+            Server: test\r\n\
+            Content-Length: 0\r\n\
+            \r\n\
+            "
+    };
+
+    let url = format!("http://{}/1", server.addr());
+    let res = reqwest::get(&url).unwrap();
+
+    let err = res.error_for_status().err().unwrap();
+    assert!(err.is_client_error());
+    assert_eq!(err.status(), Some(reqwest::StatusCode::BadRequest));
+}
+
+/// Calling `Response::error_for_status`` on a response with status in 5xx
+/// returns a error.
+#[test]
+fn test_error_for_status_5xx() {
+    let server = server! {
+        request: b"\
+            GET /1 HTTP/1.1\r\n\
+            Host: $HOST\r\n\
+            User-Agent: $USERAGENT\r\n\
+            Accept: */*\r\n\
+            Accept-Encoding: gzip\r\n\
+            \r\n\
+            ",
+        response: b"\
+            HTTP/1.1 500 OK\r\n\
+            Server: test\r\n\
+            Content-Length: 0\r\n\
+            \r\n\
+            "
+    };
+
+    let url = format!("http://{}/1", server.addr());
+    let res = reqwest::get(&url).unwrap();
+
+    let err = res.error_for_status().err().unwrap();
+    assert!(err.is_server_error());
+    assert_eq!(err.status(), Some(reqwest::StatusCode::InternalServerError));
+}


### PR DESCRIPTION
This makes it it easy to turn error responses into error results.

This is inspired by python requests' [`raise_for_status`](http://docs.python-requests.org/en/master/api/#requests.Response.raise_for_status).