### PR TITLE
Added Part::bytes(...) method

### DIFF
--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -148,6 +148,17 @@ impl Part {
         Part::new(body)
     }
 
+    /// Makes a new parameter from arbitrary bytes
+    pub fn bytes<T>(value: T) -> Part
+    where T: Into<Cow<'static, [u8]>>
+    {
+        let body = match value.into() {
+            Cow::Borrowed(slice) => Body::from(slice),
+            Cow::Owned(vec) => Body::from(vec),
+        };
+        Part::new(body)
+    }
+
     /// Adds a generic reader.
     ///
     /// Does not set filename or mime.


### PR DESCRIPTION
Fixes #215. The `std::io::Cursor` trick did not seem to work for me but this works fine for me, and besides this is clearer anyway.