### PR TITLE
redefined Method from hyper in reqwest

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,13 +6,13 @@ use std::time::Duration;
 use hyper::client::IntoUrl;
 use hyper::header::{Location, Referer, UserAgent, Accept, Encoding,
                     AcceptEncoding, Range, qitem};
-use hyper::method::Method;
 use hyper::status::StatusCode;
 use hyper::Url;
 
 use hyper_native_tls::{NativeTlsClient, TlsStream, native_tls};
 
 use body;
+use method::Method;
 use redirect::{self, RedirectPolicy, check_redirect, remove_sensitive_headers};
 use request::{self, Request, RequestBuilder};
 use response::Response;

--- a/src/error.rs
+++ b/src/error.rs
@@ -118,7 +118,8 @@ impl Error {
             Kind::UrlEncoded(ref e) => Some(e),
             Kind::Json(ref e) => Some(e),
             Kind::TooManyRedirects |
-            Kind::RedirectLoop => None,
+            Kind::RedirectLoop |
+            Kind::Method => None,
         }
     }
 
@@ -167,6 +168,7 @@ impl fmt::Display for Error {
             Kind::Json(ref e) => fmt::Display::fmt(e, f),
             Kind::TooManyRedirects => f.write_str("Too many redirects"),
             Kind::RedirectLoop => f.write_str("Infinite redirect loop"),
+            Kind::Method => f.write_str("Invalid Method specified"),
         }
     }
 }
@@ -182,6 +184,7 @@ impl StdError for Error {
             Kind::Json(ref e) => e.description(),
             Kind::TooManyRedirects => "Too many redirects",
             Kind::RedirectLoop => "Infinite redirect loop",
+            Kind::Method => "Invalid Method specified",
         }
     }
 
@@ -194,7 +197,8 @@ impl StdError for Error {
             Kind::UrlEncoded(ref e) => e.cause(),
             Kind::Json(ref e) => e.cause(),
             Kind::TooManyRedirects |
-            Kind::RedirectLoop => None,
+            Kind::RedirectLoop |
+            Kind::Method => None,
         }
     }
 }
