### PR TITLE
Re-enable Android CI target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,16 @@ matrix:
           env: FEATURES="--features trust-dns"
 
         # android
-        #- rust: stable
-        #  env: TARGET=aarch64-linux-android
-        #  install: rustup target add "$TARGET"
-        #  # disable default-tls feature since cross-compiling openssl is dragons
-        #  script: cargo build --target "$TARGET" --no-default-features
+        - rust: stable
+          env: TARGET=aarch64-linux-android
+          before_install:
+            - wget https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip;
+            - unzip -qq android-ndk*.zip;
+            - android-ndk*/build/tools/make_standalone_toolchain.py --arch arm64 --api 21 --install-dir /tmp/android-toolchain;
+            - export PATH=/tmp/android-toolchain/bin:$PATH;
+          install: rustup target add "$TARGET"
+          # disable default-tls feature since cross-compiling openssl is dragons
+          script: cargo build --target "$TARGET" --no-default-features
 
         # minimum version
         - rust: 1.31.0


### PR DESCRIPTION
Closes https://github.com/seanmonstar/reqwest/issues/489

Since the backtrace-sys install script requires clang for Android, I installed the build tool included with Android NDK with before_install.

```
error: failed to run custom build command for `backtrace-sys v0.1.28`
process didn't exit successfully: `/home/travis/build/seanmonstar/reqwest/target/debug/build/backtrace-sys-6f4a22bc8c9361d1/build-script-build` (exit code: 1)
--- stdout
cargo:rustc-cfg=rbt
TARGET = Some("aarch64-linux-android")
OPT_LEVEL = Some("0")
HOST = Some("x86_64-unknown-linux-gnu")
CC_aarch64-linux-android = None
CC_aarch64_linux_android = None
TARGET_CC = None
CC = None
CFLAGS_aarch64-linux-android = None
CFLAGS_aarch64_linux_android = None
TARGET_CFLAGS = None
CFLAGS = None
CRATE_CC_NO_DEFAULTS = None
running: "aarch64-linux-android-clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=aarch64-linux-android" "-I" "src/libbacktrace" "-I" "/home/travis/build/seanmonstar/reqwest/target/aarch64-linux-android/debug/build/backtrace-sys-cb0f45663eb5b644/out" "-fvisibility=hidden" "-DBACKTRACE_ELF_SIZE=64" "-DBACKTRACE_SUPPORTED=1" "-DBACKTRACE_USES_MALLOC=1" "-DBACKTRACE_SUPPORTS_THREADS=0" "-DBACKTRACE_SUPPORTS_DATA=0" "-D_GNU_SOURCE=1" "-D_LARGE_FILES=1" "-Dbacktrace_full=__rbt_backtrace_full" "-Dbacktrace_dwarf_add=__rbt_backtrace_dwarf_add" "-Dbacktrace_initialize=__rbt_backtrace_initialize" "-Dbacktrace_pcinfo=__rbt_backtrace_pcinfo" "-Dbacktrace_syminfo=__rbt_backtrace_syminfo" "-Dbacktrace_get_view=__rbt_backtrace_get_view" "-Dbacktrace_release_view=__rbt_backtrace_release_view" "-Dbacktrace_alloc=__rbt_backtrace_alloc" "-Dbacktrace_free=__rbt_backtrace_free" "-Dbacktrace_vector_finish=__rbt_backtrace_vector_finish" "-Dbacktrace_vector_grow=__rbt_backtrace_vector_grow" "-Dbacktrace_vector_release=__rbt_backtrace_vector_release" "-Dbacktrace_close=__rbt_backtrace_close" "-Dbacktrace_open=__rbt_backtrace_open" "-Dbacktrace_print=__rbt_backtrace_print" "-Dbacktrace_simple=__rbt_backtrace_simple" "-Dbacktrace_qsort=__rbt_backtrace_qsort" "-Dbacktrace_create_state=__rbt_backtrace_create_state" "-Dbacktrace_uncompress_zdebug=__rbt_backtrace_uncompress_zdebug" "-o" "/home/travis/build/seanmonstar/reqwest/target/aarch64-linux-android/debug/build/backtrace-sys-cb0f45663eb5b644/out/src/libbacktrace/alloc.o" "-c" "src/libbacktrace/alloc.c"
--- stderr
error occurred: Failed to find tool. Is `aarch64-linux-android-clang` installed?
warning: build failed, waiting for other jobs to finish...
error: build failed
The command "cargo build --target "$TARGET" --no-default-features" exited with 101.
Done. Your build exited with 1.
```