### PR TITLE
Use dyn Trait feature in examples & tests

### DIFF
--- a/examples/async_stream.rs
+++ b/examples/async_stream.rs
@@ -51,7 +51,7 @@ where
     File::open(path.as_ref().to_owned())
         .map_err(|err| println!("request error: {}", err))
         .and_then(|file| {
-            let source: Box<Stream<Item = Bytes, Error = io::Error> + Send> =
+            let source: Box<dyn Stream<Item = Bytes, Error = io::Error> + Send> =
                 Box::new(FileSource::new(file));
 
             Client::new()

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -239,7 +239,7 @@ fn gzip_case(response_size: usize, chunk_size: usize) {
 fn body_stream() {
     let _ = env_logger::try_init();
 
-    let source: Box<Stream<Item = Bytes, Error = io::Error> + Send>
+    let source: Box<dyn Stream<Item = Bytes, Error = io::Error> + Send>
         = Box::new(futures::stream::iter_ok::<_, io::Error>(
             vec![Bytes::from_static(b"123"), Bytes::from_static(b"4567")]));
 


### PR DESCRIPTION
Fixes the nightly build.

`dyn Trait` feature is available since 1.27, should be fine to use since reqwest requires 1.31.