### PR TITLE
Made cookie support optional with a `cookies` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ socks = { version = "0.3.2", optional = true }
 tokio-rustls = { version = "0.9", optional = true }
 trust-dns-resolver = { version = "0.11", optional = true }
 webpki-roots = { version = "0.16", optional = true }
-cookie_store = "0.7.0"
-cookie = "0.12.0"
+cookie_store = { version = "0.7.0", optional = true }
+cookie = { version = "0.12.0", optional = true }
 time = "0.1.42"
 
 [dev-dependencies]
@@ -60,7 +60,7 @@ doc-comment = "0.3"
 bytes = "0.4"
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "cookies"]
 
 tls = []
 
@@ -72,3 +72,5 @@ rustls-tls = ["hyper-rustls", "tokio-rustls", "webpki-roots", "rustls", "tls"]
 trust-dns = ["trust-dns-resolver"]
 
 hyper-011 = ["hyper-old-types"]
+
+cookies = ["cookie_store", "cookie"]

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -18,6 +18,7 @@ use serde_json;
 use url::Url;
 
 
+#[cfg(feature = "cookies")]
 use cookie;
 use super::Decoder;
 use super::body::Body;
@@ -78,6 +79,7 @@ impl Response {
     /// Retrieve the cookies contained in the response.
     /// 
     /// Note that invalid 'Set-Cookie' headers will be ignored.
+    #[cfg(feature = "cookies")]
     pub fn cookies<'a>(&'a self) -> impl Iterator<Item = cookie::Cookie<'a>> + 'a {
         cookie::extract_response_cookies(&self.headers)
             .filter_map(Result::ok)

--- a/src/client.rs
+++ b/src/client.rs
@@ -382,6 +382,7 @@ impl ClientBuilder {
     ///     .build()
     ///     .unwrap();
     /// ```
+    #[cfg(feature = "cookies")]
     pub fn cookie_store(self, enable: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.cookie_store(enable))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,9 @@
 //! - **trust-dns**: Enables a trust-dns async resolver instead of default
 //!   threadpool using `getaddrinfo`.
 //! - **hyper-011**: Provides support for hyper's old typed headers.
+//! - **cookies**: *(enabled by default)*: Enables support for automatic storing
+//!   and sending of cookies by depending on the `cookie` and `cookie_store`
+//!   crates.
 //!
 //!
 //! [hyper]: http://hyper.rs
@@ -173,7 +176,9 @@
 
 extern crate base64;
 extern crate bytes;
+#[cfg(feature = "cookies")]
 extern crate cookie as cookie_crate;
+#[cfg(feature = "cookies")]
 extern crate cookie_store;
 extern crate encoding_rs;
 #[macro_use]
@@ -248,6 +253,7 @@ mod async_impl;
 mod connect;
 mod body;
 mod client;
+#[cfg(feature = "cookies")]
 pub mod cookie;
 #[cfg(feature = "trust-dns")]
 mod dns;

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,6 +8,7 @@ use futures::{Async, Poll, Stream};
 use http;
 use serde::de::DeserializeOwned;
 
+#[cfg(feature = "cookies")]
 use cookie;
 use client::KeepCoreThreadAlive;
 use hyper::header::HeaderMap;
@@ -116,6 +117,7 @@ impl Response {
     /// Retrieve the cookies contained in the response.
     ///
     /// Note that invalid 'Set-Cookie' headers will be ignored.
+    #[cfg(feature = "cookies")]
     pub fn cookies<'a>(&'a self) -> impl Iterator< Item = cookie::Cookie<'a> > + 'a {
         cookie::extract_response_cookies(self.headers())
             .filter_map(Result::ok)

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -3,6 +3,7 @@ extern crate reqwest;
 #[macro_use]
 mod support;
 
+#[cfg(feature = "cookies")]
 #[test]
 fn cookie_response_accessor() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
@@ -78,6 +79,7 @@ fn cookie_response_accessor() {
     assert!(cookies[8].same_site_strict());
 }
 
+#[cfg(feature = "cookies")]
 #[test]
 fn cookie_store_simple() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
@@ -122,6 +124,7 @@ fn cookie_store_simple() {
     rt.block_on(client.get(&url).send()).unwrap();
 }
 
+#[cfg(feature = "cookies")]
 #[test]
 fn cookie_store_overwrite_existing() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
@@ -186,6 +189,7 @@ fn cookie_store_overwrite_existing() {
     rt.block_on(client.get(&url).send()).unwrap();
 }
 
+#[cfg(feature = "cookies")]
 #[test]
 fn cookie_store_max_age() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
@@ -229,6 +233,7 @@ fn cookie_store_max_age() {
     rt.block_on(client.get(&url).send()).unwrap();
 }
 
+#[cfg(feature = "cookies")]
 #[test]
 fn cookie_store_expires() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
@@ -272,6 +277,7 @@ fn cookie_store_expires() {
     rt.block_on(client.get(&url).send()).unwrap();
 }
 
+#[cfg(feature = "cookies")]
 #[test]
 fn cookie_store_path() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -388,6 +388,7 @@ fn test_invalid_location_stops_redirect_gh484() {
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test-yikes");
 }
 
+#[cfg(feature = "cookies")]
 #[test]
 fn test_redirect_302_with_set_cookies() {
     let code = 302;


### PR DESCRIPTION
I use `reqwest` to make API calls and have no need for cookie support. I imagine many others might be in a similar situation and so it could be useful to be able to turn off the feature to avoid the extra dependencies.

This PR makes cookie support optional with a new `cookies` feature (which is turned on by default for backward compatibility).

The direct motivation for this was that I have a few projects that use `reqwest` but now need to build for a target where some external C library dependencies are difficult to support. `cookie_store` pulls in `failure` -> `backtrace` -> `backtrace-sys` -> `libbacktrace`