### PR TITLE
Remove invalid headers after erasing body

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use futures::{Async, Future, Poll};
 use hyper::client::ResponseFuture;
 use header::{HeaderMap, HeaderValue, LOCATION, USER_AGENT, REFERER, ACCEPT,
-             ACCEPT_ENCODING, RANGE};
+             ACCEPT_ENCODING, RANGE, TRANSFER_ENCODING, CONTENT_TYPE, CONTENT_LENGTH, CONTENT_ENCODING};
 use mime::{self};
 use native_tls::{TlsConnector, TlsConnectorBuilder};
 
@@ -454,6 +454,10 @@ impl Future for PendingRequest {
                 StatusCode::FOUND |
                 StatusCode::SEE_OTHER => {
                     self.body = None;
+                    for header in &[TRANSFER_ENCODING, CONTENT_ENCODING, CONTENT_TYPE, CONTENT_LENGTH] {
+                        self.headers.remove(header);
+                    }
+
                     match self.method {
                         Method::GET | Method::HEAD => {},
                         _ => {


### PR DESCRIPTION
Fixes #341.

Maybe we will have to remove some more headers like `Content-Disposition` or `Content-Range`. However [request](https://github.com/requests/requests) is erasing only [those](https://github.com/requests/requests/blob/d26f6314ab07eb8ea42ffb0a96e28deebf61ed18/requests/sessions.py#L186-L192) from my commit.