### PR TITLE
Rename async module to asynchronous and upgrade to 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
           env: FEATURES="--features hyper-011"
 
         # minimum version
-        - rust: 1.30.0
+        - rust: 1.31.0
           script: cargo build
 
 sudo: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "reqwest"
 version = "0.9.5" # remember to update html_root_url
+edition = "2018"
 description = "higher level HTTP client library"
 keywords = ["http", "request", "client"]
 repository = "https://github.com/seanmonstar/reqwest"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -7,7 +7,7 @@ extern crate tokio;
 use std::mem;
 use std::io::{self, Cursor};
 use futures::{Future, Stream};
-use reqwest::async::{Client, Decoder};
+use reqwest::asynchronous::{Client, Decoder};
 
 
 fn fetch() -> impl Future<Item=(), Error=()> {

--- a/examples/async_multiple_requests.rs
+++ b/examples/async_multiple_requests.rs
@@ -8,7 +8,7 @@ extern crate serde;
 extern crate serde_json;
 
 use futures::Future;
-use reqwest::async::{Client, Response};
+use reqwest::asynchronous::{Client, Response};
 
 #[derive(Deserialize, Debug)]
 struct Slideshow {

--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -73,7 +73,7 @@ impl Body {
 
 impl Stream for Body {
     type Item = Chunk;
-    type Error = ::Error;
+    type Error = crate::Error;
 
     #[inline]
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -31,9 +31,10 @@ use libflate::non_blocking::gzip;
 use futures::{Async, Future, Poll, Stream};
 use hyper::{HeaderMap};
 use hyper::header::{CONTENT_ENCODING, CONTENT_LENGTH, TRANSFER_ENCODING, HeaderValue};
+use log::warn;
 
 use super::{Body, Chunk};
-use error;
+use crate::error;
 
 const INIT_BUFFER_SIZE: usize = 8192;
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -7,9 +7,9 @@ use serde_urlencoded;
 
 use super::body::{Body};
 use super::client::{Client, Pending};
-use header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+use crate::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use http::HttpTryFrom;
-use {Method, Url};
+use crate::{Method, Url};
 
 /// A request which can be executed with `Client::execute()`.
 pub struct Request {
@@ -22,7 +22,7 @@ pub struct Request {
 /// A builder to construct the properties of a `Request`.
 pub struct RequestBuilder {
     client: Client,
-    request: ::Result<Request>,
+    request: crate::Result<Request>,
 }
 
 impl Request {
@@ -91,7 +91,7 @@ impl Request {
 }
 
 impl RequestBuilder {
-    pub(super) fn new(client: Client, request: ::Result<Request>) -> RequestBuilder {
+    pub(super) fn new(client: Client, request: crate::Result<Request>) -> RequestBuilder {
         RequestBuilder {
             client,
             request,
@@ -110,10 +110,10 @@ impl RequestBuilder {
                 Ok(key) => {
                     match <HeaderValue as HttpTryFrom<V>>::try_from(value) {
                         Ok(value) => { req.headers_mut().append(key, value); }
-                        Err(e) => error = Some(::error::from(e.into())),
+                        Err(e) => error = Some(crate::error::from(e.into())),
                     }
                 },
-                Err(e) => error = Some(::error::from(e.into())),
+                Err(e) => error = Some(crate::error::from(e.into())),
             };
         }
         if let Some(err) = error {
@@ -124,7 +124,7 @@ impl RequestBuilder {
     /// Add a set of Headers to the existing ones on this Request.
     ///
     /// The headers will be merged in to any already set.
-    pub fn headers(mut self, headers: ::header::HeaderMap) -> RequestBuilder {
+    pub fn headers(mut self, headers: crate::header::HeaderMap) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             for (key, value) in headers.iter() {
                 req.headers_mut().insert(key, value.clone());
@@ -140,11 +140,11 @@ impl RequestBuilder {
     #[cfg(feature = "hyper-011")]
     pub fn header_011<H>(self, header: H) -> RequestBuilder
     where
-        H: ::hyper_011::header::Header,
+        H: crate::hyper_011::header::Header,
     {
-        let mut headers = ::hyper_011::Headers::new();
+        let mut headers = crate::hyper_011::Headers::new();
         headers.set(header);
-        let map = ::header::HeaderMap::from(headers);
+        let map = crate::header::HeaderMap::from(headers);
         self.headers(map)
     }
 
@@ -153,8 +153,8 @@ impl RequestBuilder {
     /// This method is provided to ease migration, and requires the `hyper-011`
     /// Cargo feature enabled on `reqwest`.
     #[cfg(feature = "hyper-011")]
-    pub fn headers_011(self, headers: ::hyper_011::Headers) -> RequestBuilder {
-        let map = ::header::HeaderMap::from(headers);
+    pub fn headers_011(self, headers: crate::hyper_011::Headers) -> RequestBuilder {
+        let map = crate::header::HeaderMap::from(headers);
         self.headers(map)
     }
 
@@ -169,7 +169,7 @@ impl RequestBuilder {
             None => format!("{}:", username)
         };
         let header_value = format!("basic {}", encode(&auth));
-        self.header(::header::AUTHORIZATION, &*header_value)
+        self.header(crate::header::AUTHORIZATION, &*header_value)
     }
 
     /// Set the request body.
@@ -206,7 +206,7 @@ impl RequestBuilder {
             let serializer = serde_urlencoded::Serializer::new(&mut pairs);
 
             if let Err(err) = query.serialize(serializer) {
-                error = Some(::error::from(err));
+                error = Some(crate::error::from(err));
             }
         }
         if let Some(err) = error {
@@ -227,7 +227,7 @@ impl RequestBuilder {
                     );
                     *req.body_mut() = Some(body.into());
                 },
-                Err(err) => error = Some(::error::from(err)),
+                Err(err) => error = Some(crate::error::from(err)),
             }
         }
         if let Some(err) = error {
@@ -253,7 +253,7 @@ impl RequestBuilder {
                     );
                     *req.body_mut() = Some(body.into());
                 },
-                Err(err) => error = Some(::error::from(err)),
+                Err(err) => error = Some(crate::error::from(err)),
             }
         }
         if let Some(err) = error {
@@ -264,7 +264,7 @@ impl RequestBuilder {
 
     /// Build a `Request`, which can be inspected, modified and executed with
     /// `Client::execute()`.
-    pub fn build(self) -> ::Result<Request> {
+    pub fn build(self) -> crate::Result<Request> {
         self.request
     }
 
@@ -317,6 +317,7 @@ fn fmt_request_fields<'a, 'b>(f: &'a mut fmt::DebugStruct<'a, 'b>, req: &Request
 mod tests {
     use super::Client;
     use std::collections::BTreeMap;
+    use serde_derive::Serialize;
 
     #[test]
     fn add_query_append() {

--- a/src/connect_async.rs
+++ b/src/connect_async.rs
@@ -2,7 +2,7 @@ use std::io::{self, Read, Write};
 
 use futures::{Poll, Future, Async};
 use native_tls::{self, HandshakeError, Error, TlsConnector};
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio_io::{AsyncRead, AsyncWrite, try_nb};
 
 /// A wrapper around an underlying raw stream which implements the TLS or SSL
 /// protocol.

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::io;
 
-use {StatusCode, Url};
+use crate::{StatusCode, Url};
 
 /// The Errors that may occur when processing a `Request`.
 ///
@@ -222,8 +222,8 @@ impl fmt::Debug for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(ref url) = self.inner.url {
-            try!(fmt::Display::fmt(url, f));
-            try!(f.write_str(": "));
+            fmt::Display::fmt(url, f)?;
+            f.write_str(": ")?;
         }
         match self.inner.kind {
             Kind::Http(ref e) => fmt::Display::fmt(e, f),
@@ -389,12 +389,12 @@ impl From<::rustls::TLSError> for Kind {
     }
 }
 
-impl<T> From<::wait::Waited<T>> for Kind
+impl<T> From<crate::wait::Waited<T>> for Kind
 where T: Into<Kind> {
-    fn from(err: ::wait::Waited<T>) -> Kind {
+    fn from(err: crate::wait::Waited<T>) -> Kind {
         match err {
-            ::wait::Waited::TimedOut =>  io_timeout().into(),
-            ::wait::Waited::Err(e) => e.into(),
+            crate::wait::Waited::TimedOut =>  io_timeout().into(),
+            crate::wait::Waited::Err(e) => e.into(),
         }
     }
 }
@@ -451,7 +451,7 @@ macro_rules! try_ {
         match $e {
             Ok(v) => v,
             Err(err) => {
-                return Err(::error::from(err));
+                return Err(crate::error::from(err));
             }
         }
     );
@@ -459,7 +459,7 @@ macro_rules! try_ {
         match $e {
             Ok(v) => v,
             Err(err) => {
-                return Err(::Error::from(::error::InternalFrom(err, Some($url.clone()))));
+                return Err(crate::Error::from(crate::error::InternalFrom(err, Some($url.clone()))));
             }
         }
     )

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -12,28 +12,28 @@ impl<T: PolyfillTryInto> IntoUrl for T {}
 pub trait PolyfillTryInto {
     // Besides parsing as a valid `Url`, the `Url` must be a valid
     // `http::Uri`, in that it makes sense to use in a network request.
-    fn into_url(self) -> ::Result<Url>;
+    fn into_url(self) -> crate::Result<Url>;
 }
 
 impl PolyfillTryInto for Url {
-    fn into_url(self) -> ::Result<Url> {
+    fn into_url(self) -> crate::Result<Url> {
         if self.has_host() {
             Ok(self)
         } else {
-            Err(::error::url_bad_scheme(self))
+            Err(crate::error::url_bad_scheme(self))
         }
     }
 }
 
 impl<'a> PolyfillTryInto for &'a str {
-    fn into_url(self) -> ::Result<Url> {
+    fn into_url(self) -> crate::Result<Url> {
         try_!(Url::parse(self))
             .into_url()
     }
 }
 
 impl<'a> PolyfillTryInto for &'a String {
-    fn into_url(self) -> ::Result<Url> {
+    fn into_url(self) -> crate::Result<Url> {
         (&**self).into_url()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,45 +136,11 @@
 //! [cookiejar_issue]: https://github.com/seanmonstar/reqwest/issues/14
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
-extern crate base64;
-extern crate bytes;
-extern crate encoding_rs;
-#[macro_use]
-extern crate futures;
-extern crate http;
-extern crate hyper;
-#[cfg(feature = "hyper-011")]
-pub extern crate hyper_old_types as hyper_011;
-#[cfg(feature = "default-tls")]
-extern crate hyper_tls;
-#[macro_use]
-extern crate log;
-extern crate libflate;
-extern crate mime;
-extern crate mime_guess;
-#[cfg(feature = "default-tls")]
-extern crate native_tls;
-extern crate serde;
 #[cfg(test)]
-#[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
-extern crate serde_urlencoded;
-extern crate tokio;
-#[cfg_attr(feature = "default-tls", macro_use)]
-extern crate tokio_io;
-extern crate trust_dns_resolver;
-extern crate url;
-extern crate uuid;
 
-#[cfg(feature = "rustls-tls")]
-extern crate hyper_rustls;
-#[cfg(feature = "rustls-tls")]
-extern crate tokio_rustls;
-#[cfg(feature = "rustls-tls")]
-extern crate webpki_roots;
-#[cfg(feature = "rustls-tls")]
-extern crate rustls;
+#[cfg(feature = "hyper-011")]
+pub use hyper_old_types as hyper_011;
 
 pub use hyper::header;
 pub use hyper::Method;
@@ -220,8 +186,8 @@ pub mod multipart;
 ///
 /// Relies on the `futures` crate, which is unstable, hence this module
 /// is **unstable**.
-pub mod async {
-    pub use ::async_impl::{
+pub mod asynchronous {
+    pub use crate::async_impl::{
         Body,
         Chunk,
         Decoder,
@@ -263,7 +229,7 @@ pub mod async {
 /// - there was an error while sending request
 /// - redirect loop was detected
 /// - redirect limit was exhausted
-pub fn get<T: IntoUrl>(url: T) -> ::Result<Response> {
+pub fn get<T: IntoUrl>(url: T) -> Result<Response> {
     Client::builder()
         .build()?
         .get(url)

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -10,7 +10,7 @@ use url::percent_encoding::{self, EncodeSet, PATH_SEGMENT_ENCODE_SET};
 use uuid::Uuid;
 use http::HeaderMap;
 
-use {Body};
+use crate::Body;
 
 /// A multipart/form-data request.
 pub struct Form {
@@ -222,7 +222,7 @@ impl Part {
     }
 
     /// Tries to set the mime of this part.
-    pub fn mime_str(mut self, mime: &str) -> ::Result<Part> {
+    pub fn mime_str(mut self, mime: &str) -> crate::Result<Part> {
         self.mime = Some(try_!(mime.parse()));
         Ok(self)
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use hyper::client::connect::Destination;
-use {into_url, IntoUrl, Url};
+use crate::{into_url, IntoUrl, Url};
 
 /// Configuration of a proxy that a `Client` should pass requests to.
 ///
@@ -48,8 +48,8 @@ impl Proxy {
     /// # }
     /// # fn main() {}
     /// ```
-    pub fn http<U: IntoUrl>(url: U) -> ::Result<Proxy> {
-        let uri = ::into_url::to_uri(&url.into_url()?);
+    pub fn http<U: IntoUrl>(url: U) -> crate::Result<Proxy> {
+        let uri = crate::into_url::to_uri(&url.into_url()?);
         Ok(Proxy::new(Intercept::Http(uri)))
     }
 
@@ -67,8 +67,8 @@ impl Proxy {
     /// # }
     /// # fn main() {}
     /// ```
-    pub fn https<U: IntoUrl>(url: U) -> ::Result<Proxy> {
-        let uri = ::into_url::to_uri(&url.into_url()?);
+    pub fn https<U: IntoUrl>(url: U) -> crate::Result<Proxy> {
+        let uri = crate::into_url::to_uri(&url.into_url()?);
         Ok(Proxy::new(Intercept::Https(uri)))
     }
 
@@ -86,8 +86,8 @@ impl Proxy {
     /// # }
     /// # fn main() {}
     /// ```
-    pub fn all<U: IntoUrl>(url: U) -> ::Result<Proxy> {
-        let uri = ::into_url::to_uri(&url.into_url()?);
+    pub fn all<U: IntoUrl>(url: U) -> crate::Result<Proxy> {
+        let uri = crate::into_url::to_uri(&url.into_url()?);
         Ok(Proxy::new(Intercept::All(uri)))
     }
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
-use header::HeaderMap;
+use crate::header::HeaderMap;
 use hyper::StatusCode;
 
-use Url;
+use crate::Url;
 
 /// A type that controls the policy on how to handle the following of redirects.
 ///

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -49,7 +49,7 @@ impl Certificate {
     /// # Errors
     ///
     /// It never returns error.
-    pub fn from_der(der: &[u8]) -> ::Result<Certificate> {
+    pub fn from_der(der: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
             inner: inner::Certificate::Der(der.to_owned())
         })
@@ -76,7 +76,7 @@ impl Certificate {
     /// # Errors
     ///
     /// It never returns error.
-    pub fn from_pem(der: &[u8]) -> ::Result<Certificate> {
+    pub fn from_pem(der: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
             inner: inner::Certificate::Pem(der.to_owned())
         })
@@ -116,7 +116,7 @@ impl Identity {
     ///
     /// It never returns error.
     #[cfg(feature = "default-tls")]
-    pub fn from_pkcs12_der(der: &[u8], password: &str) -> ::Result<Identity> {
+    pub fn from_pkcs12_der(der: &[u8], password: &str) -> crate::Result<Identity> {
         Ok(Identity {
             inner: inner::Identity::Pkcs12(der.to_owned(), password.to_owned())
         })
@@ -146,7 +146,7 @@ impl Identity {
     ///
     /// It never returns error.
     #[cfg(feature = "rustls-tls")]
-    pub fn from_pem(pem: &[u8]) -> ::Result<Identity> {
+    pub fn from_pem(pem: &[u8]) -> crate::Result<Identity> {
         Ok(Identity {
             inner: inner::Identity::Pem(pem.to_owned())
         })

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -6,7 +6,7 @@ extern crate tokio;
 #[macro_use]
 mod support;
 
-use reqwest::async::Client;
+use reqwest::asynchronous::Client;
 use futures::{Future, Stream};
 use std::io::Write;
 use std::time::Duration;
@@ -64,7 +64,7 @@ fn test_gzip(response_size: usize, chunk_size: usize) {
             let body = res.into_body();
             body.concat2()
         })
-        .and_then(|buf| {
+        .and_then(|buf: reqwest::asynchronous::Chunk| {
             let body = ::std::str::from_utf8(&buf).unwrap();
 
             assert_eq!(body, &content);

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -194,14 +194,14 @@ macro_rules! server {
                 $($f: $v,)+
             }),*
         ];
-        ::support::server::spawn(txns)
+        crate::support::server::spawn(txns)
     })
 }
 
 #[macro_export]
 macro_rules! __internal__txn {
     ($($field:ident: $val:expr,)+) => (
-        ::support::server::Txn {
+        crate::support::server::Txn {
             $( $field: __internal__prop!($field: $val), )+
             .. Default::default()
         }


### PR DESCRIPTION
async is now a keyword in 2018 edition, making it more difficult to use this lib in 2018 crates. I have moved the  `async` module to the name `asynchronous`, and while I was at it I went through and upgraded the crate to 2018 edition.