### PR TITLE
Fix cookie header

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -27,6 +27,7 @@ use mime;
 #[cfg(feature = "default-tls")]
 use native_tls::TlsConnector;
 use tokio::{clock, timer::Delay};
+use url::percent_encoding::{percent_encode, USERINFO_ENCODE_SET};
 
 
 use super::request::{Request, RequestBuilder};
@@ -877,7 +878,11 @@ fn add_cookie_header(headers: &mut HeaderMap, cookie_store: &cookie::CookieStore
     let header = cookie_store
         .0
         .get_request_cookies(url)
-        .map(|c| c.encoded().to_string())
+        .map(|c| {
+            let name = percent_encode(c.name().as_bytes(), USERINFO_ENCODE_SET);
+            let value = percent_encode(c.value().as_bytes(), USERINFO_ENCODE_SET);
+            format!("{}={}", name, value)
+        })
         .collect::<Vec<_>>()
         .join("; ");
     if !header.is_empty() {

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -94,7 +94,7 @@ fn cookie_store_simple() {
             ",
         response: b"\
             HTTP/1.1 200 OK\r\n\
-            Set-Cookie: key=val\r\n\
+            Set-Cookie: key=val; HttpOnly\r\n\
             Content-Length: 0\r\n\
             \r\n\
             "


### PR DESCRIPTION
I found reqwest adds 'Secure' and HttpOnly' to 'Cookie' header while it must be simple key-value pairs. It seems the use of `Cookie::encoded()` is improper here.

To fix this, I just imitated `impl Display for EncodedCookie`.