### PR TITLE
Use blocking API for Json unmarshalling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ extern crate tokio_io;
 extern crate trust_dns_resolver;
 extern crate url;
 extern crate uuid;
+extern crate tokio_threadpool;
 
 #[cfg(feature = "rustls-tls")]
 extern crate hyper_rustls;


### PR DESCRIPTION
As evoked in the [tokio's blog](https://tokio.rs/blog/2018-05-tokio-fs/) and inside the `tokio-threadpool` crate, using the blocking API for CPU heavy operation would not lock the reactor.

This wraps the `serde_json` work inside a `blocking` call.