### PR TITLE
Bump minimum rustc version to 1.21.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
           env: FEATURES=""
 
         # minimum version
-        - rust: 1.18.0
+        - rust: 1.21.0
 
         - rust: stable
           env: FEATURES="--features unstable"


### PR DESCRIPTION
Should fix CI

> error: associated constants are experimental (see issue #29646)
  --> /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/crossbeam-epoch-0.4.0/src/internal.rs:52:5
   |
52 |     const COLLECT_STEPS: usize = 8;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^