### PR TITLE
Don't panic if the client builder fails

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,8 @@ pub mod async {
 /// - redirect loop was detected
 /// - redirect limit was exhausted
 pub fn get<T: IntoUrl>(url: T) -> ::Result<Response> {
-    Client::new()
+    Client::builder()
+        .build()?
         .get(url)
         .send()
 }


### PR DESCRIPTION
There's no reason for `Result`-returning `get()` to panic. This happens, e.g. if there are too many open files.