### PR TITLE
replace libflate with flate2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ http = "0.1.15"
 hyper = "0.12.22"
 hyper-old-types = { version = "0.11", optional = true, features = ["compat"] }
 hyper-tls = { version = "0.3", optional = true }
-flate2 = { git = "https://github.com/alexcrichton/flate2-rs", features = ["rust_backend"] }
+flate2 = { git = "https://github.com/quininer/flate2-rs", branch = "fix-old", default-features = false, features = ["rust_backend"] }
 log = "0.4"
 mime = "0.3.7"
 mime_guess = "2.0.0-alpha.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ http = "0.1.15"
 hyper = "0.12.22"
 hyper-old-types = { version = "0.11", optional = true, features = ["compat"] }
 hyper-tls = { version = "0.3", optional = true }
-flate2 = { git = "https://github.com/quininer/flate2-rs", branch = "fix-old", default-features = false, features = ["rust_backend"] }
+flate2 = { version = "^1.0.7", default-features = false, features = ["rust_backend"] }
 log = "0.4"
 mime = "0.3.7"
 mime_guess = "2.0.0-alpha.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ http = "0.1.15"
 hyper = "0.12.22"
 hyper-old-types = { version = "0.11", optional = true, features = ["compat"] }
 hyper-tls = { version = "0.3", optional = true }
-libflate = "0.1.18"
+flate2 = { git = "https://github.com/alexcrichton/flate2-rs", features = ["rust_backend"] }
 log = "0.4"
 mime = "0.3.7"
 mime_guess = "2.0.0-alpha.6"
