### PR TITLE
Correcting 404 on example/simple.rs

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
     println!("GET https://www.rust-lang.org");
 
-    let mut res = reqwest::get("https://www.rust-lang.org/en-US/")?;
+    let mut res = reqwest::get("https://www.rust-lang.org/")?;
 
     println!("Status: {}", res.status());
     println!("Headers:\n{:?}", res.headers());


### PR DESCRIPTION
When executing simple.rs, the original URL results in a 404. I suspect the en-US addition was removed? 
Thought I'd bring it to your attention.

You might want to test it from US though. Maybe it is different when testing from Europe. Besides I test from a VPN as well.