### PR TITLE
Enable derive Clone for Certificate & Cert

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -5,6 +5,7 @@ use rustls::{TLSError, ServerCertVerifier, RootCertStore, ServerCertVerified};
 use tokio_rustls::webpki::DNSNameRef;
 
 /// Represent a server X509 certificate.
+#[derive(Clone)]
 pub struct Certificate {
     #[cfg(feature = "default-tls")]
     native: ::native_tls::Certificate,
@@ -13,6 +14,7 @@ pub struct Certificate {
 }
 
 #[cfg(feature = "rustls-tls")]
+#[derive(Clone)]
 enum Cert {
     Der(Vec<u8>),
     Pem(Vec<u8>)


### PR DESCRIPTION
This makes it easier to parse Certificates in advance and pass them as
clones for each client request.

Example:
```
struct Sample {
    rootca: Certificate,
}

impl Sample {
    pub fn do(&self) {
        let _client = Client::builder()
            .add_root_certificate(self.rootca.clone())
            .build()
            .unwrap();
    }
}

fn main() {
    let s = Sample {
        rootca: Certificate::from_pem(&Vec::<u8>::new()).unwrap()
    };
    s.do();
}
```