### PR TITLE
update example error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ libflate = "0.1.5"
 [dev-dependencies]
 env_logger = "0.4"
 serde_derive = "1.0"
+error-chain = "0.10"

--- a/examples/response_json.rs
+++ b/examples/response_json.rs
@@ -1,15 +1,24 @@
-// cargo run --example response_json
+//! `cargo run --example response_json`
 extern crate reqwest;
+#[macro_use] extern crate serde_derive;
+#[macro_use] extern crate error_chain;
 
-#[macro_use]
-extern crate serde_derive;
+error_chain! {
+    foreign_links {
+        ReqError(reqwest::Error);
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct Response {
     origin: String,
 }
 
-fn main() {
-    let mut res = reqwest::get("https://httpbin.org/ip").unwrap();
-    println!("JSON: {:?}", res.json::<Response>());
+fn run() -> Result<()> {
+    let mut res = reqwest::get("https://httpbin.org/ip")?;
+    let json = res.json::<Response>()?;
+    println!("JSON: {:?}", json);
+    Ok(())
 }
+
+quick_main!(run);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,17 +1,31 @@
+//! `cargo run --example simple`
 extern crate reqwest;
 extern crate env_logger;
+#[macro_use] extern crate error_chain;
 
-fn main() {
-    env_logger::init().unwrap();
+error_chain! {
+    foreign_links {
+        ReqError(reqwest::Error);
+        IoError(std::io::Error);
+    }
+}
+
+fn run() -> Result<()> {
+    env_logger::init()
+        .expect("Failed to initialize logger");
 
     println!("GET https://www.rust-lang.org");
 
-    let mut res = reqwest::get("https://www.rust-lang.org").unwrap();
+    let mut res = reqwest::get("https://www.rust-lang.org")?;
 
     println!("Status: {}", res.status());
     println!("Headers:\n{}", res.headers());
 
-    ::std::io::copy(&mut res, &mut ::std::io::stdout()).unwrap();
+    // copy the response body directly to stdout
+    let _ = std::io::copy(&mut res, &mut std::io::stdout())?;
 
     println!("\n\nDone.");
+    Ok(())
 }
+
+quick_main!(run);

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,7 +31,7 @@ static DEFAULT_USER_AGENT: &'static str = concat!(env!("CARGO_PKG_NAME"), "/", e
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// # use reqwest::{Error, Client};
 /// #
 /// # fn run() -> Result<(), Error> {
@@ -182,13 +182,18 @@ pub struct RequestBuilder {
 impl RequestBuilder {
     /// Add a `Header` to this Request.
     ///
-    /// ```no_run
+    /// ```rust
+    /// # use reqwest::Error;
+    /// #
+    /// # fn run() -> Result<(), Error> {
     /// use reqwest::header::UserAgent;
-    /// let client = reqwest::Client::new().expect("client failed to construct");
+    /// let client = reqwest::Client::new()?;
     ///
     /// let res = client.get("https://www.rust-lang.org")
     ///     .header(UserAgent("foo".to_string()))
-    ///     .send();
+    ///     .send()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn header<H: ::header::Header + ::header::HeaderFormat>(mut self, header: H) -> RequestBuilder {
         self.headers.set(header);
@@ -222,15 +227,20 @@ impl RequestBuilder {
     /// and also sets the `Content-Type: application/www-form-url-encoded`
     /// header.
     ///
-    /// ```no_run
+    /// ```rust
+    /// # use reqwest::Error;
     /// # use std::collections::HashMap;
+    /// #
+    /// # fn run() -> Result<(), Error> {
     /// let mut params = HashMap::new();
     /// params.insert("lang", "rust");
     ///
-    /// let client = reqwest::Client::new().unwrap();
+    /// let client = reqwest::Client::new()?;
     /// let res = client.post("http://httpbin.org")
     ///     .form(&params)
-    ///     .send();
+    ///     .send()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn form<T: Serialize>(mut self, form: &T) -> RequestBuilder {
         let body = serde_urlencoded::to_string(form).map_err(::error::from);
@@ -244,15 +254,20 @@ impl RequestBuilder {
     /// Sets the body to the JSON serialization of the passed value, and
     /// also sets the `Content-Type: application/json` header.
     ///
-    /// ```no_run
+    /// ```rust
+    /// # use reqwest::Error;
     /// # use std::collections::HashMap;
+    /// #
+    /// # fn run() -> Result<(), Error> {
     /// let mut map = HashMap::new();
     /// map.insert("lang", "rust");
     ///
-    /// let client = reqwest::Client::new().unwrap();
+    /// let client = reqwest::Client::new()?;
     /// let res = client.post("http://httpbin.org")
     ///     .json(&map)
-    ///     .send();
+    ///     .send()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn json<T: Serialize>(mut self, json: &T) -> RequestBuilder {
         let body = serde_json::to_vec(json).expect("serde to_vec cannot fail");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,16 @@
 //! including `String`, `Vec<u8>`, and `File`. If you wish to pass a custom
 //! Reader, you can use the `reqwest::Body::new()` constructor.
 //!
-//! ```no_run
-//! let client = reqwest::Client::new().unwrap();
+//! ```rust
+//! # use reqwest::Error;
+//! #
+//! # fn run() -> Result<(), Error> {
+//! let client = reqwest::Client::new()?;
 //! let res = client.post("http://httpbin.org/post")
 //!     .body("the exact body that is sent")
-//!     .send();
+//!     .send()?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ### Forms
@@ -64,13 +69,18 @@
 //! This can be an array of tuples, or a `HashMap`, or a custom type that
 //! implements [`Serialize`][serde].
 //!
-//! ```no_run
+//! ```rust
+//! # use reqwest::Error;
+//! #
+//! # fn run() -> Result<(), Error> {
 //! // This will POST a body of `foo=bar&baz=quux`
 //! let params = [("foo", "bar"), ("baz", "quux")];
-//! let client = reqwest::Client::new().unwrap();
+//! let client = reqwest::Client::new()?;
 //! let res = client.post("http://httpbin.org/post")
 //!     .form(&params)
-//!     .send();
+//!     .send()?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ### JSON
@@ -79,17 +89,22 @@
 //! a similar fashion the `form` method. It can take any value that can be
 //! serialized into JSON.
 //!
-//! ```no_run
+//! ```rust
+//! # use reqwest::Error;
 //! # use std::collections::HashMap;
+//! #
+//! # fn run() -> Result<(), Error> {
 //! // This will POST a body of `{"lang":"rust","body":"json"}`
 //! let mut map = HashMap::new();
 //! map.insert("lang", "rust");
 //! map.insert("body", "json");
 //!
-//! let client = reqwest::Client::new().unwrap();
+//! let client = reqwest::Client::new()?;
 //! let res = client.post("http://httpbin.org/post")
 //!     .json(&map)
-//!     .send();
+//!     .send()?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! [hyper]: http://hyper.rs
@@ -159,12 +174,31 @@ mod response;
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```rust
+/// # extern crate reqwest;
+/// # #[macro_use] extern crate error_chain;
+/// #
 /// use std::io::Read;
 ///
+/// # error_chain! {
+/// #     foreign_links {
+/// #         Reqwest(reqwest::Error);
+/// #         Io(std::io::Error);
+/// #     }
+/// # }
+/// #
+/// # fn run() -> Result<()> {
 /// let mut result = String::new();
-/// reqwest::get("https://www.rust-lang.org").unwrap()
-///     .read_to_string(&mut result);
+/// reqwest::get("https://www.rust-lang.org")?
+///     .read_to_string(&mut result)?;
+/// # Ok(())
+/// # }
+/// #
+/// # fn main() {
+/// #    if let Err(error) = run() {
+/// #        println!("Error: {:?}", error);
+/// #    }
+/// # }
 /// ```
 pub fn get<T: IntoUrl>(url: T) -> ::Result<Response> {
     let client = try!(Client::new());

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -58,9 +58,11 @@ impl RedirectPolicy {
     ///
     /// # Example
     ///
-    /// ```no_run
-    /// # use reqwest::RedirectPolicy;
-    /// # let mut client = reqwest::Client::new().unwrap();
+    /// ```rust
+    /// # use reqwest::{Error, RedirectPolicy};
+    /// #
+    /// # fn run() -> Result<(), Error> {
+    /// let mut client = reqwest::Client::new()?;
     /// client.redirect(RedirectPolicy::custom(|attempt| {
     ///     if attempt.previous().len() > 5 {
     ///         attempt.too_many_redirects()
@@ -71,6 +73,8 @@ impl RedirectPolicy {
     ///         attempt.follow()
     ///     }
     /// }));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn custom<T>(policy: T) -> RedirectPolicy
     where T: Fn(RedirectAttempt) -> RedirectAction + Send + Sync + 'static {

--- a/src/response.rs
+++ b/src/response.rs
@@ -87,27 +87,31 @@ impl Response {
         }
     }
 
-    /// Try and deserialize the response body as JSON.
+    /// Try and deserialize the response body as JSON using `serde`.
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
-    /// extern crate reqwest;
-    /// #[macro_use]
-    /// extern crate serde_derive;
-    ///
+    /// ```rust
+    /// # extern crate reqwest;
+    /// # #[macro_use] extern crate serde_derive;
+    /// #
+    /// # use reqwest::Error;
+    /// #
     /// #[derive(Deserialize)]
-    /// struct User {
-    ///     name: String,
-    ///     age: u8,
+    /// struct Response {
+    ///     origin: String,
     /// }
     ///
-    /// fn main() {
-    ///     let user: User = reqwest::get("http://127.0.0.1/user.json")
-    ///         .expect("network error")
-    ///         .json()
-    ///         .expect("malformed json");
-    /// }
+    /// # fn run() -> Result<(), Error> {
+    /// let resp: Response = reqwest::get("http://127.0.0.1/user.json")?.json()?;
+    /// # Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     if let Err(error) = run() {
+    /// #         println!("Error: {:?}", error);
+    /// #     }
+    /// # }
     /// ```
     #[inline]
     pub fn json<T: DeserializeOwned>(&mut self) -> ::Result<T> {


### PR DESCRIPTION
- Add error-chain dev dependency
- Make `doc` examples runnable
- Add error handling using `?` instead of `unwrap` for `examples` and `docs`