### PR TITLE
add bearer auth to async RequestBuilder

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -174,6 +174,15 @@ impl RequestBuilder {
         self.header(::header::AUTHORIZATION, &*header_value)
     }
 
+    /// Enable HTTP bearer authentication.
+    pub fn bearer_auth<T>(self, token: T) -> RequestBuilder
+    where
+        T: fmt::Display,
+    {
+        let header_value = format!("Bearer {}", token);
+        self.header(::header::AUTHORIZATION, &*header_value)
+    }
+
     /// Set the request body.
     pub fn body<T: Into<Body>>(mut self, body: T) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {


### PR DESCRIPTION
Shamelessly copied from the sync version.