### PR TITLE
Use executor::enter before blocking a thread in wait

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -636,9 +636,12 @@ impl ClientHandle {
         let res = match wait::timeout(fut, self.timeout.0) {
             Ok(res) => res,
             Err(wait::Waited::TimedOut) => return Err(::error::timedout(Some(url))),
-            Err(wait::Waited::Err(err)) => {
+            Err(wait::Waited::Executor(err)) => {
+                return Err(::error::from(err).with_url(url))
+            },
+            Err(wait::Waited::Inner(err)) => {
                 return Err(err.with_url(url));
-            }
+            },
         };
         res.map(|res| {
             Response::new(res, self.timeout.0, KeepCoreThreadAlive(Some(self.inner.clone())))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ extern crate serde_json;
 extern crate serde_urlencoded;
 extern crate time;
 extern crate tokio;
+extern crate tokio_executor;
 #[cfg_attr(feature = "default-tls", macro_use)]
 extern crate tokio_io;
 extern crate tokio_timer;

--- a/src/response.rs
+++ b/src/response.rs
@@ -411,7 +411,8 @@ impl Stream for WaitBody {
             Some(Err(e)) => {
                 let req_err = match e {
                     wait::Waited::TimedOut => ::error::timedout(None),
-                    wait::Waited::Err(e) => e,
+                    wait::Waited::Executor(e) => ::error::from(e),
+                    wait::Waited::Inner(e) => e,
                 };
 
                 Err(req_err)


### PR DESCRIPTION
This should help catch when people use the blocking `Client` inside some other `Future`.