### PR TITLE
Change case in auth headers

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -220,7 +220,7 @@ impl RequestBuilder {
             Some(password) => format!("{}:{}", username, password),
             None => format!("{}:", username)
         };
-        let header_value = format!("basic {}", encode(&auth));
+        let header_value = format!("Basic {}", encode(&auth));
         self.header(::header::AUTHORIZATION, &*header_value)
     }
 
@@ -239,7 +239,7 @@ impl RequestBuilder {
     where
         T: fmt::Display,
     {
-        let header_value = format!("bearer {}", token);
+        let header_value = format!("Bearer {}", token);
         self.header(::header::AUTHORIZATION, &*header_value)
     }
 


### PR DESCRIPTION
Although authorization token is case insensitive, lowercased version doesn't work with Twitter API.