### PR TITLE
Hide internal conversions to `reqwest::Error`.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -152,6 +152,7 @@ impl From<::hyper_native_tls::native_tls::Error> for Kind {
 
 pub struct InternalFrom<T>(pub T, pub Option<Url>);
 
+#[doc(hidden)] // https://github.com/rust-lang/rust/issues/42323
 impl From<InternalFrom<Error>> for Error {
     #[inline]
     fn from(other: InternalFrom<Error>) -> Error {
@@ -159,6 +160,7 @@ impl From<InternalFrom<Error>> for Error {
     }
 }
 
+#[doc(hidden)] // https://github.com/rust-lang/rust/issues/42323
 impl<T> From<InternalFrom<T>> for Error
 where
     T: Into<Kind>,


### PR DESCRIPTION
Fixes #106.