### PR TITLE
Add Response::text()

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -176,12 +176,12 @@ impl Response {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn text(&mut self) -> io::Result<String> {
+    pub fn text(&mut self) -> ::Result<String> {
         let len = self.headers().get::<::header::ContentLength>()
             .map(|ct_len| **ct_len)
             .unwrap_or(0);
         let mut content = String::with_capacity(len as usize);
-        self.read_to_string(&mut content)?;
+        self.read_to_string(&mut content).map_err(::error::from)?;
         Ok(content)
     }
 
@@ -205,10 +205,10 @@ impl Response {
     /// # }
     /// ```
     #[inline]
-    pub fn copy_to<W: ?Sized>(&mut self, w: &mut W) -> io::Result<u64>
+    pub fn copy_to<W: ?Sized>(&mut self, w: &mut W) -> ::Result<u64>
         where W: io::Write
     {
-        io::copy(self, w)
+        io::copy(self, w).map_err(::error::from)
     }
 
     /// Turn a response into an error if the server returned an error.

--- a/src/response.rs
+++ b/src/response.rs
@@ -165,6 +165,26 @@ impl Response {
         serde_json::from_reader(self).map_err(::error::from)
     }
 
+    /// Get the response text.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate reqwest;
+    /// # fn run() -> Result<(), Box<::std::error::Error>> {
+    /// let content = reqwest::get("http://httpbin.org/range/26")?.text()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn text(&mut self) -> io::Result<String> {
+        let len = self.headers().get::<::header::ContentLength>()
+            .map(|ct_len| **ct_len)
+            .unwrap_or(0);
+        let mut content = String::with_capacity(len as usize);
+        self.read_to_string(&mut content)?;
+        Ok(content)
+    }
+
     /// Copy the response body into a writer.
     ///
     /// This function internally uses [`std::io::copy`] and hence will continuously read data from


### PR DESCRIPTION
Close #86 

### Remained question:
~Should `Response::text()` and `Response::copy_to` return `reqwest::Result` instead of `io::Result`?~