### PR TITLE
Add no_percent_encode configuration to Form

### DIFF
--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -92,8 +92,8 @@ impl Form {
     }
 
     /// Configure this `Form` to skip percent-encoding
-    pub fn no_percent_encode(self) -> Form {
-        self.with_inner(|inner| inner.no_percent_encode())
+    pub fn percent_encode_noop(self) -> Form {
+        self.with_inner(|inner| inner.percent_encode_noop())
     }
 
     /// Consume this instance and transform into an instance of hyper::Body for use in a request.
@@ -284,7 +284,7 @@ impl<P: PartProps> FormParts<P> {
     }
 
     /// Configure this `Form` to skip percent-encoding
-    pub(crate) fn no_percent_encode(mut self) -> Self {
+    pub(crate) fn percent_encode_noop(mut self) -> Self {
         self.percent_encoding = PercentEncoding::NoOp;
         self
     }

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -91,6 +91,11 @@ impl Form {
         self.with_inner(|inner| inner.percent_encode_attr_chars())
     }
 
+    /// Configure this `Form` to skip percent-encoding
+    pub fn no_percent_encode(self) -> Form {
+        self.with_inner(|inner| inner.no_percent_encode())
+    }
+
     /// Consume this instance and transform into an instance of hyper::Body for use in a request.
     pub(crate) fn stream(mut self) -> hyper::Body {
         if self.inner.fields.len() == 0 {
@@ -278,6 +283,12 @@ impl<P: PartProps> FormParts<P> {
         self
     }
 
+    /// Configure this `Form` to skip percent-encoding
+    pub(crate) fn no_percent_encode(mut self) -> Self {
+        self.percent_encoding = PercentEncoding::NoOp;
+        self
+    }
+
     // If predictable, computes the length the request will have
     // The length should be preditable if only String and file fields have been added,
     // but not if a generic reader has been added;
@@ -389,6 +400,7 @@ impl EncodeSet for AttrCharEncodeSet {
 pub(crate) enum PercentEncoding {
     PathSegment,
     AttrChar,
+    NoOp,
 }
 
 impl PercentEncoding {
@@ -434,6 +446,7 @@ impl PercentEncoding {
                 percent_encoding::utf8_percent_encode(value, AttrCharEncodeSet)
                     .to_string()
             },
+            PercentEncoding::NoOp => { value.to_string() },
         };
         if value.len() == legal_value.len() {
             // nothing has been percent encoded

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -130,6 +130,11 @@ impl Form {
         self.with_inner(|inner| inner.percent_encode_attr_chars())
     }
 
+    /// Configure this `Form` to skip percent-encoding
+    pub fn no_percent_encode(self) -> Form {
+        self.with_inner(|inner| inner.no_percent_encode())
+    }
+
     pub(crate) fn reader(self) -> Reader {
         Reader::new(self)
     }

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -131,8 +131,8 @@ impl Form {
     }
 
     /// Configure this `Form` to skip percent-encoding
-    pub fn no_percent_encode(self) -> Form {
-        self.with_inner(|inner| inner.no_percent_encode())
+    pub fn percent_encode_noop(self) -> Form {
+        self.with_inner(|inner| inner.percent_encode_noop())
     }
 
     pub(crate) fn reader(self) -> Reader {


### PR DESCRIPTION
Some implementations of multipart/form parsing don't support alternate
encodings, but do allow unicode in 'standard' parameter values. This
change allows users to specify that they do not want to encode
parameters.

(See also: #419, #420.)