### PR TITLE
Add http1 case sensitive header used in hyper

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -78,6 +78,7 @@ struct Config {
     #[cfg(feature = "tls")]
     tls: TlsBackend,
     http2_only: bool,
+    http1_title_case_headers: bool,
     local_address: Option<IpAddr>,
 }
 
@@ -110,6 +111,7 @@ impl ClientBuilder {
                 #[cfg(feature = "tls")]
                 tls: TlsBackend::default(),
                 http2_only: false,
+                http1_title_case_headers: false,
                 local_address: None,
             },
         }
@@ -184,6 +186,10 @@ impl ClientBuilder {
         let mut builder = ::hyper::Client::builder();
         if config.http2_only {
             builder.http2_only(true);
+        }
+
+        if config.http1_title_case_headers {
+            builder.http1_title_case_headers(true);
         }
 
         let hyper_client = builder.build(connector);
@@ -326,6 +332,12 @@ impl ClientBuilder {
     /// Only use HTTP/2.
     pub fn h2_prior_knowledge(mut self) -> ClientBuilder {
         self.config.http2_only = true;
+        self
+    }
+
+    /// Enable case sensitive headers.
+    pub fn http1_title_case_headers(mut self) -> ClientBuilder {
+        self.config.http1_title_case_headers = true;
         self
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -324,6 +324,19 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.h2_prior_knowledge())
     }
 
+    /// Enable case sensitive headers.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let client = reqwest::Client::builder()
+    ///     .http1_title_case_headers()
+    ///     .build().unwrap();
+    /// ```
+    pub fn http1_title_case_headers(self) -> ClientBuilder {
+        self.with_inner(|inner| inner.http1_title_case_headers())
+    }
+
     /// Bind to a local IP Address
     ///
     /// # Example


### PR DESCRIPTION
Hello,

The purpose of this PR is to implement in reqwest  the `http1_title_case_headers` option and to bind it to `hyper` that has already implemented it as defined [here](https://github.com/hyperium/hyper/issues/1492).

The purpose is to be able with reqwest to use uppercase headers when sending requests to servers that are not HTTP/2 compliant.

WDYT?