### PR TITLE
Expose error Kind as ErrorKind

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,8 @@ use {StatusCode, Url};
 /// ```
 #[derive(Debug)]
 pub struct Error {
-    kind: Kind,
+    /// Underlying error kind
+    pub kind: Kind,
     url: Option<Url>,
 }
 
@@ -243,17 +244,28 @@ impl StdError for Error {
 
 // pub(crate)
 
+/// Kind wraps possible errors
 #[derive(Debug)]
 pub enum Kind {
+    /// Hyper errors
     Http(::hyper::Error),
+    /// Url parse errors
     Url(::url::ParseError),
+    /// SSL errors
     Tls(::native_tls::Error),
+    /// IO errors
     Io(io::Error),
+    /// Serde URL encoding errors
     UrlEncoded(::serde_urlencoded::ser::Error),
+    /// Serde JSON errors
     Json(::serde_json::Error),
+    /// Too many redirects error
     TooManyRedirects,
+    /// Redirect loop error
     RedirectLoop,
+    /// Client error
     ClientError(StatusCode),
+    /// Server error
     ServerError(StatusCode),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub use url::Url;
 pub use url::ParseError as UrlError;
 
 pub use self::client::{Client, ClientBuilder};
-pub use self::error::{Error, Result};
+pub use self::error::{Error, Result, Kind as ErrorKind};
 pub use self::body::Body;
 pub use self::into_url::IntoUrl;
 pub use self::proxy::Proxy;


### PR DESCRIPTION
Exposing error::Kind as ErrorKind in order to handle errors more granularly, in my case I am handling IO DNS lookup error.