### PR TITLE
Wrap unstable errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,6 @@ extern crate serde_urlencoded;
 extern crate url;
 
 pub use hyper::client::IntoUrl;
-pub use hyper::Error as HyperError;
 pub use hyper::header;
 pub use hyper::mime;
 pub use hyper::method::Method;


### PR DESCRIPTION
Addresses issue #125

- Wrap `hyper::Error` and `serde_urlencoded::ser::Error`
- Update `downcast_ref` test
- Remove re-export of `hyper::Error` (breaking change)