@@ -44,6 +44,7 @@ rustls = { version = "0.15", features = ["dangerous_configuration"], optional = 
 env_logger = "0.6"
 serde_derive = "1.0"
 tokio-tcp = "0.1"
+libflate = "0.1"
 
 [features]
 default = ["default-tls"]

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -14,21 +14,15 @@ This module consists of a few main types:
 
 - `ReadableChunks` is a `Read`-like wrapper around a stream
 - `Decoder` is a layer over `ReadableChunks` that applies the right decompression
-
-The following types directly support the gzip compression case:
-
-- `Pending` is a non-blocking constructor for a `Decoder` in case the body needs to be checked for EOF
-- `Peeked` is a buffer that keeps a few bytes available so `libflate`s `read_exact` calls won't fail
 */
 
 use std::fmt;
-use std::mem;
 use std::cmp;
 use std::io::{self, Read};
 
 use bytes::{Buf, BufMut, BytesMut};
-use libflate::non_blocking::gzip;
-use futures::{Async, Future, Poll, Stream};
+use flate2::read::GzDecoder;
+use futures::{Async, Poll, Stream};
 use hyper::{HeaderMap};
 use hyper::header::{CONTENT_ENCODING, CONTENT_LENGTH, TRANSFER_ENCODING};
 
@@ -38,7 +32,7 @@ use error;
 const INIT_BUFFER_SIZE: usize = 8192;
 
 /// A response decompressor over a non-blocking stream of chunks.
-/// 
+///
 /// The inner decoder may be constructed asynchronously.
 pub struct Decoder {
     inner: Inner
@@ -49,19 +43,12 @@ enum Inner {
     PlainText(Body),
     /// A `Gzip` decoder will uncompress the gzipped response content before returning it.
     Gzip(Gzip),
-    /// A decoder that doesn't have a value yet.
-    Pending(Pending)
 }
 
-/// A future attempt to poll the response body for EOF so we know whether to use gzip or not.
-struct Pending {
-    body: ReadableChunks<Body>,
-}
-
-/// A gzip decoder that reads from a `libflate::gzip::Decoder` into a `BytesMut` and emits the results
+/// A gzip decoder that reads from a `flate2::read::GzDecoder` into a `BytesMut` and emits the results
 /// as a `Chunk`.
 struct Gzip {
-    inner: Box<gzip::Decoder<Peeked<ReadableChunks<Body>>>>,
+    inner: Box<GzDecoder<ReadableChunks<Body>>>,
     buf: BytesMut,
 }
 
@@ -74,7 +61,7 @@ impl fmt::Debug for Decoder {
 
 impl Decoder {
     /// An empty decoder.
-    /// 
+    ///
     /// This decoder will produce a single 0 byte chunk.
     #[inline]
     pub fn empty() -> Decoder {
@@ -84,7 +71,7 @@ impl Decoder {
     }
 
     /// A plain text decoder.
-    /// 
+    ///
     /// This decoder will emit the underlying chunks as-is.
     #[inline]
     fn plain_text(body: Body) -> Decoder {
@@ -94,12 +81,12 @@ impl Decoder {
     }
 
     /// A gzip decoder.
-    /// 
+    ///
     /// This decoder will buffer and decompress chunks that are gzipped.
     #[inline]
     fn gzip(body: Body) -> Decoder {
         Decoder {
-            inner: Inner::Pending(Pending { body: ReadableChunks::new(body) })
+            inner: Inner::Gzip(Gzip::new(ReadableChunks::new(body)))
         }
     }
 
@@ -158,42 +145,9 @@ impl Stream for Decoder {
     type Error = error::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        // Do a read or poll for a pendidng decoder value.
-        let new_value = match self.inner {
-            Inner::Pending(ref mut future) => {
-                match future.poll() {
-                    Ok(Async::Ready(inner)) => inner,
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    Err(e) => return Err(e)
-                }
-            },
-            Inner::PlainText(ref mut body) => return body.poll(),
-            Inner::Gzip(ref mut decoder) => return decoder.poll()
-        };
-
-        self.inner = new_value;
-        self.poll()
-    }
-}
-
-impl Future for Pending {
-    type Item = Inner;
-    type Error = error::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let body_state = match self.body.poll_stream() {
-            Ok(Async::Ready(state)) => state,
-            Ok(Async::NotReady) => return Ok(Async::NotReady),
-            Err(e) => return Err(e)
-        };
-
-        let body = mem::replace(&mut self.body, ReadableChunks::new(Body::empty()));
-        // libflate does a read_exact([0; 2]), so its impossible to tell
-        // if the stream was empty, or truly had an UnexpectedEof.
-        // Therefore, we need to check for EOF first.
-        match body_state {
-            StreamState::Eof => Ok(Async::Ready(Inner::PlainText(Body::empty()))),
-            StreamState::HasMore => Ok(Async::Ready(Inner::Gzip(Gzip::new(body))))
+        match self.inner {
+            Inner::PlainText(ref mut body) => body.poll(),
+            Inner::Gzip(ref mut decoder) => decoder.poll()
         }
     }
 }
@@ -202,7 +156,7 @@ impl Gzip {
     fn new(stream: ReadableChunks<Body>) -> Self {
         Gzip {
             buf: BytesMut::with_capacity(INIT_BUFFER_SIZE),
-            inner: Box::new(gzip::Decoder::new(Peeked::new(stream))),
+            inner: Box::new(GzDecoder::new(stream)),
         }
     }
 }
@@ -217,10 +171,10 @@ impl Stream for Gzip {
         }
 
         // The buffer contains uninitialised memory so getting a readable slice is unsafe.
-        // We trust the `libflate` writer not to read from the memory given.
-        // 
-        // To be safe, this memory could be zeroed before passing to `libflate`.
-        // Otherwise we might need to deal with the case where `libflate` panics.
+        // We trust the `flate2` and `miniz` writer not to read from the memory given.
+        //
+        // To be safe, this memory could be zeroed before passing to `flate2`.
+        // Otherwise we might need to deal with the case where `flate2` panics.
         let read = {
             let mut buf = unsafe { self.buf.bytes_mut() };
             self.inner.read(&mut buf)
@@ -264,84 +218,6 @@ enum StreamState {
     HasMore,
     /// No more bytes can be read from the stream.
     Eof
-}
-
-/// A buffering reader that ensures `Read`s return at least a few bytes.
-struct Peeked<R> {
-    state: PeekedState,
-    peeked_buf: [u8; 2],
-    pos: usize,
-    inner: R,
-}
-
-enum PeekedState {
-    /// The internal buffer hasn't filled yet.
-    NotReady,
-    /// The internal buffer can be read.
-    Ready(usize)
-}
-
-impl<R> Peeked<R> {
-    #[inline]
-    fn new(inner: R) -> Self {
-        Peeked {
-            state: PeekedState::NotReady,
-            peeked_buf: [0; 2],
-            inner: inner,
-            pos: 0,
-        }
-    }
-
-    #[inline]
-    fn ready(&mut self) {
-        self.state = PeekedState::Ready(self.pos);
-        self.pos = 0;
-    }
-
-    #[inline]
-    fn not_ready(&mut self) {
-        self.state = PeekedState::NotReady;
-        self.pos = 0;
-    }
-}
-
-impl<R: Read> Read for Peeked<R> {
-    #[inline]
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        loop {
-            match self.state {
-                PeekedState::Ready(peeked_buf_len) => {
-                    let len = cmp::min(buf.len(), peeked_buf_len - self.pos);
-                    let start = self.pos;
-                    let end = self.pos + len;
-
-                    buf[..len].copy_from_slice(&self.peeked_buf[start..end]);
-                    self.pos += len;
-                    if self.pos == peeked_buf_len {
-                        self.not_ready();
-                    }
-
-                    return Ok(len)
-                },
-                PeekedState::NotReady => {
-                    let read = self.inner.read(&mut self.peeked_buf[self.pos..]);
-
-                    match read {
-                        Ok(0) => {
-                            self.ready();
-                        },
-                        Ok(read) => {
-                            self.pos += read;
-                            if self.pos == self.peeked_buf.len() {
-                                self.ready();
-                            }
-                        },
-                        Err(e) => return Err(e)
-                    }
-                }
-            };
-        }
-    }
 }
 
 impl<S> ReadableChunks<S> {
@@ -402,11 +278,11 @@ where
     }
 }
 
-impl<S> ReadableChunks<S> 
+impl<S> ReadableChunks<S>
     where S: Stream<Item = Chunk, Error = error::Error>
 {
     /// Poll the readiness of the inner reader.
-    /// 
+    ///
     /// This function will update the internal state and return a simplified
     /// version of the `ReadState`.
     fn poll_stream(&mut self) -> Poll<StreamState, error::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub extern crate hyper_old_types as hyper_011;
 extern crate hyper_tls;
 #[macro_use]
 extern crate log;
-extern crate libflate;
+extern crate flate2;
 extern crate mime;
 extern crate mime_guess;
 #[cfg(feature = "default-tls")]

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -75,9 +75,9 @@ fn test_gzip_empty_body() {
         .unwrap();
 
     let mut body = ::std::string::String::new();
-    res.read_to_string(&mut body).unwrap();
+    let err = res.read_to_string(&mut body).unwrap_err();
 
-    assert_eq!(body, "");
+    assert_eq!(::std::io::ErrorKind::UnexpectedEof, err.kind());
 }
 
 #[test]

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -75,9 +75,9 @@ fn test_gzip_empty_body() {
         .unwrap();
 
     let mut body = ::std::string::String::new();
-    let err = res.read_to_string(&mut body).unwrap_err();
+    res.read_to_string(&mut body).unwrap();
 
-    assert_eq!(::std::io::ErrorKind::UnexpectedEof, err.kind());
+    assert_eq!(body, "");
 }
 
 #[test]


### PR DESCRIPTION
`flate2` now supports [gzip nonblocking decode](https://github.com/alexcrichton/flate2-rs/pull/185). 

This PR removes some Hacks, and there are some improvements in performance.

```
    Running target/release/deps/gzip-bf12b85379c041af
flate2                  time:   [54.453 us 54.718 us 55.025 us]
                        change: [+6.9623% +8.3377% +9.5093%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

libflate                time:   [96.230 us 97.628 us 99.244 us]
                        change: [+1.1208% +3.6339% +6.4683%] (p = 0.01 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

libflate-nonblocking    time:   [162.50 us 163.17 us 163.92 us]
                        change: [-8.1219% -6.6838% -5.2822%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe

libflate-nonblocking-peeked
                        time:   [180.34 us 181.06 us 181.87 us]
                        change: [-8.5667% -7.7753% -6.9742%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

libflate-peeked         time:   [126.75 us 127.74 us 129.08 us]
                        change: [-9.8191% -9.0841% -8.3352%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```