### PR TITLE
Make the cookie storage optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,19 @@ matrix:
 
         # Disable default-tls
         - rust: stable
-          env: FEATURES="--no-default-features"
+          env: FEATURES="--no-default-features --features cookies"
 
         # rustls-tls
         - rust: stable
-          env: FEATURES="--no-default-features --features rustls-tls"
+          env: FEATURES="--no-default-features --features rustls-tls,cookies"
 
         # default-tls and rustls-tls
         - rust: stable
-          env: FEATURES="--features rustls-tls"
+          env: FEATURES="--features rustls-tls,cookies"
 
         # default-tls, rustls, and socks!
         - rust: stable
-          env: FEATURES="--features rustls-tls,socks"
+          env: FEATURES="--features rustls-tls,socks,cookies"
 
         - rust: stable
           env: FEATURES="--features hyper-011"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ socks = { version = "0.3.2", optional = true }
 tokio-rustls = { version = "0.9", optional = true }
 trust-dns-resolver = { version = "0.11", optional = true }
 webpki-roots = { version = "0.16", optional = true }
-cookie_store = "0.7.0"
-cookie = "0.12.0"
-time = "0.1.42"
+cookie_store = { version = "0.7.0", optional = true }
+cookie = { version = "0.12.0", optional = true }
+time = { version = "0.1.42", optional = true }
 
 [dev-dependencies]
 env_logger = "0.6"
@@ -60,7 +60,7 @@ doc-comment = "0.3"
 bytes = "0.4"
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "cookies"]
 
 tls = []
 
@@ -72,6 +72,8 @@ rustls-tls = ["hyper-rustls", "tokio-rustls", "webpki-roots", "rustls", "tls"]
 trust-dns = ["trust-dns-resolver"]
 
 hyper-011 = ["hyper-old-types"]
+
+cookies = ["cookie", "cookie_store", "time"]
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6"

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1,5 +1,7 @@
 use std::{fmt, str};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+#[cfg(feature = "cookies")]
+use std::sync::RwLock;
 use std::time::Duration;
 use std::net::IpAddr;
 
@@ -33,6 +35,7 @@ use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use connect::Connector;
 use into_url::{expect_uri, try_uri};
+#[cfg(feature = "cookies")]
 use cookie;
 use redirect::{self, RedirectPolicy, remove_sensitive_headers};
 use {IntoUrl, Method, Proxy, StatusCode, Url};
@@ -86,6 +89,7 @@ struct Config {
     http1_title_case_headers: bool,
     local_address: Option<IpAddr>,
     nodelay: bool,
+    #[cfg(feature = "cookies")]
     cookie_store: Option<cookie::CookieStore>,
 }
 
@@ -122,6 +126,7 @@ impl ClientBuilder {
                 http1_title_case_headers: false,
                 local_address: None,
                 nodelay: false,
+                #[cfg(feature = "cookies")]
                 cookie_store: None,
             },
         }
