### PR TITLE
Disable Nagle's algorithm for TLS handshake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ futures = "0.1.23"
 http = "0.1.15"
 hyper = "0.12.22"
 hyper-old-types = { version = "0.11", optional = true, features = ["compat"] }
-hyper-tls = { version = "0.3", optional = true }
 flate2 = { version = "^1.0.7", default-features = false, features = ["rust_backend"] }
+hyper-tls = { version = "0.3.2", optional = true }
 log = "0.4"
 mime = "0.3.7"
 mime_guess = "2.0.0-alpha.6"

--- a/src/client.rs
+++ b/src/client.rs
@@ -84,6 +84,11 @@ impl ClientBuilder {
         })
     }
 
+    /// Set that all sockets have `SO_NODELAY` set to `true`.
+    pub fn tcp_nodelay(self) -> ClientBuilder {
+        self.with_inner(move |inner| inner.tcp_nodelay())
+    }
+
     /// Use native TLS backend.
     #[cfg(feature = "default-tls")]
     pub fn use_default_tls(self) -> ClientBuilder {


### PR DESCRIPTION
Nagle's algorithm will have a negative impact on TLS handshake. This is mentioned in [documentation in openssl](https://www.openssl.org/docs/man1.1.1/man3/SSL_connect.html#NOTES).

I keep `nodelay` open for h2 based on [the advice of faq](https://http2.github.io/faq/#will-i-need-tcp_nodelay-for-my-http2-connections).

By the way, this PR uses a different `ClientConfig` for proxy, fixing [previous issue](https://github.com/seanmonstar/reqwest/pull/466#issuecomment-469935821).