### PR TITLE
consider exposing error kinds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub use url::Url;
 pub use url::ParseError as UrlError;
 
 pub use self::client::{Client, ClientBuilder};
-pub use self::error::{Error, Result};
+pub use self::error::{Error, ErrorKind, Result};
 pub use self::body::Body;
 pub use self::into_url::IntoUrl;
 pub use self::proxy::Proxy;


### PR DESCRIPTION
hi sean!

i'd like you to consider exposing the underlying error kind in reqwest errors.

often, i find that i want to be able to exhaustively match against all the *specific* errors that may occur in my normal usage of reqwest, and (as as a free benefit of exhaustive matching) have my program fail to compile if a new unhandled variant or type is introduced.

for example, i've found that being able to statically guarantee i am matching (and handling) all possible error values is important when:
- when i'm writing a more general purpose http client on top of reqwest,
- when i'm writing an api client that uses http transport, and want to match against specific errors and know if and when they change in reqwest,
- when i'm implementing `From<reqwest::ErrorKind> for T` and `Into<T> for reqwest::ErrorKind`, and want to ensure i am matching against all possible error variants,

the current mechanism for doing this causes us to lose out on type information. i must ask `reqwest::Error` for an `Option<&(StdError + Send + Sync + 'static)>` , check `error.is_http()`, `error.is_serialization()`, `error.is_redirect()`, ... to find out what type of error i am holding, and attempt to downcast with `downcast_ref()`. all these operations are lossy, and can easily miss a new enum variant if one is introduced in a newer version of reqwest (as the compiler cannot ensure exhaustive matching against error variants).

i'd like to access the underlying, strongly typed error values that caused a http request, or other operation, to fail. this pull request begins by publicly exporting `reqwest::error::Kind` as `reqwest::ErrorKind`.

i hope this is a step in the right direction. if you think so, i'd love to think deeper about the design of such an interface, and also to document all the `ErrorKind` variants before we merge this into master.