### PR TITLE
Allow User to Specify a Default Encoding when reading Http Response

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -250,6 +250,10 @@ impl Response {
     /// This consumes the body. Trying to read more, or use of `response.json()`
     /// will return empty values.
     pub fn text(&mut self) -> ::Result<String> {
+        self.text_with_charset(UTF_8)
+    }
+
+    pub fn text_with_charset(&mut self, &'static enc) -> ::Result<String> {
         let len = self.content_length.unwrap_or(0);
         let mut content = Vec::with_capacity(len as usize);
         self.read_to_end(&mut content).map_err(::error::from)?;
@@ -267,8 +271,8 @@ impl Response {
                     .get_param("charset")
                     .map(|charset| charset.as_str())
             })
-            .unwrap_or("utf-8");
-        let encoding = Encoding::for_label(encoding_name.as_bytes()).unwrap_or(UTF_8);
+            .unwrap_or(enc.name);
+        let encoding = Encoding::for_label(encoding_name.as_bytes()).unwrap_or(enc);
         // a block because of borrow checker
         {
             let (text, _, _) = encoding.decode(&content);


### PR DESCRIPTION
Add a function `text_with_charset` which allows the user to provide a default charset encoding. Currently it is defaulted to `UTF_8` and there's no way for us to use a different charset if the encoding, or `CONTENT_TYPE`, is not presented in the http header. Therefore I want to add this function so that we can at least specify the default encoding. The behavior of this still prefers the provided `charset` inside the http header over the provided default encoding.

This does solve my own problem of not being able to read a response from a website that's in `BIG5` encoding which also don't mention that inside the response header. The way I call the function is

``` rust
// ...
res.text_with_charset("big5")
```

p.s. This is almost the first time I submit a pull request so if there's anything I did inappropriately please definitely tell me.

