### PR TITLE
Change invalid cert API to match native-tls

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -141,7 +141,9 @@ impl ClientBuilder {
         self
     }
 
-    /// Disable hostname verification.
+    /// Controls the use of hostname verification.
+    ///
+    /// Defaults to `false`.
     ///
     /// # Warning
     ///
@@ -150,47 +152,33 @@ impl ClientBuilder {
     /// site will be trusted for use from any other. This introduces a
     /// significant vulnerability to man-in-the-middle attacks.
     #[inline]
-    pub fn danger_disable_hostname_verification(&mut self) -> &mut ClientBuilder {
-
+    pub fn danger_accept_invalid_hostnames(&mut self, accept_invalid_hostname: bool) -> &mut ClientBuilder {
         if let Some(config) = config_mut(&mut self.config, &self.err) {
-            config.hostname_verification = false;
+            config.hostname_verification = !accept_invalid_hostname;
         }
         self
     }
 
-    /// Enable hostname verification.
-    #[inline]
-    pub fn enable_hostname_verification(&mut self) -> &mut ClientBuilder {
-        if let Some(config) = config_mut(&mut self.config, &self.err) {
-            config.hostname_verification = true;
-        }
-        self
-    }
 
-    /// Disable certs verification.
+    /// Controls the use of certificate validation.
+    ///
+    /// Defaults to `false`.
     ///
     /// # Warning
     ///
-    /// You should think very carefully before you use this method. If
-    /// hostname verification is not used, any valid certificate for any
-    /// site will be trusted for use from any other. This introduces a
-    /// significant vulnerability to man-in-the-middle attacks.
+    /// You should think very carefully before using this method. If
+    /// invalid certificates are trusted, *any* certificate for *any* site
+    /// will be trusted for use. This includes expired certificates. This
+    /// introduces significant vulnerabilities, and should only be used
+    /// as a last resort.
     #[inline]
-    pub fn danger_disable_certs_verification(&mut self) -> &mut ClientBuilder {
+    pub fn danger_accept_invalid_certs(&mut self, accept_invalid_certs: bool) -> &mut ClientBuilder {
         if let Some(config) = config_mut(&mut self.config, &self.err) {
-            config.certs_verification = false;
+            config.certs_verification = !accept_invalid_certs;
         }
         self
     }
 
-    /// Enable certs verification.
-    #[inline]
-    pub fn enable_certs_verification(&mut self) -> &mut ClientBuilder {
-        if let Some(config) = config_mut(&mut self.config, &self.err) {
-            config.certs_verification = true;
-        }
-        self
-    }
 
     /// Sets the default headers for every request.
     #[inline]

--- a/src/client.rs
+++ b/src/client.rs
@@ -144,7 +144,9 @@ impl ClientBuilder {
     }
 
 
-    /// Disable hostname verification.
+    /// Controls the use of hostname verification.
+    ///
+    /// Defaults to `false`.
     ///
     /// # Warning
     ///
@@ -153,40 +155,26 @@ impl ClientBuilder {
     /// site will be trusted for use from any other. This introduces a
     /// significant vulnerability to man-in-the-middle attacks.
     #[inline]
-    pub fn danger_disable_hostname_verification(&mut self) -> &mut ClientBuilder {
-        self.inner.danger_disable_hostname_verification();
+    pub fn danger_accept_invalid_hostnames(&mut self, accept_invalid_hostname: bool) -> &mut ClientBuilder {
+        self.inner.danger_accept_invalid_hostnames(accept_invalid_hostname);
         self
     }
 
-    /// Enable hostname verification.
+
+    /// Controls the use of certificate validation.
     ///
-    /// Default is enabled.
-    #[inline]
-    pub fn enable_hostname_verification(&mut self) -> &mut ClientBuilder {
-        self.inner.enable_hostname_verification();
-        self
-    }
-
-     /// Disable certs verification.
+    /// Defaults to `false`.
     ///
     /// # Warning
     ///
-    /// You should think very carefully before you use this method. If
-    /// hostname verification is not used, any valid certificate for any
-    /// site will be trusted for use from any other. This introduces a
-    /// significant vulnerability to man-in-the-middle attacks.
+    /// You should think very carefully before using this method. If
+    /// invalid certificates are trusted, *any* certificate for *any* site
+    /// will be trusted for use. This includes expired certificates. This
+    /// introduces significant vulnerabilities, and should only be used
+    /// as a last resort.
     #[inline]
-    pub fn danger_disable_certs_verification(&mut self) -> &mut ClientBuilder {
-        self.inner.danger_disable_certs_verification();
-        self
-    }
-
-    /// Enable certs verification.
-    ///
-    /// Default is enabled.
-    #[inline]
-    pub fn enable_certs_verification(&mut self) -> &mut ClientBuilder {
-        self.inner.enable_certs_verification();
+    pub fn danger_accept_invalid_certs(&mut self, accept_invalid_certs: bool) -> &mut ClientBuilder {
+        self.inner.danger_accept_invalid_certs(accept_invalid_certs);
         self
     }
 


### PR DESCRIPTION
## Summary
- Changes the API around disabling the various kinds of cert validation
- Fixes the docstring for completely disabling certificate validation

## Details

This closely matches the API exposed from [native-tls](https://github.com/sfackler/rust-native-tls/blob/136b5f9a220650c3121b940d9b3242e5e38c1f61/src/lib.rs#L372-L387), and I think it ends up being more ergonomic for the end user.

Rather than
``` rust
let mut clientbuilder = reqwest::ClientBuilder::new();
if insecure {
    clientbuilder.danger_disable_certs_verification();
}
let client = clientbuilder.build().unwrap();
```

one can simply
``` rust
let client = reqwest::ClientBuilder::new()
    .danger_accept_invalid_certs(insecure)
    .build().unwrap();
```

If we are worried about backwards incompatibility with this change, we can add a helper function for `danger_disable_hostname_verification()` to maintain the old API for existing users. 