### PR TITLE
Added dns_threads setter to sync ClientBuilder

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -266,7 +266,7 @@ impl ClientBuilder {
     ///
     /// Default is 4
     pub fn dns_threads(self, threads: usize) -> ClientBuilder {
-        self.with_inner(move |inner| inner.dns_threads(threads))
+        self.with_inner(|inner| inner.dns_threads(threads))
     }
 
     fn with_inner<F>(mut self, func: F) -> ClientBuilder

--- a/src/client.rs
+++ b/src/client.rs
@@ -262,6 +262,13 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the number of threads to use for DNS
+    ///
+    /// Default is 4
+    pub fn dns_threads(self, threads: usize) -> ClientBuilder {
+        self.with_inner(move |inner| inner.dns_threads(threads))
+    }
+
     fn with_inner<F>(mut self, func: F) -> ClientBuilder
     where
         F: FnOnce(async_impl::ClientBuilder) -> async_impl::ClientBuilder,


### PR DESCRIPTION
I noticed in #209 that the ability to set the number of threads to use for DNS resolution was added to the async ClientBuilder. This PR enables that same ability for the default sync ClientBuilder.

Why? I have a small program that makes single requests at a time. I noticed that there were four DNS threads by default which isn't needed for my use case. I wondered whether I could set how many threads were used for that and what the memory impact of changing that count might be. After some searching I found the above PR.

I'm not sure whether it's desirable to expose this in the public API but I already had the code written from my local experiment. I thought it might be useful to somebody else as well and thought I'd see if it might be accepted.