### PR TITLE
Remove trailing '?' on empty query.

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -519,6 +519,22 @@ mod tests {
         assert_eq!(foo[1], "baz");
     }
 
+    #[test]
+    fn normalize_empty_query() {
+        let client = Client::new();
+        let some_url = "https://google.com/";
+        let empty_query: &[(&str, &str)] = &[];
+
+        let req = client
+            .get(some_url)
+            .query(empty_query)
+            .build()
+            .expect("request build");
+
+        assert_eq!(req.url().query(), None);
+        assert_eq!(req.url().as_str(), "https://google.com/");
+    }
+
     /*
     use {body, Method};
     use super::Client;

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -268,13 +268,7 @@ impl RequestBuilder {
             }
         }
         if let Ok(ref mut req) = self.request {
-            let mut remove_query = false;
-            if let Some(ref q) = req.url().query() {
-                if q.is_empty() {
-                    remove_query = true;
-                }
-            }
-            if remove_query {
+            if let Some("") = req.url().query() {
                 req.url_mut().set_query(None);
             }
         }

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -267,6 +267,17 @@ impl RequestBuilder {
                 error = Some(::error::from(err));
             }
         }
+        if let Ok(ref mut req) = self.request {
+            let mut remove_query = false;
+            if let Some(ref q) = req.url().query() {
+                if q.is_empty() {
+                    remove_query = true;
+                }
+            }
+            if remove_query {
+                req.url_mut().set_query(None);
+            }
+        }
         if let Some(err) = error {
             self.request = Err(err);
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -354,13 +354,7 @@ impl RequestBuilder {
             }
         }
         if let Ok(ref mut req) = self.request {
-            let mut remove_query = false;
-            if let Some(ref q) = req.url().query() {
-                if q.is_empty() {
-                    remove_query = true;
-                }
-            }
-            if remove_query {
+            if let Some("") = req.url().query() {
                 req.url_mut().set_query(None);
             }
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -353,6 +353,17 @@ impl RequestBuilder {
                 error = Some(::error::from(err));
             }
         }
+        if let Ok(ref mut req) = self.request {
+            let mut remove_query = false;
+            if let Some(ref q) = req.url().query() {
+                if q.is_empty() {
+                    remove_query = true;
+                }
+            }
+            if remove_query {
+                req.url_mut().set_query(None);
+            }
+        }
         if let Some(err) = error {
             self.request = Err(err);
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -842,4 +842,20 @@ mod tests {
         assert_eq!(foo[0], "bar");
         assert_eq!(foo[1], "baz");
     }
+
+    #[test]
+    fn normalize_empty_query() {
+        let client = Client::new();
+        let some_url = "https://google.com/";
+        let empty_query: &[(&str, &str)] = &[];
+
+        let req = client
+            .get(some_url)
+            .query(empty_query)
+            .build()
+            .expect("request build");
+
+        assert_eq!(req.url().query(), None);
+        assert_eq!(req.url().as_str(), "https://google.com/");
+    }
 }


### PR DESCRIPTION
Closes #464 

Following a suggestion proposed on rust-url applied into reqwest side.


One shorter but maybe less idiomatic solution is: 
```rust
// the query is not borrowed so it can be mutated inside the if let.
if let Some("") = req.url().query() {
    req.url_mut().set_query(None);
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seanmonstar/reqwest/506)
<!-- Reviewable:end -->
