### PR TITLE
Fix bugs in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ extern crate reqwest;
 
 use std::collections::HashMap;
 
-fn main() -> Result<(), Box<std::error::Error> {
-    let res: HashMap<String, String> = reqwest::get("https://httpbin.org/ip")?
+fn main() -> Result<(), Box<std::error::Error>> {
+    let resp: HashMap<String, String> = reqwest::get("https://httpbin.org/ip")?
         .json()?;
     println!("{:#?}", resp);
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
Fix missing > in method return signature, undeclared variable, and
adds return type to match method signature.