@@ -210,11 +215,10 @@ impl ClientBuilder {
             .iter()
             .any(|p| p.maybe_has_http_auth());
 
-        let cookie_store = config.cookie_store.map(RwLock::new);
-
         Ok(Client {
             inner: Arc::new(ClientRef {
-                cookie_store,
+                #[cfg(feature = "cookies")]
+                cookie_store: config.cookie_store.map(RwLock::new),
                 gzip: config.gzip,
                 hyper: hyper_client,
                 headers: config.headers,
@@ -429,6 +433,7 @@ impl ClientBuilder {
     /// additional requests.
     ///
     /// By default, no cookie store is used.
+    #[cfg(feature = "cookies")]
     pub fn cookie_store(mut self, enable: bool) -> ClientBuilder {
         self.config.cookie_store = if enable {
             Some(cookie::CookieStore::default())
@@ -567,12 +572,15 @@ impl Client {
         }
 
         // Add cookies from the cookie store.
-        if let Some(cookie_store_wrapper) = self.inner.cookie_store.as_ref() {
-            if headers.get(::header::COOKIE).is_none() {
-                let cookie_store = cookie_store_wrapper.read().unwrap();
-                add_cookie_header(&mut headers, &cookie_store, &url);
+        #[cfg(feature = "cookies")]
+            {
+                if let Some(cookie_store_wrapper) = self.inner.cookie_store.as_ref() {
+                    if headers.get(::header::COOKIE).is_none() {
+                        let cookie_store = cookie_store_wrapper.read().unwrap();
+                        add_cookie_header(&mut headers, &cookie_store, &url);
+                    }
+                }
             }
-        }
 
         if self.inner.gzip &&
             !headers.contains_key(ACCEPT_ENCODING) &&
@@ -678,6 +686,7 @@ impl fmt::Debug for ClientBuilder {
 }
 
 struct ClientRef {
+    #[cfg(feature = "cookies")]
     cookie_store: Option<RwLock<cookie::CookieStore>>,
     gzip: bool,
     headers: HeaderMap,
@@ -748,13 +757,16 @@ impl Future for PendingRequest {
                 Async::Ready(res) => res,
                 Async::NotReady => return Ok(Async::NotReady),
             };
-            if let Some(store_wrapper) = self.client.cookie_store.as_ref() {
-                let mut store = store_wrapper.write().unwrap();
-                let cookies = cookie::extract_response_cookies(&res.headers())
-                    .filter_map(|res| res.ok())
-                    .map(|cookie| cookie.into_inner().into_owned());
-                store.0.store_response_cookies(cookies, &self.url);
-            }
+            #[cfg(feature = "cookies")]
+                {
+                    if let Some(store_wrapper) = self.client.cookie_store.as_ref() {
+                        let mut store = store_wrapper.write().unwrap();
+                        let cookies = cookie::extract_response_cookies(&res.headers())
+                            .filter_map(|res| res.ok())
+                            .map(|cookie| cookie.into_inner().into_owned());
+                        store.0.store_response_cookies(cookies, &self.url);
+                    }
+                }
             let should_redirect = match res.status() {
                 StatusCode::MOVED_PERMANENTLY |
                 StatusCode::FOUND |
@@ -837,10 +849,13 @@ impl Future for PendingRequest {
                                 .expect("valid request parts");
 
                             // Add cookies from the cookie store.
-                            if let Some(cookie_store_wrapper) = self.client.cookie_store.as_ref() {
-                                let cookie_store = cookie_store_wrapper.read().unwrap();
-                                add_cookie_header(&mut self.headers, &cookie_store, &self.url);
-                            }
+                            #[cfg(feature = "cookies")]
+                                {
+                                    if let Some(cookie_store_wrapper) = self.client.cookie_store.as_ref() {
+                                        let cookie_store = cookie_store_wrapper.read().unwrap();
+                                        add_cookie_header(&mut self.headers, &cookie_store, &self.url);
+                                    }
+                                }
 
                             *req.headers_mut() = self.headers.clone();
                             self.in_flight = self.client.hyper.request(req);
@@ -894,6 +909,7 @@ fn make_referer(next: &Url, previous: &Url) -> Option<HeaderValue> {
     referer.as_str().parse().ok()
 }
 
+#[cfg(feature = "cookies")]
 fn add_cookie_header(headers: &mut HeaderMap, cookie_store: &cookie::CookieStore, url: &Url) {
     let header = cookie_store
         .0

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -18,6 +18,7 @@ use serde_json;
 use url::Url;
 
 
+#[cfg(feature = "cookies")]
 use cookie;
 use super::Decoder;
 use super::body::Body;
@@ -76,8 +77,9 @@ impl Response {
     }
 
     /// Retrieve the cookies contained in the response.
-    /// 
+    ///
     /// Note that invalid 'Set-Cookie' headers will be ignored.
+    #[cfg(feature = "cookies")]
     pub fn cookies<'a>(&'a self) -> impl Iterator<Item = cookie::Cookie<'a>> + 'a {
         cookie::extract_response_cookies(&self.headers)
             .filter_map(Result::ok)

--- a/src/client.rs
+++ b/src/client.rs
@@ -392,6 +392,7 @@ impl ClientBuilder {
     ///     .build()
     ///     .unwrap();
     /// ```
+    #[cfg(feature = "cookies")]
     pub fn cookie_store(self, enable: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.cookie_store(enable))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,8 @@
 //!
 //! - **default-tls** *(enabled by default)*: Provides TLS support via the
 //!   `native-tls` library to connect over HTTPS.
+//! - **cookies** *(enabled by default)*: Adds an optional persistent cookie
+//!   storage to the client
 //! - **default-tls-vendored**: Enables the `vendored` feature of `native-tls`.
 //! - **rustls-tls**: Provides TLS support via the `rustls` library.
 //! - **socks**: Provides SOCKS5 proxy support.
@@ -175,7 +177,9 @@
 
 extern crate base64;
 extern crate bytes;
+#[cfg(feature = "cookies")]
 extern crate cookie as cookie_crate;
+#[cfg(feature = "cookies")]
 extern crate cookie_store;
 extern crate encoding_rs;
 #[macro_use]
@@ -196,6 +200,7 @@ extern crate native_tls;
 extern crate serde;
 extern crate serde_json;
 extern crate serde_urlencoded;
+#[cfg(feature = "cookies")]
 extern crate time;
 extern crate tokio;
 extern crate tokio_executor;
@@ -252,6 +257,7 @@ mod async_impl;
 mod connect;
 mod body;
 mod client;
+#[cfg(feature = "cookies")]
 pub mod cookie;
 #[cfg(feature = "trust-dns")]
 mod dns;

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,6 +8,7 @@ use futures::{Async, Poll, Stream};
 use http;
 use serde::de::DeserializeOwned;
 
+#[cfg(feature = "cookies")]
 use cookie;
 use client::KeepCoreThreadAlive;
 use hyper::header::HeaderMap;
@@ -116,6 +117,7 @@ impl Response {
     /// Retrieve the cookies contained in the response.
     ///
     /// Note that invalid 'Set-Cookie' headers will be ignored.
+    #[cfg(feature = "cookies")]
     pub fn cookies<'a>(&'a self) -> impl Iterator< Item = cookie::Cookie<'a> > + 'a {
         cookie::extract_response_cookies(self.headers())
             .filter_map(Result::ok)


### PR DESCRIPTION
This makes three crates optional dependencies. 

While this not a breaking change, this should be released as/with 0.10.0 as rustls users use  `no-default-features`.