### PR TITLE
derive body from hyper::Body first

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -145,10 +145,11 @@ impl fmt::Debug for Response {
     }
 }
 
-impl<T: Into<body::Body>> From<http::Response<T>> for Response {
+impl<T: Into<::hyper::Body>> From<http::Response<T>> for Response {
     fn from(r: http::Response<T>) -> Response {
-        let (mut parts, body) = r.into_parts();
-        let body = body.into();
+        let (mut parts, raw) = r.into_parts();
+        let hyper_body = raw.into();
+        let body = body::wrap(hyper_body);
         let body = decoder::detect(&mut parts.headers, body, false);
         let url = parts.extensions
             .remove::<ResponseUrl>()

--- a/src/response.rs
+++ b/src/response.rs
@@ -337,7 +337,7 @@ pub fn new(mut res: async_impl::Response, timeout: Option<Duration>, thread: Kee
     }
 }
 
-impl<T: Into<async_impl::body::Body>> From<http::Response<T>> for Response {
+impl<T: Into<::hyper::Body>> From<http::Response<T>> for Response {
     fn from(r: http::Response<T>) -> Response {
         let response = async_impl::Response::from(r);
         new(response, None, KeepCoreThreadAlive::empty())


### PR DESCRIPTION
when you convert from String/&str/Vec<u8> to request::Body, it can get
to unreachable code. converting from String/&str/Vec<u8> -> hyper::Body -> reqwest::Body avoids this