### PR TITLE
Minor typo in .query() docs

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -133,7 +133,7 @@ impl RequestBuilder {
     /// be called multiple times and that existing query parameters are not
     /// overwritten if the same key is used. The key will simply show up
     /// twice in the query string.
-    /// Calling `.query([("foo", "a"), ("foo", "b")])` gives `"foo=a&boo=b"`.
+    /// Calling `.query([("foo", "a"), ("foo", "b")])` gives `"foo=a&foo=b"`.
     ///
     /// # Note
     /// This method does not support serializing a single key-value

--- a/src/request.rs
+++ b/src/request.rs
@@ -217,7 +217,7 @@ impl RequestBuilder {
     /// be called multiple times and that existing query parameters are not
     /// overwritten if the same key is used. The key will simply show up
     /// twice in the query string.
-    /// Calling `.query(&[("foo", "a"), ("foo", "b")])` gives `"foo=a&boo=b"`.
+    /// Calling `.query(&[("foo", "a"), ("foo", "b")])` gives `"foo=a&foo=b"`.
     ///
     /// ```rust
     /// # use reqwest::Error;


### PR DESCRIPTION
Great library!

I believe this is a typo, unless I'm mistaken about the functionality