### PR TITLE
Add try_clone to Request and RequestBuilder

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -109,12 +109,26 @@ impl Body {
             }
         }
     }
+
+    pub(crate) fn try_clone(&self) -> Option<Body> {
+        self.kind.try_clone()
+            .map(|kind| Body { kind })
+    }
 }
 
 
 enum Kind {
     Reader(Box<Read + Send>, Option<u64>),
     Bytes(Bytes),
+}
+
+impl Kind {
+    fn try_clone(&self) -> Option<Kind> {
+        match self {
+            Kind::Reader(..) => None,
+            Kind::Bytes(v) => Some(Kind::Bytes(v.clone())),
+        }
+    }
 }
 
 impl From<Vec<u8>> for Body {


### PR DESCRIPTION
The need to clone a request or builder may arise when repeating a
request multiple times. This can be either because:
* The Request object is consumed by Client::execute
* The request might need to be retried later
* A complex request needs to be repeated with slightly different
  parameters, such as in the Partial-Content scheme which allows seeking
  through the content of large object over HTTP by performing multiple
  HTTP GET requests.

To make this easier, it would be nice if Request and RequestBuilder
were to implement the Clone trait. However, this is not possible because
a body might be set that is a stream which can not be cloned. To get
around this, I added a try_clone function that fails if the body is not
clonable.

An alternative solution would be to add a type parameter to Request for
the body so a conditional implementation for Clone can be added.