### PR TITLE
WIP: Cookie storage session

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ webpki-roots = { version = "0.16", optional = true }
 cookie_store = "0.7.0"
 cookie = "0.12.0"
 time = "0.1.42"
+downcast = "0.10.0"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/src/async_impl/cookie.rs
+++ b/src/async_impl/cookie.rs
@@ -1,0 +1,6 @@
+// FIXME: should this even be an option? the idea of running a session async seems a little iffy
+use std::sync::{Arc, RwLock};
+use std::marker::PhantomData;
+
+use cookie::CookieStorage;
+define_session!(super::Client, super::ClientBuilder, super::ClientBuilder::new());

--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -1,10 +1,12 @@
 pub use self::body::{Body, Chunk};
+pub use self::cookie::Session;
 pub use self::decoder::{Decoder, ReadableChunks};
 pub use self::client::{Client, ClientBuilder};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::{Response, ResponseBuilderExt};
 
 pub mod body;
+pub mod cookie;
 pub mod client;
 pub mod decoder;
 pub mod multipart;

--- a/src/client.rs
+++ b/src/client.rs
@@ -367,14 +367,14 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.local_address(addr))
     }
 
-    /// Enable a persistent cookie store for the client.
-    /// 
-    /// Cookies received in responses will be preserved and included in 
+    /// Set a persistent cookie store for the client.
+    ///
+    /// Cookies received in responses will be preserved and included in
     /// additional requests.
-    /// 
+    ///
     /// By default, no cookie store is used.
-    pub fn cookie_store(self, enable: bool) -> ClientBuilder {
-        self.with_inner(|inner| inner.cookie_store(enable))
+    pub fn cookie_store(self, cookie_store: cookie_store::CookieStore) -> ClientBuilder {
+        self.with_inner(|inner| inner.cookie_store(cookie_store))
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::thread;
 use std::net::IpAddr;
@@ -8,6 +8,7 @@ use futures::{Async, Future, Stream};
 use futures::future::{self, Either};
 use futures::sync::{mpsc, oneshot};
 
+use cookie::CookieStorage;
 use request::{Request, RequestBuilder};
 use response::Response;
 use {async_impl, header, Method, IntoUrl, Proxy, RedirectPolicy, wait};
@@ -367,13 +368,13 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.local_address(addr))
     }
 
-    /// Set a persistent cookie store for the client.
+    /// Set a persistent cookie store for the client. Used internally by `Session`.
     ///
     /// Cookies received in responses will be preserved and included in
     /// additional requests.
     ///
     /// By default, no cookie store is used.
-    pub fn cookie_store(self, cookie_store: cookie_store::CookieStore) -> ClientBuilder {
+    pub(crate) fn cookie_store(self, cookie_store: Arc<RwLock<Box<CookieStorage>>>) -> ClientBuilder {
         self.with_inner(|inner| inner.cookie_store(cookie_store))
     }
 }

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -149,6 +149,18 @@ impl<'a, R : CookieStorageReader> CookieStorageReader for &'a R {
     }
 }
 
+impl CookieStorageWriter for cookie_store::CookieStore {
+    fn store_response_cookies(&mut self, cookies: impl Iterator<Item = cookie_crate::Cookie<'static>>, url: &url::Url) {
+        self.store_response_cookies(cookies, url);
+    }
+}
+impl CookieStorageReader for cookie_store::CookieStore {
+    fn get_request_cookies(&self, url: &url::Url) -> Vec<&cookie_crate::Cookie<'static>> {
+        self.get_request_cookies(url).collect::<Vec<_>>()
+    }
+}
+impl CookieStorage for cookie_store::CookieStore { }
+
 
 /// A persistent cookie store that provides session support.
 #[derive(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#![deny(missing_docs)]
+// FIXME: this is disabled due to the macro generated code
+//#![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/reqwest/0.9.16")]
@@ -176,6 +177,8 @@ extern crate base64;
 extern crate bytes;
 extern crate cookie as cookie_crate;
 extern crate cookie_store;
+#[macro_use]
+extern crate downcast;
 extern crate encoding_rs;
 #[macro_use]
 extern crate futures;
@@ -247,11 +250,14 @@ pub use self::tls::{Certificate, Identity};
 #[macro_use]
 mod error;
 
+// must be prior to async_impl for define_session macro
+#[macro_use]
+pub mod cookie;
+
 mod async_impl;
 mod connect;
 mod body;
 mod client;
-pub mod cookie;
 #[cfg(feature = "trust-dns")]
 mod dns;
 mod into_url;
@@ -279,6 +285,9 @@ pub mod async {
         ResponseBuilderExt,
         multipart
     };
