### PR TITLE
Fix mime charset value to string conversion compiler error

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -229,9 +229,9 @@ impl Response {
             .and_then(|mime| {
                 mime
                     .get_param("charset")
-                    .map(|charset| charset.as_str())
+                    .map(|charset| charset.to_content())
             })
-            .unwrap_or("utf-8");
+            .unwrap_or(Cow::from("utf-8"));
         let encoding = Encoding::for_label(encoding_name.as_bytes()).unwrap_or(UTF_8);
         // a block because of borrow checker
         {


### PR DESCRIPTION
The [current](https://github.com/seanmonstar/reqwest/commit/e40cc33e529444e30a50ce4acc79a25e53c1110c) `master` branch fails to compile, due to the `mime` crate not reliably providing the `as_str()` function. This PR fixes this issue.

This is the error that showed up:
```
    Checking reqwest v0.9.2
error[E0599]: no method named `as_str` found for type `mime::Value<'_>` in the current scope
   --> /home/timvisee/.cargo/registry/src/github.com-1ecc6299db9ec823/reqwest-0.9.2/src/response.rs:216:44
    |
216 |                     .map(|charset| charset.as_str())
    |                                            ^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: Could not compile `reqwest`.
```

See https://github.com/seanmonstar/reqwest/issues/293#issuecomment-429979155.