### PR TITLE
put all TLS functionality behind a feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,14 @@ matrix:
           rust: stable
 
         - rust: stable
-          env: FEATURES=""
         - rust: beta
-          env: FEATURES=""
         - rust: nightly
-          env: FEATURES=""
+
+        # Disable default-tls
+        - rust: stable
+          env: FEATURES="--no-default-features"
 
         - rust: stable
-          env: FEATURES="--features hyper-011"
-        - rust: beta
-          env: FEATURES="--features hyper-011"
-        - rust: nightly
           env: FEATURES="--features hyper-011"
 
         # minimum version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ futures = "0.1.23"
 http = "0.1.10"
 hyper = "0.12.13"
 hyper-old-types = { version = "0.11", optional = true, features = ["compat"] }
-hyper-tls = "0.3"
+hyper-tls = { version = "0.3", optional = true }
 libflate = "0.1.18"
 log = "0.4"
 mime = "0.3.7"
 mime_guess = "2.0.0-alpha.6"
-native-tls = "0.2"
+native-tls = { version = "0.2", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.5"
@@ -36,8 +36,9 @@ env_logger = "0.5"
 serde_derive = "1.0"
 
 [features]
-default = []
+default = ["default-tls"]
 hyper-011 = ["hyper-old-types"]
+default-tls = ["hyper-tls", "native-tls"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docs_rs_workaround"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,9 @@ use futures::sync::{mpsc, oneshot};
 
 use request::{Request, RequestBuilder};
 use response::Response;
-use {async_impl, header, Certificate, Identity, Method, IntoUrl, Proxy, RedirectPolicy, wait};
+use {async_impl, header, Method, IntoUrl, Proxy, RedirectPolicy, wait};
+#[cfg(feature = "default-tls")]
+use {Certificate, Identity};
 
 /// A `Client` to make Requests with.
 ///
@@ -106,6 +108,7 @@ impl ClientBuilder {
     /// # Errors
     ///
     /// This method fails if adding root certificate was unsuccessful.
+    #[cfg(feature = "default-tls")]
     pub fn add_root_certificate(self, cert: Certificate) -> ClientBuilder {
         self.with_inner(move |inner| inner.add_root_certificate(cert))
     }
@@ -133,6 +136,7 @@ impl ClientBuilder {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg(feature = "default-tls")]
     pub fn identity(self, identity: Identity) -> ClientBuilder {
         self.with_inner(move |inner| inner.identity(identity))
     }
@@ -148,6 +152,7 @@ impl ClientBuilder {
     /// hostname verification is not used, any valid certificate for any
     /// site will be trusted for use from any other. This introduces a
     /// significant vulnerability to man-in-the-middle attacks.
+    #[cfg(feature = "default-tls")]
     pub fn danger_accept_invalid_hostnames(self, accept_invalid_hostname: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.danger_accept_invalid_hostnames(accept_invalid_hostname))
     }
@@ -164,6 +169,7 @@ impl ClientBuilder {
     /// will be trusted for use. This includes expired certificates. This
     /// introduces significant vulnerabilities, and should only be used
     /// as a last resort.
+    #[cfg(feature = "default-tls")]
     pub fn danger_accept_invalid_certs(self, accept_invalid_certs: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.danger_accept_invalid_certs(accept_invalid_certs))
     }

--- a/src/connect_async.rs
+++ b/src/connect_async.rs
@@ -1,8 +1,7 @@
 use std::io::{self, Read, Write};
 
 use futures::{Poll, Future, Async};
-use native_tls;
-use native_tls::{HandshakeError, Error, TlsConnector};
+use native_tls::{self, HandshakeError, Error, TlsConnector};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// A wrapper around an underlying raw stream which implements the TLS or SSL

--- a/src/error.rs
+++ b/src/error.rs
@@ -135,6 +135,7 @@ impl Error {
             Kind::Hyper(ref e) => Some(e),
             Kind::Mime(ref e) => Some(e),
             Kind::Url(ref e) => Some(e),
+            #[cfg(feature = "default-tls")]
             Kind::Tls(ref e) => Some(e),
             Kind::Io(ref e) => Some(e),
             Kind::UrlEncoded(ref e) => Some(e),
@@ -224,6 +225,7 @@ impl fmt::Display for Error {
             Kind::Mime(ref e) => fmt::Display::fmt(e, f),
             Kind::Url(ref e) => fmt::Display::fmt(e, f),
             Kind::UrlBadScheme => f.write_str("URL scheme is not allowed"),
+            #[cfg(feature = "default-tls")]
             Kind::Tls(ref e) => fmt::Display::fmt(e, f),
             Kind::Io(ref e) => fmt::Display::fmt(e, f),
             Kind::UrlEncoded(ref e) => fmt::Display::fmt(e, f),
@@ -250,6 +252,7 @@ impl StdError for Error {
             Kind::Mime(ref e) => e.description(),
             Kind::Url(ref e) => e.description(),
             Kind::UrlBadScheme => "URL scheme is not allowed",
+            #[cfg(feature = "default-tls")]
             Kind::Tls(ref e) => e.description(),
             Kind::Io(ref e) => e.description(),
             Kind::UrlEncoded(ref e) => e.description(),
@@ -267,6 +270,7 @@ impl StdError for Error {
             Kind::Hyper(ref e) => e.cause(),
             Kind::Mime(ref e) => e.cause(),
             Kind::Url(ref e) => e.cause(),
+            #[cfg(feature = "default-tls")]
             Kind::Tls(ref e) => e.cause(),
             Kind::Io(ref e) => e.cause(),
             Kind::UrlEncoded(ref e) => e.cause(),
@@ -287,6 +291,7 @@ pub(crate) enum Kind {
     Mime(::mime::FromStrError),
     Url(::url::ParseError),
     UrlBadScheme,
+    #[cfg(feature = "default-tls")]
     Tls(::native_tls::Error),
     Io(io::Error),
     UrlEncoded(::serde_urlencoded::ser::Error),
@@ -347,6 +352,7 @@ impl From<::serde_json::Error> for Kind {
     }
 }
 
+#[cfg(feature = "default-tls")]
 impl From<::native_tls::Error> for Kind {
     fn from(err: ::native_tls::Error) -> Kind {
         Kind::Tls(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,16 @@
 //! # }
 //! ```
 //!
+//! ## Optional Features
+//!
+//! The following are a list of [Cargo features][cargo-features] that can be
+//! enabled or disabled:
+//!
+//! - **default-tls** *(enabled by default)*: Provides TLS support via the
+//!   `native-tls` library to connect over HTTPS.
+//! - **hyper-011**: Provides support for hyper's old typed headers.
+//!
+//!
 //! [hyper]: http://hyper.rs
 //! [client]: ./struct.Client.html
 //! [response]: ./struct.Response.html
@@ -124,6 +134,7 @@
 //! [builder]: ./struct.RequestBuilder.html
 //! [serde]: http://serde.rs
 //! [cookiejar_issue]: https://github.com/seanmonstar/reqwest/issues/14
+//! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
 extern crate base64;
 extern crate bytes;
@@ -134,12 +145,14 @@ extern crate http;
 extern crate hyper;
 #[cfg(feature = "hyper-011")]
 pub extern crate hyper_old_types as hyper_011;
+#[cfg(feature = "default-tls")]
 extern crate hyper_tls;
 #[macro_use]
 extern crate log;
 extern crate libflate;
 extern crate mime;
 extern crate mime_guess;
+#[cfg(feature = "default-tls")]
 extern crate native_tls;
 extern crate serde;
 #[cfg(test)]
@@ -148,7 +161,7 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate serde_urlencoded;
 extern crate tokio;
-#[macro_use]
+#[cfg_attr(feature = "default-tls", macro_use)]
 extern crate tokio_io;
 extern crate url;
 extern crate uuid;
@@ -167,6 +180,7 @@ pub use self::proxy::Proxy;
 pub use self::redirect::{RedirectAction, RedirectAttempt, RedirectPolicy};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::Response;
+#[cfg(feature = "default-tls")]
 pub use self::tls::{Certificate, Identity};
 
 
@@ -176,6 +190,7 @@ mod error;
 
 mod async_impl;
 mod connect;
+#[cfg(feature = "default-tls")]
 mod connect_async;
 mod body;
 mod client;
@@ -184,6 +199,7 @@ mod proxy;
 mod redirect;
 mod request;
 mod response;
+#[cfg(feature = "default-tls")]
 mod tls;
 mod wait;
 


### PR DESCRIPTION
The "Cargo feature" `default-tls`, which is enabled by default, is
added, with all TLS support relying on it. This allows using reqwest but
disabling the `native-tls` dependency, by disabling this feature.

Closes #225