### PR TITLE
Fix the AppVeyor build failure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,11 +3,14 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
   - TARGET: x86_64-pc-windows-gnu
+    MINGW_PATH: 'C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin'
   - TARGET: i686-pc-windows-gnu
+    MINGW_PATH: 'C:\MinGW\bin'
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
   - rustup-init.exe -y --default-host %TARGET%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - if defined MINGW_PATH set PATH=%PATH%;%MINGW_PATH%
   - rustc -vV
   - cargo -vV
 build: false


### PR DESCRIPTION
Fixed the AppVeyor build failure due to the backtrace-sys being added to the dependency.

```
error: failed to run custom build command for `backtrace-sys v0.1.28`
process didn't exit successfully: `C:\projects\reqwest\target\debug\build\backtrace-sys-51a850b72a6add66\build-script-build` (exit code: 1)
--- stdout
cargo:rustc-cfg=rbt
TARGET = Some("x86_64-pc-windows-gnu")
OPT_LEVEL = Some("0")
HOST = Some("x86_64-pc-windows-gnu")
CC_x86_64-pc-windows-gnu = None
CC_x86_64_pc_windows_gnu = None
HOST_CC = None
CC = None
CFLAGS_x86_64-pc-windows-gnu = None
CFLAGS_x86_64_pc_windows_gnu = None
HOST_CFLAGS = None
CFLAGS = None
CRATE_CC_NO_DEFAULTS = None
CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
running: "gcc.exe" "-O0" "-ffunction-sections" "-fdata-sections" "-m64" "-I" "src/libbacktrace" "-I" "C:\\projects\\reqwest\\target\\debug\\build\\backtrace-sys-8dafb3eefc924f8e\\out" "-fvisibility=hidden" "-DBACKTRACE_SUPPORTED=1" "-DBACKTRACE_USES_MALLOC=1" "-DBACKTRACE_SUPPORTS_THREADS=0" "-DBACKTRACE_SUPPORTS_DATA=0" "-DHAVE_DL_ITERATE_PHDR=1" "-D_GNU_SOURCE=1" "-D_LARGE_FILES=1" "-Dbacktrace_full=__rbt_backtrace_full" "-Dbacktrace_dwarf_add=__rbt_backtrace_dwarf_add" "-Dbacktrace_initialize=__rbt_backtrace_initialize" "-Dbacktrace_pcinfo=__rbt_backtrace_pcinfo" "-Dbacktrace_syminfo=__rbt_backtrace_syminfo" "-Dbacktrace_get_view=__rbt_backtrace_get_view" "-Dbacktrace_release_view=__rbt_backtrace_release_view" "-Dbacktrace_alloc=__rbt_backtrace_alloc" "-Dbacktrace_free=__rbt_backtrace_free" "-Dbacktrace_vector_finish=__rbt_backtrace_vector_finish" "-Dbacktrace_vector_grow=__rbt_backtrace_vector_grow" "-Dbacktrace_vector_release=__rbt_backtrace_vector_release" "-Dbacktrace_close=__rbt_backtrace_close" "-Dbacktrace_open=__rbt_backtrace_open" "-Dbacktrace_print=__rbt_backtrace_print" "-Dbacktrace_simple=__rbt_backtrace_simple" "-Dbacktrace_qsort=__rbt_backtrace_qsort" "-Dbacktrace_create_state=__rbt_backtrace_create_state" "-Dbacktrace_uncompress_zdebug=__rbt_backtrace_uncompress_zdebug" "-o" "C:\\projects\\reqwest\\target\\debug\\build\\backtrace-sys-8dafb3eefc924f8e\\out\\src/libbacktrace\\alloc.o" "-c" "src/libbacktrace/alloc.c"
--- stderr
error occurred: Failed to find tool. Is `gcc.exe` installed? (see https://github.com/alexcrichton/cc-rs#compile-time-requirements for help)
warning: build failed, waiting for other jobs to finish...
error: build failed
Command exited with code 101
```

The build failed because gcc.exe was not found, so we added MinGW's PATH with gcc.exe etc.