### PR TITLE
Don't set a user-agent header by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Reqwest no longer sets a User-Agent header by default. If you are interacting
+  with services which require a user agent, you will need to set one manually.
+
 ## v0.9.18
 
 - Fix `Cookie` headers to no longer send as percent-encoded (instead, exactly as sent by the server).

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -19,7 +19,6 @@ use header::{
     RANGE,
     REFERER,
     TRANSFER_ENCODING,
-    USER_AGENT,
 };
 use http::Uri;
 use hyper::client::ResponseFuture;
@@ -40,9 +39,6 @@ use {IntoUrl, Method, Proxy, StatusCode, Url};
 use {Certificate, Identity};
 #[cfg(feature = "tls")]
 use ::tls::TlsBackend;
-
-static DEFAULT_USER_AGENT: &'static str =
-    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 /// An asynchronous `Client` to make Requests with.
 ///
@@ -94,7 +90,6 @@ impl ClientBuilder {
     /// This is the same as `Client::builder()`.
     pub fn new() -> ClientBuilder {
         let mut headers: HeaderMap<HeaderValue> = HeaderMap::with_capacity(2);
-        headers.insert(USER_AGENT, HeaderValue::from_static(DEFAULT_USER_AGENT));
         headers.insert(ACCEPT, HeaderValue::from_str(mime::STAR_STAR.as_ref()).expect("unable to parse mime"));
 
         ClientBuilder {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -63,7 +63,6 @@ fn multipart() {
         request: format!("\
             POST /multipart/1 HTTP/1.1\r\n\
             content-type: multipart/form-data; boundary={}\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -105,7 +104,6 @@ fn request_timeout() {
     let server = server! {
         request: b"\
             GET /slow HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -145,7 +143,6 @@ fn response_timeout() {
     let server = server! {
         request: b"\
             GET /slow HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -200,7 +197,6 @@ fn gzip_case(response_size: usize, chunk_size: usize) {
     let server = server! {
         request: b"\
             GET /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -10,7 +10,6 @@ fn test_response_text() {
     let server = server! {
         request: b"\
             GET /text HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -41,7 +40,6 @@ fn test_response_non_utf_8_text() {
     let server = server! {
         request: b"\
             GET /text HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -74,7 +72,6 @@ fn test_response_copy_to() {
     let server = server! {
         request: b"\
             GET /1 HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -106,7 +103,6 @@ fn test_get() {
     let server = server! {
         request: b"\
             GET /1 HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -140,7 +136,6 @@ fn test_post() {
         request: b"\
             POST /2 HTTP/1.1\r\n\
             content-length: 5\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -179,7 +174,6 @@ fn test_post_form() {
             POST /form HTTP/1.1\r\n\
             content-type: application/x-www-form-urlencoded\r\n\
             content-length: 24\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -214,7 +208,6 @@ fn test_error_for_status_4xx() {
     let server = server! {
         request: b"\
             GET /1 HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -243,7 +236,6 @@ fn test_error_for_status_5xx() {
     let server = server! {
         request: b"\
             GET /1 HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -277,7 +269,6 @@ fn test_default_headers() {
     let server = server! {
         request: b"\
             GET /1 HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             cookie: a=b;c=d\r\n\
             accept-encoding: gzip\r\n\
@@ -303,7 +294,6 @@ fn test_default_headers() {
     let server = server! {
         request: b"\
             GET /2 HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             cookie: a=b;c=d\r\n\
             accept-encoding: gzip\r\n\
@@ -340,7 +330,6 @@ fn test_override_default_headers() {
         request: b"\
             GET /3 HTTP/1.1\r\n\
             authorization: secret\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -373,7 +362,6 @@ fn test_appended_headers_not_overwritten() {
             GET /4 HTTP/1.1\r\n\
             accept: application/json\r\n\
             accept: application/json+hal\r\n\
-            user-agent: $USERAGENT\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
             \r\n\
@@ -407,7 +395,6 @@ fn test_appended_headers_not_overwritten() {
             GET /4 HTTP/1.1\r\n\
             accept: application/json\r\n\
             accept: application/json+hal\r\n\
-            user-agent: $USERAGENT\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
             \r\n\

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -11,7 +11,6 @@ fn cookie_response_accessor() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -86,7 +85,6 @@ fn cookie_store_simple() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -105,7 +103,6 @@ fn cookie_store_simple() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             cookie: key=val\r\n\
             accept-encoding: gzip\r\n\
@@ -130,7 +127,6 @@ fn cookie_store_overwrite_existing() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -149,7 +145,6 @@ fn cookie_store_overwrite_existing() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             cookie: key=val\r\n\
             accept-encoding: gzip\r\n\
@@ -169,7 +164,6 @@ fn cookie_store_overwrite_existing() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             cookie: key=val2\r\n\
             accept-encoding: gzip\r\n\
@@ -194,7 +188,6 @@ fn cookie_store_max_age() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -213,7 +206,6 @@ fn cookie_store_max_age() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -237,7 +229,6 @@ fn cookie_store_expires() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -256,7 +247,6 @@ fn cookie_store_expires() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -280,7 +270,6 @@ fn cookie_store_path() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -299,7 +288,6 @@ fn cookie_store_path() {
     let server = server! {
         request: b"\
             GET / HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -317,7 +305,6 @@ fn cookie_store_path() {
     let server = server! {
         request: b"\
             GET /subpath HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             cookie: key=val\r\n\
             accept-encoding: gzip\r\n\

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -31,7 +31,6 @@ fn test_gzip_response() {
     let server = server! {
         request: b"\
             GET /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -54,7 +53,6 @@ fn test_gzip_empty_body() {
     let server = server! {
         request: b"\
             HEAD /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -85,7 +83,6 @@ fn test_gzip_invalid_body() {
     let server = server! {
         request: b"\
             GET /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -114,7 +111,6 @@ fn test_accept_header_is_not_changed_if_set() {
         request: b"\
             GET /accept HTTP/1.1\r\n\
             accept: application/json\r\n\
-            user-agent: $USERAGENT\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
             \r\n\
@@ -143,7 +139,6 @@ fn test_accept_encoding_header_is_not_changed_if_set() {
         request: b"\
             GET /accept-encoding HTTP/1.1\r\n\
             accept-encoding: identity\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             host: $HOST\r\n\
             \r\n\

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -23,7 +23,6 @@ fn text_part() {
             POST /multipart/1 HTTP/1.1\r\n\
             content-type: multipart/form-data; boundary={}\r\n\
             content-length: 125\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -72,7 +71,6 @@ fn file() {
             POST /multipart/2 HTTP/1.1\r\n\
             content-type: multipart/form-data; boundary={}\r\n\
             content-length: {}\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -8,7 +8,6 @@ fn http_proxy() {
     let server = server! {
         request: b"\
             GET http://hyper.rs/prox HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: hyper.rs\r\n\
@@ -43,7 +42,6 @@ fn http_proxy_basic_auth() {
     let server = server! {
         request: b"\
             GET http://hyper.rs/prox HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             proxy-authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\r\n\
@@ -83,7 +81,6 @@ fn http_proxy_basic_auth_parsed() {
     let server = server! {
         request: b"\
             GET http://hyper.rs/prox HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             proxy-authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\r\n\

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -12,7 +12,6 @@ fn test_redirect_301_and_302_and_303_changes_post_to_get() {
         let redirect = server! {
             request: format!("\
                 POST /{} HTTP/1.1\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 host: $HOST\r\n\
@@ -30,7 +29,6 @@ fn test_redirect_301_and_302_and_303_changes_post_to_get() {
 
             request: format!("\
                 GET /dst HTTP/1.1\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 referer: http://$HOST/{}\r\n\
@@ -64,7 +62,6 @@ fn test_redirect_307_and_308_tries_to_get_again() {
         let redirect = server! {
             request: format!("\
                 GET /{} HTTP/1.1\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 host: $HOST\r\n\
@@ -82,7 +79,6 @@ fn test_redirect_307_and_308_tries_to_get_again() {
 
             request: format!("\
                 GET /dst HTTP/1.1\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 referer: http://$HOST/{}\r\n\
@@ -117,7 +113,6 @@ fn test_redirect_307_and_308_tries_to_post_again() {
             request: format!("\
                 POST /{} HTTP/1.1\r\n\
                 content-length: 5\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 host: $HOST\r\n\
@@ -137,7 +132,6 @@ fn test_redirect_307_and_308_tries_to_post_again() {
             request: format!("\
                 POST /dst HTTP/1.1\r\n\
                 content-length: 5\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 referer: http://$HOST/{}\r\n\
@@ -173,7 +167,6 @@ fn test_redirect_307_does_not_try_if_reader_cannot_reset() {
         let redirect = server! {
             request: format!("\
                 POST /{} HTTP/1.1\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 host: $HOST\r\n\
@@ -212,7 +205,6 @@ fn test_redirect_removes_sensitive_headers() {
         request: b"\
             GET /otherhost HTTP/1.1\r\n\
             accept-encoding: gzip\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             host: $HOST\r\n\
             \r\n\
@@ -229,7 +221,6 @@ fn test_redirect_removes_sensitive_headers() {
         request: b"\
             GET /sensitive HTTP/1.1\r\n\
             cookie: foo=bar\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -259,7 +250,6 @@ fn test_redirect_policy_can_return_errors() {
     let server = server! {
         request: b"\
             GET /loop HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -283,7 +273,6 @@ fn test_redirect_policy_can_stop_redirects_without_an_error() {
     let server = server! {
         request: b"\
             GET /no-redirect HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -318,7 +307,6 @@ fn test_referer_is_not_set_if_disabled() {
     let server = server! {
         request: b"\
             GET /no-refer HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -336,7 +324,6 @@ fn test_referer_is_not_set_if_disabled() {
 
         request: b"\
             GET /dst HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -364,7 +351,6 @@ fn test_invalid_location_stops_redirect_gh484() {
     let server = server! {
         request: b"\
             GET /yikes HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -395,7 +381,6 @@ fn test_redirect_302_with_set_cookies() {
     let server = server! {
             request: format!("\
                 GET /{} HTTP/1.1\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 host: $HOST\r\n\
@@ -414,7 +399,6 @@ fn test_redirect_302_with_set_cookies() {
 
             request: format!("\
                 GET /dst HTTP/1.1\r\n\
-                user-agent: $USERAGENT\r\n\
                 accept: */*\r\n\
                 accept-encoding: gzip\r\n\
                 referer: http://$HOST/{}\r\n\

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -40,9 +40,6 @@ pub struct Txn {
     pub chunk_size: Option<usize>,
 }
 
-static DEFAULT_USER_AGENT: &'static str =
-    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
-
 pub fn spawn(txns: Vec<Txn>) -> Server {
     let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
@@ -56,7 +53,7 @@ pub fn spawn(txns: Vec<Txn>) -> Server {
 
             socket.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
 
-            replace_expected_vars(&mut expected, addr.to_string().as_ref(), DEFAULT_USER_AGENT.as_ref());
+            replace_expected_vars(&mut expected, addr.to_string().as_ref());
 
             if let Some(dur) = txn.read_timeout {
                 thread::park_timeout(dur);
@@ -155,7 +152,7 @@ pub fn spawn(txns: Vec<Txn>) -> Server {
     }
 }
 
-fn replace_expected_vars(bytes: &mut Vec<u8>, host: &[u8], ua: &[u8]) {
+fn replace_expected_vars(bytes: &mut Vec<u8>, host: &[u8]) {
     // plenty horrible, but these are just tests, and gets the job done
     let mut index = 0;
     loop {
@@ -175,14 +172,6 @@ fn replace_expected_vars(bytes: &mut Vec<u8>, host: &[u8], ua: &[u8]) {
             bytes.drain(index - 1..index + 4);
             for (i, b) in host.iter().enumerate() {
                 bytes.insert(index - 1 + i, *b);
-            }
-        } else {
-            let has_ua = (&bytes[index..]).starts_with(b"USERAGENT");
-            if has_ua {
-                bytes.drain(index - 1..index + 9);
-                for (i, b) in ua.iter().enumerate() {
-                    bytes.insert(index - 1 + i, *b);
-                }
             }
         }
     }

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -21,7 +21,6 @@ fn timeout_closes_connection() {
     let server = server! {
         request: b"\
             GET /closes HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -63,7 +62,6 @@ fn write_timeout_large_body() {
     let server = server! {
         request: format!("\
             POST /write-timeout HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             content-length: {}\r\n\
             accept-encoding: gzip\r\n\
@@ -100,7 +98,6 @@ fn test_response_timeout() {
     let server = server! {
         request: b"\
             GET /response-timeout HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\
@@ -132,7 +129,6 @@ fn test_read_timeout() {
     let server = server! {
         request: b"\
             GET /read-timeout HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
             accept: */*\r\n\
             accept-encoding: gzip\r\n\
             host: $HOST\r\n\


### PR DESCRIPTION
I'm not entirely sure why this behavior was added to begin with. It was
originally added in 1259128d921499662acdcfbde7096a003ac72017, which only
has "add native-tls and serde json support" as the commit message, so
I'm not even sure if it was intentional or just meant to temporarily
work around some other issue.

Reqwest is not a user agent, and should not identify itself as such. To
give a more concrete example of what I mean, `curl` the CLI tool which
is directly making a request on behalf of a user identifies itself as
such. `libcurl` the library used to programatically make HTTP requests
(e.g. to build a user agent) does not.

Why does this matter? Some services, including GitHub and crates.io
choose to block traffic that does not provide a user agent. Services
which do this typically do so for a reason. Ultimately `reqwest/0.9.18`
is no more useful to someone operating a service than an empty string.
If folks have a legitimate privacy concern with setting one, they can
still set it to "hello" or whatever non-identifying value they want --
but by setting a default user agent, that choice is being made for them,
and they may not even be aware that the service they're hitting is
requesting a unique user agent.

If someone makes a request to crates.io without supplying a user agent
header, they'll receive the following response:

    We require that all requests include a `User-Agent` header.  To allow us to determine the impact your bot has on our service, we ask that your user agent actually identify your bot, and not just report the HTTP client library you're using.  Including contact information will also reduce the chance that we will need to take action against your bot.

    Bad:
      User-Agent: reqwest/0.9.1

    Better:
      User-Agent: my_crawler

    Best:
      User-Agent: my_crawler (my_crawler.com/info)
      User-Agent: my_crawler (help@my_crawler.com)

    If you believe you've received this message in error, please email help@crates.io and include the request id {}.

But if they're using reqwest, they won't get the opportunity to think
about this, I end up blocking their traffic because their request rate
is slightly too high but I have no other way to politely ask them to
slow it down, and everybody is worse off for it.

The majority of APIs that I've interacted with over the years don't
require a user agent, so most users of reqwest shouldn't ever notice
this change. This of course will break some users (anyone who's using
reqwest to hit crates.io and not setting an explicit UA for example),
but I believe the benefit for both the people writing bots and those
operating services they're hitting is worth it.