### PR TITLE
revert docstring back because ClientBuilder don't use system proxy.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -416,8 +416,7 @@ impl Client {
 
     /// Creates a `ClientBuilder` to configure a `Client`.
     ///
-    /// This builder will use system proxy setting, you can use
-    /// `reqwest::Client::builder().no_proxy()` to disable it.
+    /// This is the same as `ClientBuilder::new()`.
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new()
     }


### PR DESCRIPTION
Sorry for leaving incorrect docsting in #547 :(
This PR is going to fix it.