### PR TITLE
Disable Travis build cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,6 @@ matrix:
 sudo: false
 dist: trusty
 
-cache:
-  apt: true
-  directories:
-    - target/debug/deps
-    - target/debug/build
-
 script:
   - cargo build $FEATURES
   - cargo test -v $FEATURES

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! # use reqwest::{Error, Response};
 //!
 //! # fn run() -> Result<(), Error> {
-//! let text = reqwest::get("https://www.rust-lang.org")?
+//! let body = reqwest::get("https://www.rust-lang.org")?
 //!     .text()?;
 //!
 //! println!("body = {:?}", body);


### PR DESCRIPTION
As Cargo doesn't remove old build artifacts (which aren't compatible between Rust versions), a build cache means a lot of time is spent downloading constantly increasing in size build artifacts, especially on nightly.