### PR TITLE
Improve type signature of RequestBuilder::basic_auth().

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -203,10 +203,12 @@ impl RequestBuilder {
     }
 
     /// Enable HTTP basic authentication.
-    pub fn basic_auth(self, username: String, password: Option<String>) -> RequestBuilder {
+    pub fn basic_auth<U, P>(self, username: U, password: Option<P>) -> RequestBuilder
+            where U: Into<String>, P: Into<String>
+    {
         self.header(::header::Authorization(::header::Basic{
-            username: username,
-            password: password,
+            username: username.into(),
+            password: password.map(|p| p.into()),
         }))
     }
 


### PR DESCRIPTION
Use Into<String> for both arguments to make the API more convenient.