### PR TITLE
Try to make reqwest use system proxies.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,5 +15,5 @@ install:
   - cargo -vV
 build: false
 test_script:
-  - cargo test
+  - cargo test -- --test-threads=1
 skip_branch_with_pr: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ env:
 
 script:
   - cargo build $FEATURES
-  - cargo test -v $FEATURES
+  - cargo test -v $FEATURES -- --test-threads=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,6 @@ rustls-tls = ["hyper-rustls", "tokio-rustls", "webpki-roots", "rustls", "tls"]
 trust-dns = ["trust-dns-resolver"]
 
 hyper-011 = ["hyper-old-types"]
+
+[target.'cfg(windows)'.dependencies]
+winreg = "0.6"

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -36,6 +36,7 @@ use into_url::{expect_uri, try_uri};
 use cookie;
 use redirect::{self, RedirectPolicy, remove_sensitive_headers};
 use {IntoUrl, Method, Proxy, StatusCode, Url};
+use ::proxy::get_proxies;
 #[cfg(feature = "tls")]
 use {Certificate, Identity};
 #[cfg(feature = "tls")]
@@ -332,6 +333,20 @@ impl ClientBuilder {
         self.config.proxies.clear();
         self
     }
+
+    /// Add system proxy setting to the list of proxies
+    pub fn use_sys_proxy(mut self) -> ClientBuilder {
+        let proxies = get_proxies();
+        self.config.proxies.push(Proxy::custom(move |url| {
+            if proxies.contains_key(url.scheme()) {
+                return Some((*proxies.get(url.scheme()).unwrap()).clone());
+            } else {
+                return None;
+            }
+        }));
+        self
+    }
+
 
     /// Set a `RedirectPolicy` for this client.
     ///

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -338,10 +338,10 @@ impl ClientBuilder {
     pub fn use_sys_proxy(mut self) -> ClientBuilder {
         let proxies = get_proxies();
         self.config.proxies.push(Proxy::custom(move |url| {
-            if proxies.contains_key(url.scheme()) {
-                return Some((*proxies.get(url.scheme()).unwrap()).clone());
+            return if proxies.contains_key(url.scheme()) {
+                Some((*proxies.get(url.scheme()).unwrap()).clone())
             } else {
-                return None;
+                None
             }
         }));
         self

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -327,6 +327,12 @@ impl ClientBuilder {
         self
     }
 
+    /// Clear all `Proxies`, so `Client` will use no proxy anymore.
+    pub fn no_proxy(mut self) -> ClientBuilder {
+        self.config.proxies.clear();
+        self
+    }
+
     /// Set a `RedirectPolicy` for this client.
     ///
     /// Default will follow redirects up to a maximum of 10.

--- a/src/client.rs
+++ b/src/client.rs
@@ -418,15 +418,18 @@ impl Client {
     /// instead of panicking.
     pub fn new() -> Client {
         ClientBuilder::new()
+            .use_sys_proxy()
             .build()
             .expect("Client::new()")
     }
 
     /// Creates a `ClientBuilder` to configure a `Client`.
     ///
-    /// This is the same as `ClientBuilder::new()`.
+    /// This builder will use system proxy setting, if you with to
+    /// disable proxy setting, you can use `reqwest::Client::builder().no_proxy()`
+    /// to disable it.
     pub fn builder() -> ClientBuilder {
-        ClientBuilder::new()
+        ClientBuilder::new().use_sys_proxy()
     }
 
     /// Convenience method to make a `GET` request to a URL.

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,6 @@ use response::Response;
 use {async_impl, header, Method, IntoUrl, Proxy, RedirectPolicy, wait};
 #[cfg(feature = "tls")]
 use {Certificate, Identity};
-use proxy::get_proxies;
 
 /// A `Client` to make Requests with.
 ///
@@ -92,14 +91,7 @@ impl ClientBuilder {
 
     /// Enable system proxy setting.
     pub fn use_sys_proxy(self) -> ClientBuilder {
-        let proxies = get_proxies();
-        self.proxy(Proxy::custom(move |url| {
-            if proxies.contains_key(url.scheme()) {
-                return Some((*proxies.get(url.scheme()).unwrap()).clone());
-            } else {
-                return None;
-            }
-        }))
+        self.with_inner(move |inner| inner.use_sys_proxy())
     }
 
     /// Set that all sockets have `SO_NODELAY` set to `true`.

--- a/src/client.rs
+++ b/src/client.rs
@@ -410,7 +410,6 @@ impl Client {
     /// instead of panicking.
     pub fn new() -> Client {
         ClientBuilder::new()
-            .use_sys_proxy()
             .build()
             .expect("Client::new()")
     }
@@ -420,7 +419,7 @@ impl Client {
     /// This builder will use system proxy setting, you can use
     /// `reqwest::Client::builder().no_proxy()` to disable it.
     pub fn builder() -> ClientBuilder {
-        ClientBuilder::new().use_sys_proxy()
+        ClientBuilder::new()
     }
 
     /// Convenience method to make a `GET` request to a URL.

--- a/src/client.rs
+++ b/src/client.rs
@@ -91,7 +91,7 @@ impl ClientBuilder {
     }
 
     /// Enable system proxy setting.
-    pub fn system_proxy(self) -> ClientBuilder {
+    pub fn use_sys_proxy(self) -> ClientBuilder {
         let proxies = get_proxies();
         self.proxy(Proxy::custom(move |url| {
             if proxies.contains_key(url.scheme()) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use response::Response;
 use {async_impl, header, Method, IntoUrl, Proxy, RedirectPolicy, wait};
 #[cfg(feature = "tls")]
 use {Certificate, Identity};
-use proxy::{get_proxies};
+use proxy::get_proxies;
 
 /// A `Client` to make Requests with.
 ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -67,7 +67,7 @@ impl ClientBuilder {
     ///
     /// This is the same as `Client::builder()`.
     pub fn new(need_proxy: bool) -> ClientBuilder {
-        if need_proxy == false {
+        if !need_proxy {
             ClientBuilder {
                 inner: async_impl::ClientBuilder::new(),
                 timeout: Timeout::default(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -417,9 +417,8 @@ impl Client {
 
     /// Creates a `ClientBuilder` to configure a `Client`.
     ///
-    /// This builder will use system proxy setting, if you with to
-    /// disable proxy setting, you can use `reqwest::Client::builder().no_proxy()`
-    /// to disable it.
+    /// This builder will use system proxy setting, you can use
+    /// `reqwest::Client::builder().no_proxy()` to disable it.
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new().use_sys_proxy()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,7 @@ pub mod async {
 /// - redirect limit was exhausted
 pub fn get<T: IntoUrl>(url: T) -> ::Result<Response> {
     Client::builder()
+        .system_proxy()
         .build()?
         .get(url)
         .send()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,6 @@ pub mod async {
 /// - redirect limit was exhausted
 pub fn get<T: IntoUrl>(url: T) -> ::Result<Response> {
     Client::builder()
-        .use_sys_proxy()
         .build()?
         .get(url)
         .send()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,8 @@
 //! A `Client` can be configured to make use of HTTP proxies by adding
 //! [`Proxy`](Proxy)s to a `ClientBuilder`.
 //!
+//! ** NOTE** System proxies will be used in the next breaking change.
+//!
 //! ## TLS
 //!
 //! By default, a `Client` will make use of system-native transport layer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,8 @@ extern crate url;
 extern crate uuid;
 #[cfg(feature = "socks")]
 extern crate socks;
+#[cfg(target_os = "windows")]
+extern crate winreg;
 
 #[cfg(feature = "rustls-tls")]
 extern crate hyper_rustls;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ pub use self::client::{Client, ClientBuilder};
 pub use self::error::{Error, Result};
 pub use self::body::Body;
 pub use self::into_url::IntoUrl;
-pub use self::proxy::{Proxy};
+pub use self::proxy::Proxy;
 pub use self::redirect::{RedirectAction, RedirectAttempt, RedirectPolicy};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::Response;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ pub use self::client::{Client, ClientBuilder};
 pub use self::error::{Error, Result};
 pub use self::body::Body;
 pub use self::into_url::IntoUrl;
-pub use self::proxy::{Proxy, get_proxies};
+pub use self::proxy::{Proxy};
 pub use self::redirect::{RedirectAction, RedirectAttempt, RedirectPolicy};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::Response;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ pub mod async {
 /// - redirect limit was exhausted
 pub fn get<T: IntoUrl>(url: T) -> ::Result<Response> {
     Client::builder()
-        .system_proxy()
+        .use_sys_proxy()
         .build()?
         .get(url)
         .send()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ pub use self::client::{Client, ClientBuilder};
 pub use self::error::{Error, Result};
 pub use self::body::Body;
 pub use self::into_url::IntoUrl;
-pub use self::proxy::Proxy;
+pub use self::proxy::{Proxy, get_proxies};
 pub use self::redirect::{RedirectAction, RedirectAttempt, RedirectPolicy};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::Response;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -671,21 +671,27 @@ mod tests {
 
     #[test]
     fn test_get_proxies() {
+        // save system setting first.
+        let system_proxy = env::var("http_pxoxy");
+
+        // remove proxy.
         env::remove_var("http_proxy");
+        assert_eq!(get_proxies().len(), 0);
+
+        // the system proxy setting url is invalid.
+        env::set_var("http_proxy", "123465");
+        assert_eq!(get_proxies().len(), 0);
+
+        // set valid proxy
         env::set_var("http_proxy", "http://127.0.0.1/");
         let proxies = get_proxies();
         let http_target = proxies.get("http").unwrap().as_str();
         assert_eq!(http_target, "http://127.0.0.1/");
-        // clean job.
-        env::remove_var("http_proxy");
-    }
 
-    #[test]
-    fn test_get_proxies_when_proxy_url_is_invalid() {
-        env::remove_var("http_proxy");
-        env::set_var("http_proxy", "123465");
-        assert_eq!(get_proxies().len(), 0);
-        // clean job.
-        env::remove_var("http_proxy");
+        // reset user setting.
+        match system_proxy {
+            Err(_) => env::remove_var("http_proxy"),
+            Ok(proxy) => env::set_var("http_proxy", proxy)
+        }
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -668,4 +668,30 @@ mod tests {
         assert_eq!(intercepted_uri(&p, https), target1);
         assert!(p.intercept(&url(other)).is_none());
     }
+
+    #[test]
+    fn test_get_proxies() {
+        // save system setting first.
+        let system_proxy = env::var("http_pxoxy");
+
+        // remove proxy.
+        env::remove_var("http_proxy");
+        assert_eq!(get_proxies().contains_key("http"), false);
+
+        // the system proxy setting url is invalid.
+        env::set_var("http_proxy", "123465");
+        assert_eq!(get_proxies().contains_key("http"), false);
+
+        // set valid proxy
+        env::set_var("http_proxy", "http://127.0.0.1/");
+        let proxies = get_proxies();
+        let http_target = proxies.get("http").unwrap().as_str();
+        assert_eq!(http_target, "http://127.0.0.1/");
+
+        // reset user setting.
+        match system_proxy {
+            Err(_) => env::remove_var("http_proxy"),
+            Ok(proxy) => env::set_var("http_proxy", proxy)
+        }
+    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -481,11 +481,11 @@ impl Dst for Uri {
 ///
 /// It can only support Linux, Unix like, and windows system.  Note that it will always
 /// return a HashMap, even if something runs into error when find registry information in
-/// Windows system.
+/// Windows system.  Note that invalid proxy url in the system setting will be ignored.
 ///
 /// Returns:
 ///     System proxies information as a hashmap like
-///     {"http": "http://127.0.0.1:80", "https": "https://127.0.0.1:80"}
+///     {"http": Url::parse("http://127.0.0.1:80"), "https": Url::parse("https://127.0.0.1:80")}
 pub fn get_proxies() -> HashMap<String, Url> {
     let proxies: HashMap<String, Url> = get_from_environment();
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -663,4 +663,30 @@ mod tests {
         assert_eq!(intercepted_uri(&p, https), target1);
         assert!(p.intercept(&url(other)).is_none());
     }
+
+    #[test]
+    fn test_get_proxies() {
+        // save system setting first.
+        let system_proxy = env::var("http_proxy");
+
+        // remove proxy.
+        env::remove_var("http_proxy");
+        assert_eq!(get_proxies().contains_key("http"), false);
+
+        // the system proxy setting url is invalid.
+        env::set_var("http_proxy", "123465");
+        assert_eq!(get_proxies().contains_key("http"), false);
+
+        // set valid proxy
+        env::set_var("http_proxy", "http://127.0.0.1/");
+        let proxies = get_proxies();
+        let http_target = proxies.get("http").unwrap().as_str();
+
+        assert_eq!(http_target, "http://127.0.0.1/");
+        // reset user setting.
+        match system_proxy {
+            Err(_) => env::remove_var("http_proxy"),
+            Ok(proxy) => env::set_var("http_proxy", proxy)
+        }
+    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -490,6 +490,7 @@ pub fn get_proxies() -> HashMap<String, Url> {
     let proxies: HashMap<String, Url> = get_from_environment();
 
     if proxies.is_empty() {
+        // TODO: move the following #[cfg] to `if expression` when attributes on `if` expressions allowed
         // don't care errors if can't get proxies from registry, just return an empty HashMap.
         #[cfg(target_os = "windows")]
         return get_from_registry();

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -666,30 +666,4 @@ mod tests {
         assert_eq!(intercepted_uri(&p, https), target1);
         assert!(p.intercept(&url(other)).is_none());
     }
-
-    #[test]
-    fn test_get_proxies() {
-        // save system setting first.
-        let system_proxy = env::var("http_pxoxy");
-
-        // remove proxy.
-        env::remove_var("http_proxy");
-        assert_eq!(get_proxies().contains_key("http"), false);
-
-        // the system proxy setting url is invalid.
-        env::set_var("http_proxy", "123465");
-        assert_eq!(get_proxies().contains_key("http"), false);
-
-        // set valid proxy
-        env::set_var("http_proxy", "http://127.0.0.1/");
-        let proxies = get_proxies();
-        let http_target = proxies.get("http").unwrap().as_str();
-        assert_eq!(http_target, "http://127.0.0.1/");
-
-        // reset user setting.
-        match system_proxy {
-            Err(_) => env::remove_var("http_proxy"),
-            Ok(proxy) => env::set_var("http_proxy", proxy)
-        }
-    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -7,6 +7,14 @@ use http::{header::HeaderValue, Uri};
 use hyper::client::connect::Destination;
 use url::percent_encoding::percent_decode;
 use {IntoUrl, Url};
+use std::collections::HashMap;
+use std::env;
+#[cfg(target_os = "windows")]
+use std::error::Error;
+#[cfg(target_os = "windows")]
+use winreg::enums::HKEY_CURRENT_USER;
+#[cfg(target_os = "windows")]
+use winreg::RegKey;
 
 /// Configuration of a proxy that a `Client` should pass requests to.
 ///
@@ -466,6 +474,104 @@ impl Dst for Uri {
 
     fn port(&self) -> Option<u16> {
         self.port_part().map(|p| p.as_u16())
+    }
+}
+
+/// Get system proxies information.
+///
+/// It can only support Linux, Unix like, and windows system.  Note that it will always
+/// return a HashMap, even if something runs into error when find registry information in
+/// Windows system.
+///
+/// Returns:
+///     System proxies information as a hashmap like
+///     {"http": "http://127.0.0.1:80", "https": "https://127.0.0.1:80"}
+pub fn get_proxies() -> HashMap<String, Url> {
+    let proxies: HashMap<String, Url> = get_from_environment();
+
+    if proxies.len() == 0 {
+        // don't cared if we can't get proxies from registry, just return an empty proxies.
+        #[cfg(target_os = "windows")]
+        let proxies = get_from_registry();
+        return proxies;
+    } else {
+        return proxies;
+    }
+}
+
+fn insert_proxy(proxies: &mut HashMap<String, Url>, schema: String, addr: String)
+{
+    if let Ok(valid_addr) = Url::parse(&addr) {
+        proxies.insert(schema, valid_addr);
+    }
+}
+
+fn get_from_environment() -> HashMap<String, Url> {
+    let mut proxies: HashMap<String, Url> = HashMap::new();
+
+    const PROXY_KEY_ENDS: &str = "_proxy";
+
+    for (key, value) in env::vars() {
+        let key: String = key.to_lowercase();
+        if key.ends_with(PROXY_KEY_ENDS) {
+            let end_indx = key.len() - PROXY_KEY_ENDS.len();
+            let schema = &key[..end_indx];
+            insert_proxy(&mut proxies, String::from(schema), String::from(value));
+        }
+    }
+    return proxies;
+}
+
+
+#[cfg(target_os = "windows")]
+fn get_from_registry_impl() -> Result<HashMap<String, Url>, Box<dyn Error>> {
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let internet_setting: RegKey =
+        hkcu.open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings")?;
+    // ensure the proxy is enable, if the value doesn't exist, an error will returned.
+    let proxy_enable: u32 = internet_setting.get_value("ProxyEnable")?;
+    let proxy_server: String = internet_setting.get_value("ProxyServer")?;
+
+    if proxy_enable == 0 {
+        return Ok(HashMap::new());
+    }
+
+    let mut proxies: HashMap<String, Url> = HashMap::new();
+    if proxy_server.contains("=") {
+        // per-protocol settings.
+        for p in proxy_server.split(";") {
+            let protocol_parts: Vec<&str> = p.split("=").collect();
+            match protocol_parts.as_slice() {
+                [protocol, address] => {
+                    insert_proxy(&mut proxies, String::from(*protocol), String::from(*address));
+                }
+                _ => {
+                    // Contains invalid protocol setting, just break the loop
+                    // And make proxies to be empty.
+                    proxies.clear();
+                    break;
+                }
+            }
+        }
+    } else {
+        // Use one setting for all protocols.
+        if proxy_server.starts_with("http:") {
+            insert_proxy(&mut proxies, String::from("http"), proxy_server);
+        } else {
+            insert_proxy(&mut proxies, String::from("http"), format!("http://{}", proxy_server));
+            insert_proxy(&mut proxies, String::from("https"), format!("https://{}", proxy_server));
+            insert_proxy(&mut proxies, String::from("ftp"), format!("https://{}", proxy_server));
+        }
+    }
+    return Ok(proxies);
+}
+
+#[cfg(target_os = "windows")]
+fn get_from_registry() -> HashMap<String, Url> {
+    let results = get_from_registry_impl();
+    match results {
+        Ok(proxies) => proxies,
+        Err(_) => HashMap::new(),
     }
 }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -489,12 +489,12 @@ impl Dst for Uri {
 pub fn get_proxies() -> HashMap<String, Url> {
     let proxies: HashMap<String, Url> = get_from_environment();
 
-    if proxies.len() == 0 {
+    if proxies.is_empty() {
         // don't care errors if can't get proxies from registry, just return an empty HashMap.
         #[cfg(target_os = "windows")]
         return get_from_registry();
     }
-    return proxies;
+    proxies
 }
 
 fn insert_proxy(proxies: &mut HashMap<String, Url>, schema: String, addr: String)
@@ -517,7 +517,7 @@ fn get_from_environment() -> HashMap<String, Url> {
             insert_proxy(&mut proxies, String::from(schema), String::from(value));
         }
     }
-    return proxies;
+    proxies
 }
 
 
@@ -561,16 +561,12 @@ fn get_from_registry_impl() -> Result<HashMap<String, Url>, Box<dyn Error>> {
             insert_proxy(&mut proxies, String::from("ftp"), format!("https://{}", proxy_server));
         }
     }
-    return Ok(proxies);
+    Ok(proxies)
 }
 
 #[cfg(target_os = "windows")]
 fn get_from_registry() -> HashMap<String, Url> {
-    let results = get_from_registry_impl();
-    match results {
-        Ok(proxies) => proxies,
-        Err(_) => HashMap::new(),
-    }
+    get_from_registry_impl().unwrap_or(HashMap::new())
 }
 
 #[cfg(test)]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -490,13 +490,11 @@ pub fn get_proxies() -> HashMap<String, Url> {
     let proxies: HashMap<String, Url> = get_from_environment();
 
     if proxies.len() == 0 {
-        // don't cared if we can't get proxies from registry, just return an empty proxies.
+        // don't care errors if can't get proxies from registry, just return an empty HashMap.
         #[cfg(target_os = "windows")]
-        let proxies = get_from_registry();
-        return proxies;
-    } else {
-        return proxies;
+        return get_from_registry();
     }
+    return proxies;
 }
 
 fn insert_proxy(proxies: &mut HashMap<String, Url>, schema: String, addr: String)

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -668,30 +668,4 @@ mod tests {
         assert_eq!(intercepted_uri(&p, https), target1);
         assert!(p.intercept(&url(other)).is_none());
     }
-
-    #[test]
-    fn test_get_proxies() {
-        // save system setting first.
-        let system_proxy = env::var("http_pxoxy");
-
-        // remove proxy.
-        env::remove_var("http_proxy");
-        assert_eq!(get_proxies().len(), 0);
-
-        // the system proxy setting url is invalid.
-        env::set_var("http_proxy", "123465");
-        assert_eq!(get_proxies().len(), 0);
-
-        // set valid proxy
-        env::set_var("http_proxy", "http://127.0.0.1/");
-        let proxies = get_proxies();
-        let http_target = proxies.get("http").unwrap().as_str();
-        assert_eq!(http_target, "http://127.0.0.1/");
-
-        // reset user setting.
-        match system_proxy {
-            Err(_) => env::remove_var("http_proxy"),
-            Ok(proxy) => env::set_var("http_proxy", proxy)
-        }
-    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -489,11 +489,13 @@ impl Dst for Uri {
 pub fn get_proxies() -> HashMap<String, Url> {
     let proxies: HashMap<String, Url> = get_from_environment();
 
-    if proxies.is_empty() {
-        // TODO: move the following #[cfg] to `if expression` when attributes on `if` expressions allowed
-        // don't care errors if can't get proxies from registry, just return an empty HashMap.
-        #[cfg(target_os = "windows")]
-        return get_from_registry();
+    // TODO: move the following #[cfg] to `if expression` when attributes on `if` expressions allowed
+    #[cfg(target_os = "windows")]
+    {
+        if proxies.is_empty() {
+            // don't care errors if can't get proxies from registry, just return an empty HashMap.
+            return get_from_registry();
+        }
     }
     proxies
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -668,4 +668,24 @@ mod tests {
         assert_eq!(intercepted_uri(&p, https), target1);
         assert!(p.intercept(&url(other)).is_none());
     }
+
+    #[test]
+    fn test_get_proxies() {
+        env::remove_var("http_proxy");
+        env::set_var("http_proxy", "http://127.0.0.1/");
+        let proxies = get_proxies();
+        let http_target = proxies.get("http").unwrap().as_str();
+        assert_eq!(http_target, "http://127.0.0.1/");
+        // clean job.
+        env::remove_var("http_proxy");
+    }
+
+    #[test]
+    fn test_get_proxies_when_proxy_url_is_invalid() {
+        env::remove_var("http_proxy");
+        env::set_var("http_proxy", "123465");
+        assert_eq!(get_proxies().len(), 0);
+        // clean job.
+        env::remove_var("http_proxy");
+    }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -480,7 +480,7 @@ fn test_system_proxy_is_used() {
             "
     };
     // save system setting first.
-    let system_proxy = env::var("http_pxoxy");
+    let system_proxy = env::var("http_proxy");
 
     // set-up http proxy.
     env::set_var("http_proxy", format!("http://{}", server.addr()));

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -4,7 +4,6 @@ extern crate reqwest;
 mod support;
 
 use std::io::Read;
-use std::env;
 
 #[test]
 fn test_response_text() {
@@ -459,36 +458,4 @@ fn test_appended_headers_not_overwritten() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
-}
-
-#[test]
-fn test_system_proxy_is_used() {
-    let server = server! {
-        request: b"\
-            GET http://hyper.rs/prox HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: hyper.rs\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: proxied\r\n\
-            Content-Length: 0\r\n\
-            \r\n\
-            "
-    };
-    // set-up http proxy first.
-    env::set_var("http_proxy", format!("http://{}", server.addr()));
-
-    let url = "http://hyper.rs/prox";
-    let res = reqwest::get(url).unwrap();
-
-    assert_eq!(res.url().as_str(), url);
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
-
-    // clean system setting
-    env::remove_var("http");
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -3,7 +3,6 @@ extern crate reqwest;
 #[macro_use]
 mod support;
 
-use std::env;
 use std::io::Read;
 
 #[test]
@@ -459,42 +458,4 @@ fn test_appended_headers_not_overwritten() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
-}
-
-#[test]
-fn test_system_proxy_is_used() {
-    let server = server! {
-        request: b"\
-            GET http://hyper.rs/prox HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: hyper.rs\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: proxied\r\n\
-            Content-Length: 0\r\n\
-            \r\n\
-            "
-    };
-    // save system setting first.
-    let system_proxy = env::var("http_proxy");
-
-    // set-up http proxy.
-    env::set_var("http_proxy", format!("http://{}", server.addr()));
-
-    let url = "http://hyper.rs/prox";
-    let res = reqwest::get(url).unwrap();
-
-    assert_eq!(res.url().as_str(), url);
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
-
-    // reset user setting.
-    match system_proxy {
-        Err(_) => env::remove_var("http_proxy"),
-        Ok(proxy) => env::set_var("http_proxy", proxy)
-    }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -4,6 +4,7 @@ extern crate reqwest;
 mod support;
 
 use std::io::Read;
+use std::env;
 
 #[test]
 fn test_response_text() {
@@ -432,7 +433,7 @@ fn test_appended_headers_not_overwritten() {
     let client = reqwest::Client::builder()
         .default_headers(headers)
         .build().unwrap();
-    
+
     let server = server! {
         request: b"\
             GET /4 HTTP/1.1\r\n\
@@ -458,4 +459,36 @@ fn test_appended_headers_not_overwritten() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
+}
+
+#[test]
+fn test_system_proxy_is_used() {
+    let server = server! {
+        request: b"\
+            GET http://hyper.rs/prox HTTP/1.1\r\n\
+            user-agent: $USERAGENT\r\n\
+            accept: */*\r\n\
+            accept-encoding: gzip\r\n\
+            host: hyper.rs\r\n\
+            \r\n\
+            ",
+        response: b"\
+            HTTP/1.1 200 OK\r\n\
+            Server: proxied\r\n\
+            Content-Length: 0\r\n\
+            \r\n\
+            "
+    };
+    // set-up http proxy first.
+    env::set_var("http_proxy", format!("http://{}", server.addr()));
+
+    let url = "http://hyper.rs/prox";
+    let res = reqwest::get(url).unwrap();
+
+    assert_eq!(res.url().as_str(), url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
+
+    // clean system setting
+    env::remove_var("http");
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -3,6 +3,7 @@ extern crate reqwest;
 #[macro_use]
 mod support;
 
+use std::env;
 use std::io::Read;
 
 #[test]
@@ -458,4 +459,42 @@ fn test_appended_headers_not_overwritten() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
+}
+
+#[test]
+fn test_system_proxy_is_used() {
+    let server = server! {
+        request: b"\
+            GET http://hyper.rs/prox HTTP/1.1\r\n\
+            user-agent: $USERAGENT\r\n\
+            accept: */*\r\n\
+            accept-encoding: gzip\r\n\
+            host: hyper.rs\r\n\
+            \r\n\
+            ",
+        response: b"\
+            HTTP/1.1 200 OK\r\n\
+            Server: proxied\r\n\
+            Content-Length: 0\r\n\
+            \r\n\
+            "
+    };
+    // save system setting first.
+    let system_proxy = env::var("http_pxoxy");
+
+    // set-up http proxy.
+    env::set_var("http_proxy", format!("http://{}", server.addr()));
+
+    let url = "http://hyper.rs/prox";
+    let res = reqwest::get(url).unwrap();
+
+    assert_eq!(res.url().as_str(), url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
+
+    // reset user setting.
+    match system_proxy {
+        Err(_) => env::remove_var("http_proxy"),
+        Ok(proxy) => env::set_var("http_proxy", proxy)
+    }
 }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,4 +1,9 @@
 extern crate reqwest;
+#[macro_use]
+extern crate lazy_static;
+
+use std::env;
+use std::sync::Mutex;
 
 #[macro_use]
 mod support;
@@ -114,4 +119,74 @@ fn http_proxy_basic_auth_parsed() {
     assert_eq!(res.url().as_str(), url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
+}
+
+lazy_static! {
+    static ref LOCK: Mutex<()> = Mutex::new(());
+}
+
+#[test]
+fn test_get_proxies() {
+    let _l = LOCK.lock();
+    // save system setting first.
+    let system_proxy = env::var("http_pxoxy");
+
+    // remove proxy.
+    env::remove_var("http_proxy");
+    assert_eq!(reqwest::get_proxies().len(), 0);
+
+    // the system proxy setting url is invalid.
+    env::set_var("http_proxy", "123465");
+    assert_eq!(reqwest::get_proxies().len(), 0);
+
+    // set valid proxy
+    env::set_var("http_proxy", "http://127.0.0.1/");
+    let proxies = reqwest::get_proxies();
+    let http_target = proxies.get("http").unwrap().as_str();
+    assert_eq!(http_target, "http://127.0.0.1/");
+
+    // reset user setting.
+    match system_proxy {
+        Err(_) => env::remove_var("http_proxy"),
+        Ok(proxy) => env::set_var("http_proxy", proxy)
+    }
+}
+
+#[test]
+fn test_system_proxy_is_used() {
+    let _l = LOCK.lock();
+    let server = server! {
+        request: b"\
+            GET http://hyper.rs/prox HTTP/1.1\r\n\
+            user-agent: $USERAGENT\r\n\
+            accept: */*\r\n\
+            accept-encoding: gzip\r\n\
+            host: hyper.rs\r\n\
+            \r\n\
+            ",
+        response: b"\
+            HTTP/1.1 200 OK\r\n\
+            Server: proxied\r\n\
+            Content-Length: 0\r\n\
+            \r\n\
+            "
+    };
+    // save system setting first.
+    let system_proxy = env::var("http_pxoxy");
+
+    // set-up http proxy.
+    env::set_var("http_proxy", format!("http://{}", server.addr()));
+
+    let url = "http://hyper.rs/prox";
+    let res = reqwest::get(url).unwrap();
+
+    assert_eq!(res.url().as_str(), url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
+
+    // reset user setting.
+    match system_proxy {
+        Err(_) => env::remove_var("http_proxy"),
+        Ok(proxy) => env::set_var("http_proxy", proxy)
+    }
 }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -119,32 +119,6 @@ fn http_proxy_basic_auth_parsed() {
 }
 
 #[test]
-fn test_get_proxies() {
-    // save system setting first.
-    let system_proxy = env::var("http_proxy");
-
-    // remove proxy.
-    env::remove_var("http_proxy");
-    assert_eq!(reqwest::get_proxies().contains_key("http"), false);
-
-    // the system proxy setting url is invalid.
-    env::set_var("http_proxy", "123465");
-    assert_eq!(reqwest::get_proxies().contains_key("http"), false);
-
-    // set valid proxy
-    env::set_var("http_proxy", "http://127.0.0.1/");
-    let proxies = reqwest::get_proxies();
-    let http_target = proxies.get("http").unwrap().as_str();
-
-    assert_eq!(http_target, "http://127.0.0.1/");
-    // reset user setting.
-    match system_proxy {
-        Err(_) => env::remove_var("http_proxy"),
-        Ok(proxy) => env::set_var("http_proxy", proxy)
-    }
-}
-
-#[test]
 fn test_no_proxy() {
     let server = server! {
         request: b"\

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -143,3 +143,89 @@ fn test_get_proxies() {
         Ok(proxy) => env::set_var("http_proxy", proxy)
     }
 }
+
+#[test]
+fn test_no_proxy() {
+    let server = server! {
+        request: b"\
+            GET /4 HTTP/1.1\r\n\
+            user-agent: $USERAGENT\r\n\
+            accept: */*\r\n\
+            accept-encoding: gzip\r\n\
+            host: $HOST\r\n\
+            \r\n\
+            ",
+        response: b"\
+            HTTP/1.1 200 OK\r\n\
+            Server: test\r\n\
+            Content-Length: 0\r\n\
+            \r\n\
+            "
+    };
+    // save system setting first.
+    let system_proxy = env::var("http_proxy");
+    // set-up http proxy.
+    env::set_var("http_proxy", format!("http://{}", server.addr()));
+
+    let url = format!("http://{}/4", server.addr());
+    let res = reqwest::Client::builder()
+        .use_sys_proxy()
+        .no_proxy()
+        .build()
+        .unwrap()
+        .get(&url)
+        .send()
+        .unwrap();
+
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+
+    // reset user setting.
+    match system_proxy {
+        Err(_) => env::remove_var("http_proxy"),
+        Ok(proxy) => env::set_var("http_proxy", proxy)
+    }
+}
+
+#[test]
+fn test_using_system_proxy() {
+    let server = server! {
+        request: b"\
+            GET http://hyper.rs/prox HTTP/1.1\r\n\
+            user-agent: $USERAGENT\r\n\
+            accept: */*\r\n\
+            accept-encoding: gzip\r\n\
+            host: hyper.rs\r\n\
+            \r\n\
+            ",
+        response: b"\
+            HTTP/1.1 200 OK\r\n\
+            Server: proxied\r\n\
+            Content-Length: 0\r\n\
+            \r\n\
+            "
+    };
+    // save system setting first.
+    let system_proxy = env::var("http_proxy");
+    // set-up http proxy.
+    env::set_var("http_proxy", format!("http://{}", server.addr()));
+
+    let url = "http://hyper.rs/prox";
+    let res = reqwest::Client::builder()
+        .use_sys_proxy()
+        .build()
+        .unwrap()
+        .get(url)
+        .send()
+        .unwrap();
+
+    assert_eq!(res.url().as_str(), url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
+
+    // reset user setting.
+    match system_proxy {
+        Err(_) => env::remove_var("http_proxy"),
+        Ok(proxy) => env::set_var("http_proxy", proxy)
+    }
+}

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -121,7 +121,7 @@ fn http_proxy_basic_auth_parsed() {
 #[test]
 fn test_get_proxies() {
     // save system setting first.
-    let system_proxy = env::var("http_pxoxy");
+    let system_proxy = env::var("http_proxy");
 
     // remove proxy.
     env::remove_var("http_proxy");

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -133,14 +133,20 @@ fn test_get_proxies() {
 
     // remove proxy.
     env::remove_var("http_proxy");
+    // ensure that the proxy is removed
+    assert_eq!(env::var("http_proxy").is_err(), true);
     assert_eq!(reqwest::get_proxies().len(), 0);
 
     // the system proxy setting url is invalid.
     env::set_var("http_proxy", "123465");
+    // ensure that the proxy is set
+    assert_eq!(env::var("http_proxy").is_ok(), true);
     assert_eq!(reqwest::get_proxies().len(), 0);
 
     // set valid proxy
     env::set_var("http_proxy", "http://127.0.0.1/");
+    // ensure that the proxy is set
+    assert_eq!(env::var("http_proxy").is_ok(), true);
     let proxies = reqwest::get_proxies();
     let http_target = proxies.get("http").unwrap().as_str();
     assert_eq!(http_target, "http://127.0.0.1/");
@@ -176,6 +182,8 @@ fn test_system_proxy_is_used() {
 
     // set-up http proxy.
     env::set_var("http_proxy", format!("http://{}", server.addr()));
+    // ensure that the proxy is set
+    assert_eq!(env::var("http_proxy").is_ok(), true);
 
     let url = "http://hyper.rs/prox";
     let res = reqwest::get(url).unwrap();

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,9 +1,4 @@
 extern crate reqwest;
-#[macro_use]
-extern crate lazy_static;
-
-use std::env;
-use std::sync::Mutex;
 
 #[macro_use]
 mod support;
@@ -119,82 +114,4 @@ fn http_proxy_basic_auth_parsed() {
     assert_eq!(res.url().as_str(), url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
-}
-
-lazy_static! {
-    static ref LOCK: Mutex<()> = Mutex::new(());
-}
-
-#[test]
-fn test_get_proxies() {
-    let _l = LOCK.lock();
-    // save system setting first.
-    let system_proxy = env::var("http_pxoxy");
-
-    // remove proxy.
-    env::remove_var("http_proxy");
-    // ensure that the proxy is removed
-    assert_eq!(env::var("http_proxy").is_err(), true);
-    assert_eq!(reqwest::get_proxies().len(), 0);
-
-    // the system proxy setting url is invalid.
-    env::set_var("http_proxy", "123465");
-    // ensure that the proxy is set
-    assert_eq!(env::var("http_proxy").is_ok(), true);
-    assert_eq!(reqwest::get_proxies().len(), 0);
-
-    // set valid proxy
-    env::set_var("http_proxy", "http://127.0.0.1/");
-    // ensure that the proxy is set
-    assert_eq!(env::var("http_proxy").is_ok(), true);
-    let proxies = reqwest::get_proxies();
-    let http_target = proxies.get("http").unwrap().as_str();
-    assert_eq!(http_target, "http://127.0.0.1/");
-
-    // reset user setting.
-    match system_proxy {
-        Err(_) => env::remove_var("http_proxy"),
-        Ok(proxy) => env::set_var("http_proxy", proxy)
-    }
-}
-
-#[test]
-fn test_system_proxy_is_used() {
-    let _l = LOCK.lock();
-    let server = server! {
-        request: b"\
-            GET http://hyper.rs/prox HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: hyper.rs\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: proxied\r\n\
-            Content-Length: 0\r\n\
-            \r\n\
-            "
-    };
-    // save system setting first.
-    let system_proxy = env::var("http_pxoxy");
-
-    // set-up http proxy.
-    env::set_var("http_proxy", format!("http://{}", server.addr()));
-    // ensure that the proxy is set
-    assert_eq!(env::var("http_proxy").is_ok(), true);
-
-    let url = "http://hyper.rs/prox";
-    let res = reqwest::get(url).unwrap();
-
-    assert_eq!(res.url().as_str(), url);
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
-
-    // reset user setting.
-    match system_proxy {
-        Err(_) => env::remove_var("http_proxy"),
-        Ok(proxy) => env::set_var("http_proxy", proxy)
-    }
 }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -3,6 +3,8 @@ extern crate reqwest;
 #[macro_use]
 mod support;
 
+use std::env;
+
 #[test]
 fn http_proxy() {
     let server = server! {
@@ -114,4 +116,30 @@ fn http_proxy_basic_auth_parsed() {
     assert_eq!(res.url().as_str(), url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
+}
+
+#[test]
+fn test_get_proxies() {
+    // save system setting first.
+    let system_proxy = env::var("http_pxoxy");
+
+    // remove proxy.
+    env::remove_var("http_proxy");
+    assert_eq!(reqwest::get_proxies().contains_key("http"), false);
+
+    // the system proxy setting url is invalid.
+    env::set_var("http_proxy", "123465");
+    assert_eq!(reqwest::get_proxies().contains_key("http"), false);
+
+    // set valid proxy
+    env::set_var("http_proxy", "http://127.0.0.1/");
+    let proxies = reqwest::get_proxies();
+    let http_target = proxies.get("http").unwrap().as_str();
+
+    assert_eq!(http_target, "http://127.0.0.1/");
+    // reset user setting.
+    match system_proxy {
+        Err(_) => env::remove_var("http_proxy"),
+        Ok(proxy) => env::set_var("http_proxy", proxy)
+    }
 }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -136,14 +136,14 @@ fn test_no_proxy() {
             \r\n\
             "
     };
-    // save system setting first.
-    let system_proxy = env::var("http_proxy");
-    // set-up http proxy.
-    env::set_var("http_proxy", format!("http://{}", server.addr()));
-
+    let proxy = format!("http://{}", server.addr());
     let url = format!("http://{}/4", server.addr());
+
+    // set up proxy and use no_proxy to clear up client builder proxies.
     let res = reqwest::Client::builder()
-        .use_sys_proxy()
+        .proxy(
+            reqwest::Proxy::http(&proxy).unwrap()
+        )
         .no_proxy()
         .build()
         .unwrap()
@@ -153,12 +153,6 @@ fn test_no_proxy() {
 
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
-
-    // reset user setting.
-    match system_proxy {
-        Err(_) => env::remove_var("http_proxy"),
-        Ok(proxy) => env::set_var("http_proxy", proxy)
-    }
 }
 
 #[test]

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -391,7 +391,7 @@ fn test_invalid_location_stops_redirect_gh484() {
 #[test]
 fn test_redirect_302_with_set_cookies() {
     let code = 302;
-    let client = reqwest::ClientBuilder::new().cookie_store(true).build().unwrap();
+    let client = reqwest::ClientBuilder::new(true).cookie_store(true).build().unwrap();
     let server = server! {
             request: format!("\
                 GET /{} HTTP/1.1\r\n\

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -391,7 +391,7 @@ fn test_invalid_location_stops_redirect_gh484() {
 #[test]
 fn test_redirect_302_with_set_cookies() {
     let code = 302;
-    let client = reqwest::ClientBuilder::new(true).cookie_store(true).build().unwrap();
+    let client = reqwest::ClientBuilder::new().cookie_store(true).build().unwrap();
     let server = server! {
             request: format!("\
                 GET /{} HTTP/1.1\r\n\


### PR DESCRIPTION
Try to resolve issue #403 
The core function for this feature is `get_proxies()`, which is a copy from `python` [getproxies implementation](https://github.com/python/cpython/blob/master/Lib/urllib/request.py).

### Some consideration about the design:
After looking the `getproxies` implementation in python, I don't whink we need to use something like [env_proxy] crate, because it doesn't support `windows system`.  So I implement it once again..  And this version of `getproxies` should work on `windows` and `linux`.

### Something about testing
In `windows` system, because the proxy setting is configured from `registry`.  I just do manually testing for this scenario.  (I have implemented it [in another place first](https://github.com/WindSoilder/hors/blob/master/src/proxies.rs))
I'm afraid the testing code may break `windows registry setting`.  It can be a very big problem.  So I just leave it away :(