### PR TITLE
Allow unsized types in `query`, `form` and `json`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ name = "simple"
 path = "examples/simple.rs"
 
 [[example]]
+name = "form"
+path = "examples/form.rs"
+
+[[example]]
 name = "async"
 path = "examples/async.rs"
 required-features = ["unstable"]

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -1,0 +1,9 @@
+extern crate reqwest;
+
+fn main() {
+    reqwest::Client::new()
+        .post("http://www.baidu.com")
+        .form(&[("one", "1")])
+        .send()
+        .unwrap();
+}

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -144,7 +144,7 @@ impl RequestBuilder {
     /// # Errors
     /// This method will fail if the object you provide cannot be serialized
     /// into a query string.
-    pub fn query<T: Serialize>(&mut self, query: &T) -> &mut RequestBuilder {
+    pub fn query<T: Serialize + ?Sized>(&mut self, query: &T) -> &mut RequestBuilder {
         if let Some(req) = request_mut(&mut self.request, &self.err) {
             let url = req.url_mut();
             let mut pairs = url.query_pairs_mut();
@@ -158,7 +158,7 @@ impl RequestBuilder {
     }
 
     /// Send a form body.
-    pub fn form<T: Serialize>(&mut self, form: &T) -> &mut RequestBuilder {
+    pub fn form<T: Serialize + ?Sized>(&mut self, form: &T) -> &mut RequestBuilder {
         if let Some(req) = request_mut(&mut self.request, &self.err) {
             match serde_urlencoded::to_string(form) {
                 Ok(body) => {
@@ -177,7 +177,7 @@ impl RequestBuilder {
     ///
     /// Serialization can fail if `T`'s implementation of `Serialize` decides to
     /// fail, or if `T` contains a map with non-string keys.
-    pub fn json<T: Serialize>(&mut self, json: &T) -> &mut RequestBuilder {
+    pub fn json<T: Serialize + ?Sized>(&mut self, json: &T) -> &mut RequestBuilder {
         if let Some(req) = request_mut(&mut self.request, &self.err) {
             match serde_json::to_vec(json) {
                 Ok(body) => {

--- a/src/request.rs
+++ b/src/request.rs
@@ -240,7 +240,7 @@ impl RequestBuilder {
     /// # Errors
     /// This method will fail if the object you provide cannot be serialized
     /// into a query string.
-    pub fn query<T: Serialize>(&mut self, query: &T) -> &mut RequestBuilder {
+    pub fn query<T: Serialize + ?Sized>(&mut self, query: &T) -> &mut RequestBuilder {
         if let Some(req) = request_mut(&mut self.request, &self.err) {
             let url = req.url_mut();
             let mut pairs = url.query_pairs_mut();
@@ -279,7 +279,7 @@ impl RequestBuilder {
     ///
     /// This method fails if the passed value cannot be serialized into
     /// url encoded format
-    pub fn form<T: Serialize>(&mut self, form: &T) -> &mut RequestBuilder {
+    pub fn form<T: Serialize + ?Sized>(&mut self, form: &T) -> &mut RequestBuilder {
         if let Some(req) = request_mut(&mut self.request, &self.err) {
             match serde_urlencoded::to_string(form) {
                 Ok(body) => {
@@ -317,7 +317,7 @@ impl RequestBuilder {
     ///
     /// Serialization can fail if `T`'s implementation of `Serialize` decides to
     /// fail, or if `T` contains a map with non-string keys.
-    pub fn json<T: Serialize>(&mut self, json: &T) -> &mut RequestBuilder {
+    pub fn json<T: Serialize + ?Sized>(&mut self, json: &T) -> &mut RequestBuilder {
         if let Some(req) = request_mut(&mut self.request, &self.err) {
             match serde_json::to_vec(json) {
                 Ok(body) => {


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/47928

cc @Matrix-Zhang