### PR TITLE
Use radix64 rather than the base64 crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming::http-client"]
 all-features = true
 
 [dependencies]
-base64 = "0.10"
+radix64 = { version = "0.6", default-features = false }
 bytes = "0.4"
 encoding_rs = "0.8"
 futures = "0.1.23"

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use base64::{encode};
 use futures::Future;
+use radix64 as base64;
 use serde::Serialize;
 use serde_json;
 use serde_urlencoded;
@@ -170,7 +170,7 @@ impl RequestBuilder {
             Some(password) => format!("{}:{}", username, password),
             None => format!("{}:", username)
         };
-        let header_value = format!("Basic {}", encode(&auth));
+        let header_value = format!("Basic {}", base64::Display::new(base64::STD, &auth));
         self.header(::header::AUTHORIZATION, &*header_value)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,6 @@
 //! [Proxy]: ./struct.Proxy.html
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
-extern crate base64;
 extern crate bytes;
 extern crate cookie as cookie_crate;
 extern crate cookie_store;
@@ -193,6 +192,7 @@ extern crate mime;
 extern crate mime_guess;
 #[cfg(feature = "default-tls")]
 extern crate native_tls;
+extern crate radix64;
 extern crate serde;
 extern crate serde_json;
 extern crate serde_urlencoded;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -428,8 +428,9 @@ impl fmt::Debug for Custom {
 }
 
 pub(crate) fn encode_basic_auth(username: &str, password: &str) -> HeaderValue {
+    use radix64 as base64;
     let val = format!("{}:{}", username, password);
-    let mut header = format!("Basic {}", base64::encode(&val))
+    let mut header = format!("Basic {}", base64::Display::new(base64::STD, &val))
         .parse::<HeaderValue>()
         .expect("base64 is always valid HeaderValue");
     header.set_sensitive(true);

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use base64::encode;
+use radix64 as base64;
 use serde::Serialize;
 use serde_json;
 use serde_urlencoded;
@@ -238,7 +238,7 @@ impl RequestBuilder {
             Some(password) => format!("{}:{}", username, password),
             None => format!("{}:", username)
         };
-        let header_value = format!("Basic {}", encode(&auth));
+        let header_value = format!("Basic {}", base64::Display::new(base64::STD, &auth));
         self.header(::header::AUTHORIZATION, &*header_value)
     }
 


### PR DESCRIPTION
Cards on the table: I'm the author of the radix64 crate.

This is a relatively small change to more efficiently encode basic auth headers. This is not monumental, but the base64 encoding by radix64 is faster than the base64 crate and by using the Display wrapper it reduces the number of allocations necessary.