### PR TITLE
Fix GET request 307 and 308 redirects

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -419,9 +419,7 @@ impl Future for Pending {
                     true
                 },
                 StatusCode::TemporaryRedirect |
-                StatusCode::PermanentRedirect => {
-                    self.body.is_some()
-                },
+                StatusCode::PermanentRedirect => true,
                 _ => false,
             };
             if should_redirect {

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -59,6 +59,59 @@ fn test_redirect_301_and_302_and_303_changes_post_to_get() {
 }
 
 #[test]
+fn test_redirect_307_and_308_get_stays_get() {
+    let client = reqwest::Client::new().unwrap();
+    let codes = [307, 308];
+    for code in codes.iter() {
+        let redirect = server! {
+            request: format!("\
+                GET /{} HTTP/1.1\r\n\
+                Host: $HOST\r\n\
+                User-Agent: $USERAGENT\r\n\
+                Accept: */*\r\n\
+                Accept-Encoding: gzip\r\n\
+                \r\n\
+                ", code),
+            response: format!("\
+                HTTP/1.1 {} reason\r\n\
+                Server: test-redirect\r\n\
+                Content-Length: 0\r\n\
+                Location: /dst\r\n\
+                Connection: close\r\n\
+                \r\n\
+                ", code),
+
+            request: format!("\
+                GET /dst HTTP/1.1\r\n\
+                Host: $HOST\r\n\
+                User-Agent: $USERAGENT\r\n\
+                Accept: */*\r\n\
+                Accept-Encoding: gzip\r\n\
+                Referer: http://$HOST/{}\r\n\
+                \r\n\
+                ", code),
+            response: b"\
+                HTTP/1.1 200 OK\r\n\
+                Server: test-dst\r\n\
+                Content-Length: 0\r\n\
+                \r\n\
+                "
+        };
+
+        let url = format!("http://{}/{}", redirect.addr(), code);
+        let dst = format!("http://{}/{}", redirect.addr(), "dst");
+        let res = client.get(&url)
+            .unwrap()
+            .send()
+            .unwrap();
+        assert_eq!(res.url().as_str(), dst);
+        assert_eq!(res.status(), reqwest::StatusCode::Ok);
+        assert_eq!(res.headers().get(),
+                   Some(&reqwest::header::Server::new("test-dst".to_string())));
+    }
+}
+
+#[test]
 fn test_redirect_307_and_308_tries_to_post_again() {
     let client = reqwest::Client::new().unwrap();
     let codes = [307, 308];


### PR DESCRIPTION
I ran into an issue with 307 redirects not being followed. It looks like 307 and 308 redirects will only be followed when then request has a body, effectively disabling redirect following for GET requests.

It looks like before the switch to hyper 0.11 the condition was previously:

``` rust
StatusCode::TemporaryRedirect |
StatusCode::PermanentRedirect => {
    if let Some(ref body) = body {
        body::can_reset(body)
    } else {
        true
    }
},
```

and was mistakenly changed to `self.body.is_some()`.

I'm not sure if there is an equivalent check to `body::can_reset()` anymore, but an unconditional `true` seems to pass the tests.
