### PR TITLE
Update uuid to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio-core = "0.1.6"
 tokio-io = "0.1"
 tokio-tls = "0.1"
 url = "1.2"
-uuid = { version = "0.5", features = ["v4"] }
+uuid = { version = "0.6", features = ["v4"] }
 
 [dev-dependencies]
 env_logger = "0.5"


### PR DESCRIPTION
Hey

Updating this crate to 0.6 since the new release is out. There are no further changes required. 