### PR TITLE
Change RequestBuilder methods to own a builder

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -16,10 +16,10 @@ pub struct Request {
 }
 
 /// A builder to construct the properties of a `Request`.
+#[derive(Debug)]
 pub struct RequestBuilder {
     client: Client,
-    request: Option<Request>,
-    err: Option<::Error>,
+    request: ::Result<Request>,
 }
 
 impl Request {
@@ -95,11 +95,11 @@ impl RequestBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn header<H>(&mut self, header: H) -> &mut RequestBuilder
+    pub fn header<H>(mut self, header: H) -> RequestBuilder
     where
         H: ::header::Header,
     {
-        if let Some(req) = request_mut(&mut self.request, &self.err) {
+        if let Ok(ref mut req) = self.request {
             req.headers_mut().set(header);
         }
         self
@@ -130,8 +130,8 @@ impl RequestBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn headers(&mut self, headers: ::header::Headers) -> &mut RequestBuilder {
-        if let Some(req) = request_mut(&mut self.request, &self.err) {
+    pub fn headers(mut self, headers: ::header::Headers) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
             req.headers_mut().extend(headers.iter());
         }
         self
@@ -148,7 +148,7 @@ impl RequestBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn basic_auth<U, P>(&mut self, username: U, password: Option<P>) -> &mut RequestBuilder
+    pub fn basic_auth<U, P>(self, username: U, password: Option<P>) -> RequestBuilder
     where
         U: Into<String>,
         P: Into<String>,
@@ -203,8 +203,8 @@ impl RequestBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn body<T: Into<Body>>(&mut self, body: T) -> &mut RequestBuilder {
-        if let Some(req) = request_mut(&mut self.request, &self.err) {
+    pub fn body<T: Into<Body>>(mut self, body: T) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
             *req.body_mut() = Some(body.into());
         }
         self
@@ -240,15 +240,19 @@ impl RequestBuilder {
     /// # Errors
     /// This method will fail if the object you provide cannot be serialized
     /// into a query string.
-    pub fn query<T: Serialize>(&mut self, query: &T) -> &mut RequestBuilder {
-        if let Some(req) = request_mut(&mut self.request, &self.err) {
+    pub fn query<T: Serialize>(mut self, query: &T) -> RequestBuilder {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
             let url = req.url_mut();
             let mut pairs = url.query_pairs_mut();
             let serializer = serde_urlencoded::Serializer::new(&mut pairs);
 
             if let Err(err) = query.serialize(serializer) {
-                self.err = Some(::error::from(err));
+                error = Some(::error::from(err));
             }
+        }
+        if let Some(err) = error {
+            self.request = Err(err);
         }
         self
     }
@@ -279,15 +283,19 @@ impl RequestBuilder {
     ///
     /// This method fails if the passed value cannot be serialized into
     /// url encoded format
-    pub fn form<T: Serialize>(&mut self, form: &T) -> &mut RequestBuilder {
-        if let Some(req) = request_mut(&mut self.request, &self.err) {
+    pub fn form<T: Serialize>(mut self, form: &T) -> RequestBuilder {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
             match serde_urlencoded::to_string(form) {
                 Ok(body) => {
                     req.headers_mut().set(ContentType::form_url_encoded());
                     *req.body_mut() = Some(body.into());
                 },
-                Err(err) => self.err = Some(::error::from(err)),
+                Err(err) => error = Some(::error::from(err)),
             }
+        }
+        if let Some(err) = error {
+            self.request = Err(err);
         }
         self
     }
@@ -317,15 +325,19 @@ impl RequestBuilder {
     ///
     /// Serialization can fail if `T`'s implementation of `Serialize` decides to
     /// fail, or if `T` contains a map with non-string keys.
-    pub fn json<T: Serialize>(&mut self, json: &T) -> &mut RequestBuilder {
-        if let Some(req) = request_mut(&mut self.request, &self.err) {
+    pub fn json<T: Serialize>(mut self, json: &T) -> RequestBuilder {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
             match serde_json::to_vec(json) {
                 Ok(body) => {
                     req.headers_mut().set(ContentType::json());
                     *req.body_mut() = Some(body.into());
                 },
-                Err(err) => self.err = Some(::error::from(err)),
+                Err(err) => error = Some(::error::from(err)),
             }
+        }
+        if let Some(err) = error {
+            self.request = Err(err);
         }
         self
     }
@@ -350,8 +362,8 @@ impl RequestBuilder {
     /// ```
     ///
     /// See [`multipart`](multipart/) for more examples.
-    pub fn multipart(&mut self, mut multipart: ::multipart::Form) -> &mut RequestBuilder {
-        if let Some(req) = request_mut(&mut self.request, &self.err) {
+    pub fn multipart(mut self, mut multipart: ::multipart::Form) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
             req.headers_mut().set(
                 ::header::ContentType(format!("multipart/form-data; boundary={}", ::multipart_::boundary(&multipart))
                     .parse().unwrap()
@@ -367,19 +379,8 @@ impl RequestBuilder {
 
     /// Build a `Request`, which can be inspected, modified and executed with
     /// `Client::execute()`.
-    ///
-    /// # Panics
-    ///
-    /// This method consumes builder internal state. It panics on an attempt to
-    /// reuse already consumed builder.
-    pub fn build(&mut self) -> ::Result<Request> {
-        if let Some(err) = self.err.take() {
-            Err(err)
-        } else {
-            Ok(self.request
-                .take()
-                .expect("RequestBuilder cannot be reused after builder a Request"))
-        }
+    pub fn build(self) -> ::Result<Request> {
+        self.request
     }
 
     /// Constructs the Request and sends it the target URL, returning a Response.
@@ -388,39 +389,16 @@ impl RequestBuilder {
     ///
     /// This method fails if there was an error while sending request,
     /// redirect loop was detected or redirect limit was exhausted.
-    pub fn send(&mut self) -> ::Result<::Response> {
-        let request = self.build()?;
-        self.client.execute(request)
+    pub fn send(self) -> ::Result<::Response> {
+        self.client.execute(self.request?)
     }
 
-}
-
-
-fn request_mut<'a>(req: &'a mut Option<Request>, err: &Option<::Error>) -> Option<&'a mut Request> {
-    if err.is_some() {
-        None
-    } else {
-        req.as_mut()
-    }
 }
 
 impl fmt::Debug for Request {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt_request_fields(&mut f.debug_struct("Request"), self)
             .finish()
-    }
-}
-
-impl fmt::Debug for RequestBuilder {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref req) = self.request {
-            fmt_request_fields(&mut f.debug_struct("RequestBuilder"), req)
-                .finish()
-        } else {
-            f.debug_tuple("RequestBuilder")
-                .field(&"Consumed")
-                .finish()
-        }
     }
 }
 
@@ -433,19 +411,8 @@ fn fmt_request_fields<'a, 'b>(f: &'a mut fmt::DebugStruct<'a, 'b>, req: &Request
 // pub(crate)
 
 #[inline]
-pub fn builder(client: Client, req: ::Result<Request>) -> RequestBuilder {
-    match req {
-        Ok(req) => RequestBuilder {
-            client: client,
-            request: Some(req),
-            err: None,
-        },
-        Err(err) => RequestBuilder {
-            client: client,
-            request: None,
-            err: Some(err)
-        },
-    }
+pub fn builder(client: Client, request: ::Result<Request>) -> RequestBuilder {
+    RequestBuilder { client, request }
 }
 
 #[inline]
@@ -536,7 +503,7 @@ mod tests {
     fn add_header() {
         let client = Client::new();
         let some_url = "https://google.com/";
-        let mut r = client.post(some_url);
+        let r = client.post(some_url);
 
         let header = Host::new("google.com", None);
 
@@ -551,7 +518,7 @@ mod tests {
     fn add_headers() {
         let client = Client::new();
         let some_url = "https://google.com/";
-        let mut r = client.post(some_url);
+        let r = client.post(some_url);
 
         let header = Host::new("google.com", None);
 
@@ -569,7 +536,7 @@ mod tests {
     fn add_body() {
         let client = Client::new();
         let some_url = "https://google.com/";
-        let mut r = client.post(some_url);
+        let r = client.post(some_url);
 
         let body = "Some interesting content";
 
@@ -586,8 +553,8 @@ mod tests {
         let some_url = "https://google.com/";
         let mut r = client.get(some_url);
 
-        r.query(&[("foo", "bar")]);
-        r.query(&[("qux", 3)]);
+        r = r.query(&[("foo", "bar")]);
+        r = r.query(&[("qux", 3)]);
 
         let req = r.build().expect("request is valid");
         assert_eq!(req.url().query(), Some("foo=bar&qux=3"));
@@ -599,7 +566,7 @@ mod tests {
         let some_url = "https://google.com/";
         let mut r = client.get(some_url);
 
-        r.query(&[("foo", "a"), ("foo", "b")]);
+        r = r.query(&[("foo", "a"), ("foo", "b")]);
 
         let req = r.build().expect("request is valid");
         assert_eq!(req.url().query(), Some("foo=a&foo=b"));
@@ -619,7 +586,7 @@ mod tests {
 
         let params = Params { foo: "bar".into(), qux: 3 };
 
-        r.query(&params);
+        r = r.query(&params);
 
         let req = r.build().expect("request is valid");
         assert_eq!(req.url().query(), Some("foo=bar&qux=3"));
@@ -635,7 +602,7 @@ mod tests {
         let some_url = "https://google.com/";
         let mut r = client.get(some_url);
 
-        r.query(&params);
+        r = r.query(&params);
 
         let req = r.build().expect("request is valid");
         assert_eq!(req.url().query(), Some("foo=bar&qux=three"));
@@ -645,7 +612,7 @@ mod tests {
     fn add_form() {
         let client = Client::new();
         let some_url = "https://google.com/";
-        let mut r = client.post(some_url);
+        let r = client.post(some_url);
 
         let mut form_data = HashMap::new();
         form_data.insert("foo", "bar");
@@ -666,7 +633,7 @@ mod tests {
     fn add_json() {
         let client = Client::new();
         let some_url = "https://google.com/";
-        let mut r = client.post(some_url);
+        let r = client.post(some_url);
 
         let mut json_data = HashMap::new();
         json_data.insert("foo", "bar");
@@ -697,7 +664,7 @@ mod tests {
 
         let client = Client::new();
         let some_url = "https://google.com/";
-        let mut r = client.post(some_url);
+        let r = client.post(some_url);
         let json_data = MyStruct;
         assert!(r.json(&json_data).build().unwrap_err().is_serialization());
     }


### PR DESCRIPTION
This pull request is for 0.9.x branch, not master.

**Warning:** This is a breaking change, but this isn't 1.0.0 and the changes that will be required due to this change will likely be minimal for most usages (if there will be changes needed to begin with).

This means that `build` cannot possibly panic anymore due to being called multiple times. This is a breaking change as it breaks the behaviour of builder methods called without assigning to a new variable or chaining. It's rather easy to fix those usages, as they won't compile anymore and can be fixed by assigning a result.

Additionally, this change reduces the size of `RequestBuilder`, although this likely isn't all that meaningful, as usually there is no reason to store builders in structures.