### PR TITLE
Fix build for nightly-2017-05-22

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -185,25 +185,6 @@ pub fn too_many_redirects(url: Url) -> Error {
     }
 }
 
-macro_rules! try_ {
-    ($e:expr) => (
-        match $e {
-            Ok(v) => v,
-            Err(err) => {
-                return Err(::Error::from(::error::InternalFrom(err, None)));
-            }
-        }
-    );
-    ($e:expr, $url:expr) => (
-        match $e {
-            Ok(v) => v,
-            Err(err) => {
-                return Err(::Error::from(::error::InternalFrom(err, Some($url.clone()))));
-            }
-        }
-    )
-}
-
 #[test]
 fn test_error_get_ref_downcasts() {
     let err: Error = from(::hyper::Error::Status);


### PR DESCRIPTION
Compilation fails with nightly-2017-05-22:

```
error: unused macro definition
   --> src/error.rs:188:1
    |
188 | / macro_rules! try_ {
189 | |     ($e:expr) => (
190 | |         match $e {
191 | |             Ok(v) => v,
...   |
204 | |     )
205 | | }
    | |_^
    |
    = note: #[deny(unused_macros)] implied by #[deny(warnings)]
note: lint level defined here
   --> src/lib.rs:1:9
    |
1   | #![deny(warnings)]
    |         ^^^^^^^^
```

Removing the duplicate (and unused) `try_!` macro in error.rs fixes the
warning.