### PR TITLE
Add doc-comment to test README examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ env_logger = "0.6"
 serde_derive = "1.0"
 tokio-tcp = "0.1"
 libflate = "0.1"
+doc-comment = "0.3"
 
 [features]
 default = ["default-tls"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An ergonomic, batteries-included HTTP Client for Rust.
 
 ## Example
 
-```rust
+```rust,no_run
 extern crate reqwest;
 
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,12 @@ extern crate tokio_rustls;
 extern crate webpki_roots;
 #[cfg(feature = "rustls-tls")]
 extern crate rustls;
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
 
 pub use hyper::header;
 pub use hyper::Method;


### PR DESCRIPTION
Allows to keep in check the README file examples.