@@ -211,6 +215,7 @@ pub enum Kind {
     Json(::serde_json::Error),
     TooManyRedirects,
     RedirectLoop,
+    Method,
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,11 +135,11 @@ pub use hyper::client::IntoUrl;
 pub use hyper::Error as HyperError;
 pub use hyper::header;
 pub use hyper::mime;
-pub use hyper::method::Method;
 pub use hyper::status::StatusCode;
 pub use hyper::Url;
 pub use url::ParseError as UrlError;
 
+pub use self::method::Method;
 pub use self::client::{Certificate, Client, ClientBuilder};
 pub use self::error::{Error, Result};
 pub use self::body::Body;
@@ -149,6 +149,7 @@ pub use self::response::Response;
 
 #[macro_use]
 mod error;
+mod method;
 mod body;
 mod client;
 mod redirect;

--- a/src/method.rs
+++ b/src/method.rs
@@ -1,0 +1,193 @@
+//! The HTTP request method
+use std::fmt;
+use std::str::FromStr;
+use std::convert::AsRef;
+
+use error::{Error, Kind};
+use self::Method::{Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch,
+                   Extension};
+
+
+/// The Request Method (VERB)
+///
+/// Currently includes 8 variants representing the 8 methods defined in
+/// [RFC 7230](https://tools.ietf.org/html/rfc7231#section-4.1), plus PATCH,
+/// and an Extension variant for all extensions.
+///
+/// It may make sense to grow this to include all variants currently
+/// registered with IANA, if they are at all common to use.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum Method {
+    /// OPTIONS
+    Options,
+    /// GET
+    Get,
+    /// POST
+    Post,
+    /// PUT
+    Put,
+    /// DELETE
+    Delete,
+    /// HEAD
+    Head,
+    /// TRACE
+    Trace,
+    /// CONNECT
+    Connect,
+    /// PATCH
+    Patch,
+    /// Method extensions. An example would be `let m = Extension("FOO".to_string())`.
+    Extension(String)
+}
+
+impl AsRef<str> for Method {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Options => "OPTIONS",
+            Get => "GET",
+            Post => "POST",
+            Put => "PUT",
+            Delete => "DELETE",
+            Head => "HEAD",
+            Trace => "TRACE",
+            Connect => "CONNECT",
+            Patch => "PATCH",
+            Extension(ref s) => s.as_ref()
+        }
+    }
+}
+
+impl Method {
+    /// Whether a method is considered "safe", meaning the request is
+    /// essentially read-only.
+    ///
+    /// See [the spec](https://tools.ietf.org/html/rfc7231#section-4.2.1)
+    /// for more words.
+    pub fn safe(&self) -> bool {
+        match *self {
+            Get | Head | Options | Trace => true,
+            _ => false
+        }
+    }
+
+    /// Whether a method is considered "idempotent", meaning the request has
+    /// the same result if executed multiple times.
+    ///
+    /// See [the spec](https://tools.ietf.org/html/rfc7231#section-4.2.2) for
+    /// more words.
+    pub fn idempotent(&self) -> bool {
+        if self.safe() {
+            true
+        } else {
+            match *self {
+                Put | Delete => true,
+                _ => false
+            }
+        }
+    }
+}
+
+impl FromStr for Method {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Method, Error> {
+        if s == "" {
+            Err(method_error())
+        } else {
+            Ok(match s {
+                "OPTIONS" => Options,
+                "GET" => Get,
+                "POST" => Post,
+                "PUT" => Put,
+                "DELETE" => Delete,
+                "HEAD" => Head,
+                "TRACE" => Trace,
+                "CONNECT" => Connect,
+                "PATCH" => Patch,
+                _ => Extension(s.to_owned())
+            })
+        }
+    }
+}
+
+impl fmt::Display for Method {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str(match *self {
+            Options => "OPTIONS",
+            Get => "GET",
+            Post => "POST",
+            Put => "PUT",
+            Delete => "DELETE",
+            Head => "HEAD",
+            Trace => "TRACE",
+            Connect => "CONNECT",
+            Patch => "PATCH",
+            Extension(ref s) => s.as_ref()
+        })
+    }
+}
+
+impl Default for Method {
+    fn default() -> Method {
+        Method::Get
+    }
+}
+
+fn method_error() -> Error {
+    Error{kind: Kind::Method, url: Option::None}
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::str::FromStr;
+    use error::{Error, Kind};
+    use super::Method;
+    use super::Method::{Get, Post, Put, Extension};
+
+    #[test]
+    fn test_safe() {
+        assert_eq!(true, Get.safe());
+        assert_eq!(false, Post.safe());
+    }
+
+    #[test]
+    fn test_idempotent() {
+        assert_eq!(true, Get.idempotent());
+        assert_eq!(true, Put.idempotent());
+        assert_eq!(false, Post.idempotent());
+    }
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(Get, FromStr::from_str("GET").unwrap());
+        assert_eq!(Extension("MOVE".to_owned()),
+                   FromStr::from_str("MOVE").unwrap());
+        let x: Result<Method, _> = FromStr::from_str("");
+        if let Err(Error{kind: Kind::Method, url: Option::None}) = x {
+        } else {
+            panic!("An empty method is invalid!")
+        }
+    }
+
+    #[test]
+    fn test_fmt() {
+        assert_eq!("GET".to_owned(), format!("{}", Get));
+        assert_eq!("MOVE".to_owned(),
+                   format!("{}", Extension("MOVE".to_owned())));
+    }
+
+    #[test]
+    fn test_hashable() {
+        let mut counter: HashMap<Method,usize> = HashMap::new();
+        counter.insert(Get, 1);
+        assert_eq!(Some(&1), counter.get(&Get));
+    }
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(Get.as_ref(), "GET");
+        assert_eq!(Post.as_ref(), "POST");
+        assert_eq!(Put.as_ref(), "PUT");
+        assert_eq!(Extension("MOVE".to_owned()).as_ref(), "MOVE");
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -348,7 +348,7 @@ pub fn pieces(req: Request) -> (Method, Url, Headers, Option<Body>) {
 mod tests {
     use body;
     use client::Client;
-    use hyper::method::Method;
+    use method::Method;
     use hyper::header::{Host, Headers, ContentType};
     use std::collections::HashMap;
     use serde_urlencoded;


### PR DESCRIPTION
Addresses #128 

@seanmonstar I'm not sure how to proceed with these errors - 

```
error[E0308]: mismatched types
   --> src/client.rs:501:50
    |
501 |                 let mut req = self.hyper.request(method.clone(), url.clone())
    |                                                  ^^^^^^^^^^^^^^ expected enum `hyper::method::Method`, found enum `method::Method`
    |
    = note: expected type `hyper::method::Method`
               found type `method::Method`

```

Thanks :)