### PR TITLE
Force a CRLF at the end of a multipart request

### DIFF
--- a/src/multipart_.rs
+++ b/src/multipart_.rs
@@ -108,7 +108,7 @@ impl Form {
         }
         // If there is a at least one field there is a special boundary for the very last field.
         if self.fields.len() != 0 {
-            length += 2 + self.boundary.len() as u64 + 2
+            length += 2 + self.boundary.len() as u64 + 4
         }
         Some(length)
     }
@@ -271,7 +271,7 @@ impl Reader {
                 Some(Box::new(reader))
             } else {
                 Some(Box::new(reader.chain(Cursor::new(
-                    format!("--{}--", self.form.boundary),
+                    format!("--{}--\r\n", self.form.boundary),
                 ))))
             }
         } else {
@@ -377,7 +377,7 @@ mod tests {
                         \r\n\
                         --boundary\r\n\
                         Content-Disposition: form-data; name=\"key3\"; filename=\"filename\"\r\n\r\n\
-                        value3\r\n--boundary--";
+                        value3\r\n--boundary--\r\n";
         form.reader().read_to_end(&mut output).unwrap();
         // These prints are for debug purposes in case the test fails
         println!(
@@ -413,7 +413,7 @@ mod tests {
                         value2\r\n\
                         --boundary\r\n\
                         Content-Disposition: form-data; name=\"key3\"; filename=\"filename\"\r\n\r\n\
-                        value3\r\n--boundary--";
+                        value3\r\n--boundary--\r\n";
         form.reader().read_to_end(&mut output).unwrap();
         // These prints are for debug purposes in case the test fails
         println!(

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -15,7 +15,7 @@ fn test_multipart() {
         --{0}\r\n\
         Content-Disposition: form-data; name=\"foo\"\r\n\r\n\
         bar\r\n\
-        --{0}--\
+        --{0}--\r\n\
     ", form.boundary());
 
     let server = server! {
@@ -24,7 +24,7 @@ fn test_multipart() {
             user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             content-type: multipart/form-data; boundary={}\r\n\
-            content-length: 123\r\n\
+            content-length: 125\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
             \r\n\


### PR DESCRIPTION
Some servers ([\*ahem\*](https://github.com/swisspol/GCDWebServer/blob/a5548938448c7a197996609c4b7d6592117b9d22/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m#L130)) expects that there will be a CRLF after the end boundary of a multipart request, even if it is part of the epilogue which is optional. Not having this CRLF will cause those servers fail. 

I've also checked that at least Firefox and Safari both emit this additional CRLF when uploading a file.