### PR TITLE
Use base64 to fully encode basic auth creds

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -123,12 +123,14 @@ impl RequestBuilder {
     /// Enable HTTP basic authentication.
     pub fn basic_auth<U, P>(&mut self, username: U, password: Option<P>) -> &mut RequestBuilder
     where
-        U: Into<String>,
-        P: Into<String>,
+        U: fmt::Display,
+        P: fmt::Display,
     {
-        let username = username.into();
-        let password = password.map(|p| p.into()).unwrap_or(String::new());
-        let header_value = format!("basic {}:{}", username, encode(&password));
+        let auth = match password {
+            Some(password) => format!("{}:{}", username, password),
+            None => format!("{}:", username)
+        };
+        let header_value = format!("basic {}", encode(&auth));
         self.header(::header::AUTHORIZATION, HeaderValue::from_str(header_value.as_str()).expect(""))
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -162,12 +162,14 @@ impl RequestBuilder {
     /// ```
     pub fn basic_auth<U, P>(&mut self, username: U, password: Option<P>) -> &mut RequestBuilder
     where
-        U: Into<String>,
-        P: Into<String>,
+        U: fmt::Display,
+        P: fmt::Display,
     {
-        let username = username.into();
-        let password = password.map(|p| p.into()).unwrap_or(String::new());
-        let header_value = format!("basic {}:{}", username, encode(&password));
+        let auth = match password {
+            Some(password) => format!("{}:{}", username, password),
+            None => format!("{}:", username)
+        };
+        let header_value = format!("basic {}", encode(&auth));
         self.header(::header::AUTHORIZATION, HeaderValue::from_str(header_value.as_str()).expect(""))
     }
 


### PR DESCRIPTION
Not sure if you mind me reducing number of allocations, I think it would be better to use directly `Display` rather than `Into<String>` and allocate only formatted string instead of each String for username and password

Closes #320