### PR TITLE
async: return 'impl Future' instead of private types

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -1,13 +1,15 @@
 use std::fmt;
 
 use base64::{encode};
+use futures::Future;
 use serde::Serialize;
 use serde_json;
 use serde_urlencoded;
 
 use super::body::{Body};
-use super::multipart;
 use super::client::{Client, Pending};
+use super::multipart;
+use super::response::Response;
 use header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use http::HttpTryFrom;
 use {Method, Url};
@@ -315,13 +317,14 @@ impl RequestBuilder {
         self.request
     }
 
-    /// Constructs the Request and sends it the target URL, returning a Response.
+    /// Constructs the Request and sends it to the target URL, returning a
+    /// future Response.
     ///
     /// # Errors
     ///
     /// This method fails if there was an error while sending request,
     /// redirect loop was detected or redirect limit was exhausted.
-    pub fn send(self) -> Pending {
+    pub fn send(self) -> impl Future<Item = Response, Error = ::Error> {
         match self.request {
             Ok(req) => self.client.execute(req),
             Err(err) => Pending::new_err(err),

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -324,6 +324,26 @@ impl RequestBuilder {
     ///
     /// This method fails if there was an error while sending request,
     /// redirect loop was detected or redirect limit was exhausted.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # extern crate futures;
+    /// # extern crate reqwest;
+    /// #
+    /// # use reqwest::Error;
+    /// # use futures::future::Future;
+    /// #
+    /// # fn run() -> Result<(), Error> {
+    /// let response = reqwest::r#async::Client::new()
+    ///     .get("https://hyper.rs")
+    ///     .send()
+    ///     .map(|resp| println!("status: {}", resp.status()));
+    ///
+    /// let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
+    /// rt.block_on(response)
+    /// # }
+    /// ```
     pub fn send(self) -> impl Future<Item = Response, Error = ::Error> {
         match self.request {
             Ok(req) => self.client.execute(req),

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -127,7 +127,7 @@ impl Response {
 
     /// Try to deserialize the response body as JSON using `serde`.
     #[inline]
-    pub fn json<T: DeserializeOwned>(&mut self) -> Json<T> {
+    pub fn json<T: DeserializeOwned>(&mut self) -> impl Future<Item = T, Error = ::Error> {
         let body = mem::replace(&mut self.body, Decoder::empty());
 
         Json {


### PR DESCRIPTION
This changes asynchronous `json()` and `send()` methods to return plain `impl Future` instead of the underlying private types. It also adds a simple example for send.

Closes: https://github.com/seanmonstar/reqwest/issues/205