### PR TITLE
Support creating a client with a custom tls connector

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -156,6 +156,22 @@ impl ClientBuilder {
 
                     Connector::new_default_tls(tls, proxies.clone(), config.local_address, config.nodelay)?
                 },
+                #[cfg(feature = "default-tls")]
+                TlsBackend::BuiltDefault(conn) => {
+                    Connector::from_built_default(
+                        conn,
+                        proxies.clone(),
+                        config.local_address,
+                        config.nodelay)?
+                },
+                #[cfg(feature = "rustls-tls")]
+                TlsBackend::BuiltRustls(conn) => {
+                    Connector::new_rustls_tls(
+                        conn,
+                        proxies.clone(),
+                        config.local_address,
+                        config.nodelay)?
+                },
                 #[cfg(feature = "rustls-tls")]
                 TlsBackend::Rustls => {
                     use ::tls::NoVerifier;
@@ -237,6 +253,16 @@ impl ClientBuilder {
     #[cfg(feature = "default-tls")]
     pub fn use_default_tls(mut self) -> ClientBuilder {
         self.config.tls = TlsBackend::Default;
+        self
+    }
+
+    /// Use a preconfigured backed.
+    /// If you are planning on using this, you should have a unit test that builds a reqwest Client
+    /// using this option, and verifying no panics, which means the provided Any was succesfully cast
+    /// to a compatible backend connector
+    #[cfg(feature = "tls")]
+    pub(crate) fn with_preconfigured_connector(mut self, connector: TlsBackend) -> ClientBuilder {
+        self.config.tls = connector;
         self
     }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -88,6 +88,28 @@ impl Connector {
         })
     }
 
+    #[cfg(feature = "default-tls")]
+    pub(crate) fn from_built_default<T> (
+        tls: TlsConnector,
+        proxies: Arc<Vec<Proxy>>,
+        local_addr: T,
+        nodelay: bool) -> ::Result<Connector>
+        where
+            T: Into<Option<IpAddr>>,
+    {
+
+        let mut http = http_connector()?;
+        http.set_local_address(local_addr.into());
+        http.enforce_http(false);
+
+        Ok(Connector {
+            inner: Inner::DefaultTls(http, tls),
+            proxies,
+            timeout: None,
+            nodelay
+        })
+    }
+
     #[cfg(feature = "rustls-tls")]
     pub(crate) fn new_rustls_tls<T>(
         tls: rustls::ClientConfig,

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -106,7 +106,7 @@ impl Certificate {
                 .map_err(TLSError::WebPKIError)),
             Cert::Pem(buf) => {
                 let mut pem = Cursor::new(buf);
-                let mut certs = try_!(pemfile::certs(&mut pem)
+                let certs = try_!(pemfile::certs(&mut pem)
                     .map_err(|_| TLSError::General(String::from("No valid certificate was found"))));
                 for c in certs {
                     try_!(tls.root_store.add(&c)
@@ -181,7 +181,7 @@ impl Identity {
 
         let (key, certs) = {
             let mut pem = Cursor::new(buf);
-            let mut certs = try_!(pemfile::certs(&mut pem)
+            let certs = try_!(pemfile::certs(&mut pem)
                 .map_err(|_| TLSError::General(String::from("No valid certificate was found"))));
             pem.set_position(0);
             let mut sk = try_!(pemfile::pkcs8_private_keys(&mut pem)
@@ -260,8 +260,12 @@ impl fmt::Debug for Identity {
 pub(crate) enum TlsBackend {
     #[cfg(feature = "default-tls")]
     Default,
+    #[cfg(feature = "default-tls")]
+    BuiltDefault(native_tls::TlsConnector),
     #[cfg(feature = "rustls-tls")]
-    Rustls
+    Rustls,
+    #[cfg(feature = "rustls-tls")]
+    BuiltRustls(rustls::ClientConfig),
 }
 
 impl Default for TlsBackend {


### PR DESCRIPTION
This PR would allow a user to create a client by supplying a `native-tls::TlsConnector`, rather than just being able to specify either `default-tls` or `rustls`.