+    pub mod cookie {
+        pub use ::async_impl::cookie::Session;
+    }
 }
 
 /// Shortcut method to quickly make a `GET` request.

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -391,7 +391,7 @@ fn test_invalid_location_stops_redirect_gh484() {
 #[test]
 fn test_redirect_302_with_set_cookies() {
     let code = 302;
-    let client = reqwest::ClientBuilder::new().cookie_store(true).build().unwrap();
+    let client = reqwest::ClientBuilder::new().cookie_store(cookie_store::CookieStore::default()).build().unwrap();
     let server = server! {
             request: format!("\
                 GET /{} HTTP/1.1\r\n\

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -391,7 +391,7 @@ fn test_invalid_location_stops_redirect_gh484() {
 #[test]
 fn test_redirect_302_with_set_cookies() {
     let code = 302;
-    let client = reqwest::ClientBuilder::new().cookie_store(cookie_store::CookieStore::default()).build().unwrap();
+    let session = reqwest::cookie::Session::new(cookie_store::CookieStore::default()).unwrap();
     let server = server! {
             request: format!("\
                 GET /{} HTTP/1.1\r\n\
@@ -432,7 +432,7 @@ fn test_redirect_302_with_set_cookies() {
 
     let url = format!("http://{}/{}", server.addr(), code);
     let dst = format!("http://{}/{}", server.addr(), "dst");
-    let res = client.get(&url)
+    let res = session.get(&url)
         .send()
         .unwrap();
 


### PR DESCRIPTION
With `cookie_store` support landed in `reqwest`, I'd like to retire `user_agent` which has some shortcomings due to being externally implemented. For my needs, the current support in `reqwest` for `cookie_store` is only lacking being able to provide an initial cookie storage and being able to retrieve the cookie storage at the end of a session.

I implemented a couple of different ideas to this end; this PR is the approach that seemed cleanest to me.

# Approach
We introduce a simple trait `CookieStorage` which represents the actions `reqwest` needs for cookie storage, storing and retrieving cookies. We then introduce `cookie::Session`, which simply holds an instance implementing `CookieStorage` for use for the duration of a set of requests. The idea of the usage being:
* Initialize a session with a `CookieStorage` implementer, (`cookie_store::CookieStore::default()`, loaded from disk, etc.). `Session::new(cookie_store)` mimics `Client::new()` in that the session will contain a default `Client`. `Session::from_builder(cookie_store, client_builder)` may be used to specify `Client` configuration.
* `Session` provides a `Deref<Target = Client>` implementation, so it can be used as a stand in for `Client`.
* During a series of requests, the storage may be manipulated via `session.modify_cookie_store(|cookie_store| { ... })`. The `cookie_store` here is a `& mut` to the concrete implementation provided at `Session` creation.
* At the end of a series of requests, the concrete implementer may be retrieved via `session.end(self)`, allowing the user to serialize the final state, etc.

To implement the above, the `Session` holds an `Arc<RwLock<Box<dyn CookieStorage>>>` alongside the `Client` instance. To provide access to and recover the original concrete type, the `downcast` crate is pulled in as a new dependency.

# FIXMEs/TODOs
There are a handful of un-addressed issues:
* `CookieStorage` is defined here directly in `reqwest`, along with the `impl` for `cookie_store::CookieStore`. It could instead be provided as a separate crate, and `cookie_store` could implement it for `CookieStore`; this would allow `reqwest` to remove the dependency on the `cookie_store` crate in lieu of some minimal `cookie_storage` crate defining the trait.
* This implementation is a breaking change w.r.t. the API added when `CookieStore` was initially added; we could choose to implement this as a non-breaking change.
    * The `cookie_store` fn is now marked `pub(crate)` to prevent external usage and hide implementation details such as the `Arc<RwLock<...>>` of the new API.
* For the `downcast` crate, the code generated by the `downcast!` macro call does not include documentation, so causes a failure of the `deny(missing_docs)` directive. This PR disables this check for now; I am not sure what the elegant way to deal with this, perhaps there is a simple workaround. We could implement by hand the functionality of `downcast`, avoiding this issue as well as the new dependency. 
* This implements both `reqwest::cookie::Session` and `reqwest::async::cookie::Session`. I am not sure it's a benefit to provide an `async` version of a `Session`; it may be non-obvious to e.g. attempt to `modify_cookie_store()` when requests are in flight, etc.
* Also implemented is a fn `Session::replace_cookie_store()`. I am inclined to drop this functionality, especially if `async` support is retained. It seems like niche usage, and would be better to encourage users to `end()` their current session and start a new one.

# Alternatives
* An initial implementation is present in [this branch](https://github.com/pfernie/reqwest/tree/set-cookie-store), which simply exposes `cookie_store::CookieStore` directly. However, per prior discussion, a goal is to avoid exposing this in `reqwest` public API.
* Another approach using the `CookieStorage` trait is [this branch](https://github.com/pfernie/reqwest/tree/cookie-storage-generic-type), which instead opts to implement it via a generic type. This avoids introducing the `downcast` dependency and type casting shenanigans, but ends up needing to thread the generic parameter through many types (`Client`, `ClientBuilder`, `Request`, etc.). The implementation works, but IMO clutters the API/typescape.