### PR TITLE
Add RequestBuilder::pretty_json()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde_derive = "1.0"
 default = ["default-tls"]
 hyper-011 = ["hyper-old-types"]
 default-tls = ["hyper-tls", "native-tls"]
+pretty-json = []
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docs_rs_workaround"]


### PR DESCRIPTION
Allows sending prettified JSON body.
Sometimes it is useful and desirable to be able to send "pretty" JSON formatted body.
This PR adds this ability. It comes under "pretty-json" feature, but it (feature) can be dropped if this will prove to be generally useful.