### PR TITLE
Change RequestBuilder methods to own a builder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! # use reqwest::{Error, Response};
 //!
 //! # fn run() -> Result<(), Error> {
-//! let text = reqwest::get("https://www.rust-lang.org")?
+//! let body = reqwest::get("https://www.rust-lang.org")?
 //!     .text()?;
 //!
 //! println!("body = {:?}", body);


### PR DESCRIPTION
**Warning:** This is a breaking change, but this isn't 1.0.0 and the changes that will be required due to this change will likely be minimal for most usages (if there will be changes needed to begin with).

This means that `build` cannot possibly panic anymore due to being called multiple times. This is a breaking change as it breaks the behaviour of builder methods called without assigning to a new variable or chaining. It's rather easy to fix those usages, as they won't compile anymore and can be fixed by assigning a result.

Additionally, this change reduces the size of `RequestBuilder`, although this likely isn't all that meaningful, as usually there is no reason to store builders in structures.