### PR TITLE
Update cookie 0.12 and cookie_store 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ socks = { version = "0.3.2", optional = true }
 tokio-rustls = { version = "0.9", optional = true }
 trust-dns-resolver = { version = "0.11", optional = true }
 webpki-roots = { version = "0.16", optional = true }
-cookie_store = "0.6.0"
+cookie_store = "0.7.0"
 cookie = "0.12.0"
 time = "0.1.42"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ socks = { version = "0.3.2", optional = true }
 tokio-rustls = { version = "0.9", optional = true }
 trust-dns-resolver = { version = "0.11", optional = true }
 webpki-roots = { version = "0.16", optional = true }
-cookie_store = "0.5.1"
-cookie = "0.11.0"
+cookie_store = "0.6.0"
+cookie = "0.12.0"
 time = "0.1.42"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes cookie compile error (#517) by only using `ring` 0.14 instead of mix of 0.13 & 0.14.