### PR TITLE
Make RedirectPolicy::redirect() public

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -91,6 +91,26 @@ impl RedirectPolicy {
         }
     }
 
+    /// Apply this policy to a given [`RedirectAttempt`] to produce a [`RedirectAction`].
+    ///
+    /// # Note
+    ///
+    /// This method can be used together with RedirectPolicy::custom()
+    /// to construct one RedirectPolicy that wraps another.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use reqwest::{Error, RedirectPolicy};
+    /// #
+    /// # fn run() -> Result<(), Error> {
+    /// let custom = RedirectPolicy::custom(|attempt| {
+    ///     eprintln!("Location: {:?}", attempt.url());
+    ///     RedirectPolicy::default().redirect(attempt)
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn redirect(&self, attempt: RedirectAttempt) -> RedirectAction {
         match self.inner {
             Policy::Custom(ref custom) => custom(attempt),

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -91,7 +91,7 @@ impl RedirectPolicy {
         }
     }
 
-    fn redirect(&self, attempt: RedirectAttempt) -> RedirectAction {
+    pub fn redirect(&self, attempt: RedirectAttempt) -> RedirectAction {
         match self.inner {
             Policy::Custom(ref custom) => custom(attempt),
             Policy::Limit(max) => {


### PR DESCRIPTION
Make `RedirectPolicy` composable (together with `RedirectPolicy::custom()` and closures).

Fixes #281.