### PR TITLE
Support PKCS12 identity on the ClientBuilder

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -17,7 +17,7 @@ use super::response::{self, Response};
 use connect::Connector;
 use into_url::to_uri;
 use redirect::{self, RedirectPolicy, check_redirect, remove_sensitive_headers};
-use {Certificate, IntoUrl, Method, proxy, Proxy, StatusCode, Url};
+use {Certificate, Pkcs12, IntoUrl, Method, proxy, Proxy, StatusCode, Url};
 
 static DEFAULT_USER_AGENT: &'static str =
     concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
@@ -112,6 +112,20 @@ impl ClientBuilder {
     pub fn add_root_certificate(&mut self, cert: Certificate) -> ::Result<&mut ClientBuilder> {
         let cert = ::tls::cert(cert);
         try_!(self.config_mut().tls.add_root_certificate(cert));
+        Ok(self)
+    }
+
+    /// Sets the identity to be used for client certificate authentication.
+    ///
+    /// This can be used in mutual authentication scenarios to identify to a server
+    /// with a Pkcs12 archive containing a certificate and private key for example.
+    ///
+    /// # Errors
+    ///
+    /// This method fails if adding client identity was unsuccessful.
+    pub fn identity(&mut self, pkcs12: Pkcs12) -> ::Result<&mut ClientBuilder> {
+        let pkcs12 = ::tls::pkcs12(pkcs12);
+        try_!(self.config_mut().tls.identity(pkcs12));
         Ok(self)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use futures::sync::{mpsc, oneshot};
 
 use request::{self, Request, RequestBuilder};
 use response::{self, Response};
-use {async_impl, Certificate, Method, IntoUrl, Proxy, RedirectPolicy, wait};
+use {async_impl, Certificate, Pkcs12, Method, IntoUrl, Proxy, RedirectPolicy, wait};
 
 /// A `Client` to make Requests with.
 ///
@@ -119,6 +119,41 @@ impl ClientBuilder {
         self.inner.add_root_certificate(cert)?;
         Ok(self)
     }
+
+    /// Sets the identity to be used for client certificate authentication.
+    ///
+    /// This can be used in mutual authentication scenarios to identify to a server
+    /// with a Pkcs12 archive containing a certificate and private key for example.
+    ///
+    /// # Example
+    /// ```
+    /// # use std::fs::File;
+    /// # use std::io::Read;
+    /// # fn build_client() -> Result<(), Box<std::error::Error>> {
+    /// // read a local PKCS12 bundle
+    /// let mut buf = Vec::new();
+    /// File::open("my-ident.pfx")?.read_to_end(&mut buf)?;
+    ///
+    /// // create a Pkcs12 instance
+    /// let pkcs12 = reqwest::Pkcs12::from_der(&buf, "my-privkey-password")?;
+    ///
+    /// // get a client builder
+    /// let client = reqwest::ClientBuilder::new()?
+    ///     .identity(pkcs12)?
+    ///     .build()?;
+    /// # drop(client);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This method fails if adding client identity was unsuccessful.
+    pub fn identity(&mut self, pkcs12: Pkcs12) -> ::Result<&mut ClientBuilder> {
+        self.inner.identity(pkcs12)?;
+        Ok(self)
+    }
+
 
     /// Disable hostname verification.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub use self::proxy::Proxy;
 pub use self::redirect::{RedirectAction, RedirectAttempt, RedirectPolicy};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::Response;
-pub use self::tls::Certificate;
+pub use self::tls::{Certificate, Pkcs12};
 
 
 // this module must be first because of the `try_` macro

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -43,3 +43,58 @@ impl fmt::Debug for Certificate {
 pub fn cert(cert: Certificate) -> native_tls::Certificate {
     cert.0
 }
+
+
+/// Represent a PKCS12 bundle containing a private key and X509 cert.
+pub struct Pkcs12(native_tls::Pkcs12);
+
+impl Pkcs12 {
+    /// Parses a DER-formatted PKCS #12 archive, using the specified password to decrypt the key.
+    ///
+    /// The archive should contain a leaf certificate and its private key, as well any intermediate
+    /// certificates that allow clients to build a chain to a trusted root.
+    /// The chain certificates should be in order from the leaf certificate towards the root.
+    ///
+    /// PKCS #12 archives typically have the file extension `.p12` or `.pfx`, and can be created
+    /// with the OpenSSL `pkcs12` tool:
+    ///
+    /// ```bash
+    /// openssl pkcs12 -export -out identity.pfx -inkey key.pem -in cert.pem -certfile chain_certs.pem
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::fs::File;
+    /// # use std::io::Read;
+    /// # fn pkcs12() -> Result<(), Box<std::error::Error>> {
+    /// let mut buf = Vec::new();
+    /// File::open("my-ident.pfx")?
+    ///     .read_to_end(&mut buf)?;
+    /// let pkcs12 = reqwest::Pkcs12::from_der(&buf, "my-privkey-password")?;
+    /// # drop(pkcs12);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// If the provided buffer is not valid DER, an error will be returned.
+    pub fn from_der(der: &[u8], password: &str) -> ::Result<Pkcs12> {
+        let inner = try_!(native_tls::Pkcs12::from_der(der, password));
+        Ok(Pkcs12(inner))
+    }
+}
+
+impl fmt::Debug for Pkcs12 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Pkcs12")
+            .finish()
+    }
+}
+
+// pub(crate)
+
+pub fn pkcs12(pkcs12: Pkcs12) -> native_tls::Pkcs12 {
+    pkcs12.0
+}


### PR DESCRIPTION
I wasn't certain how far into the weeds of TLS features reqwest wants to go, but this seemed straight-forward to add by following the patterns set by `add_root_certificate` to include the `TlsConnectorBuilder::identity` method, so I figured I'd send a PR and see what you thought.

I started using it for an internal tool that needs TLS client authorization to connect to a kubernetes API server. (It *might* become the beginnings of a kubernetes client crate).