### PR TITLE
Document `gzip` client's behaviour

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -166,6 +166,14 @@ impl ClientBuilder {
 
     /// Enable auto gzip decompression by checking the ContentEncoding response header.
     ///
+    /// If auto gzip decompresson is turned on:
+    /// - When sending a request and if the request's headers do not already contain
+    ///   an `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to `gzip`.
+    ///   The body is **not** automatically inflated.
+    /// - When receiving a response, if it's headers contain a `Content-Encoding` value that
+    ///   equals to `gzip`, both values `Content-Encoding` and `Content-Length` are removed from the 
+    ///   headers' set. The body is automatically deinflated.
+    /// 
     /// Default is enabled.
     pub fn gzip(mut self, enable: bool) -> ClientBuilder {
         self.config.gzip = enable;

--- a/src/client.rs
+++ b/src/client.rs
@@ -212,6 +212,14 @@ impl ClientBuilder {
 
     /// Enable auto gzip decompression by checking the ContentEncoding response header.
     ///
+    /// If auto gzip decompresson is turned on:
+    /// - When sending a request and if the request's headers do not already contain
+    ///   an `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to `gzip`.
+    ///   The body is **not** automatically inflated.
+    /// - When receiving a response, if it's headers contain a `Content-Encoding` value that
+    ///   equals to `gzip`, both values `Content-Encoding` and `Content-Length` are removed from the 
+    ///   headers' set. The body is automatically deinflated.
+    /// 
     /// Default is enabled.
     pub fn gzip(self, enable: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.gzip(enable))


### PR DESCRIPTION
As suggested in #306, the behaviour of the `auto gzip decompression` should
be clearly explained inside the documentation.