### PR TITLE
Add option to allow connections with invalid ssl certificates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,17 @@ categories = ["web-programming::http-client"]
 bytes = "0.4"
 futures = "0.1.15"
 hyper = "0.11"
-hyper-tls = "0.1.2"
+hyper-tls = { git = "https://github.com/scottschroeder/hyper-tls", branch = "noverify" }
 libflate = "0.1.11"
 log = "0.3"
 mime_guess = "2.0.0-alpha.2"
-native-tls = "0.1.3"
+native-tls = { git = "https://github.com/scottschroeder/rust-native-tls", branch = "noverify" }
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.5"
 tokio-core = "0.1.6"
 tokio-io = "0.1"
-tokio-tls = "0.1"
+tokio-tls = { git = "https://github.com/scottschroeder/tokio-tls", branch = "noverify" }
 url = "1.2"
 uuid = { version = "0.5", features = ["v4"] }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -123,6 +123,21 @@ impl ClientBuilder {
         self
     }
 
+    /// Specifies whether to trust invalid certificates.
+    ///
+    /// # Warning
+    ///
+    /// You should think very carefully before using this method. If invalid
+    /// certificates are trusted, *any* certificate for *any* site will be
+    /// trusted for use. This includes expired certificates. This introduces
+    /// significant vulnerabilities, and should only be used as a last resort.
+    pub fn danger_disable_certificate_validation_entirely(&mut self) -> &mut ClientBuilder {
+        if let Some(config) = config_mut(&mut self.config, &self.err) {
+            config.tls.danger_disable_certificate_validation_entirely();
+        }
+        self
+    }
+
     /// Sets the identity to be used for client certificate authentication.
     pub fn identity(&mut self, identity: Identity) -> &mut ClientBuilder {
         if let Some(config) = config_mut(&mut self.config, &self.err) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -115,6 +115,19 @@ impl ClientBuilder {
         self
     }
 
+    /// Specifies whether to trust invalid certificates.
+    ///
+    /// # Warning
+    ///
+    /// You should think very carefully before using this method. If invalid
+    /// certificates are trusted, *any* certificate for *any* site will be
+    /// trusted for use. This includes expired certificates. This introduces
+    /// significant vulnerabilities, and should only be used as a last resort.
+    pub fn danger_disable_certificate_validation_entirely(&mut self) -> &mut ClientBuilder {
+        self.inner.danger_disable_certificate_validation_entirely();
+        self
+    }
+
     /// Sets the identity to be used for client certificate authentication.
     ///
     /// # Example


### PR DESCRIPTION
**DON'T MERGE, blocked on https://github.com/sfackler/rust-native-tls/pull/56** _(and probably updates to the dependencies of `hyper-tls` and `tokio-tls`)_. 

Given that it may be a while before this is merge-able, consider this PR an RFC.
## Motivation

I know this is just... _wrong_, and everyone should be using letsencrypt, or adding their self-signed cert as a trusted root. Allowing invalid SSL connections is still a "feature" that rust doesn't have, and I'd like to fix that.

Also, this should put #15 to bed.

## Changes
Add methods to the `ClientBuilder`s that disable certificate validation. Added a doc-string with a warning about how this is a bad practice. If anything can be more clear and/or obnoxious, let me know.

## Example
```rust
let mut client = reqwest::ClientBuilder::new()
    .danger_disable_certificate_validation_entirely()
    .build().unwrap();

let mut res = client.get("https://expired.badssl.com/")
    .send().unwrap();

let mut body: String = String::new();
let _ = res.read_to_string(&mut body).unwrap();
println!("{}", body);
```
You can try this out by using my fork in `Cargo.toml`
```toml
reqwest = { git = "https://github.com/scottschroeder/reqwest", branch = "noverify" }
```