### PR TITLE
Remove rust 1.31 pipeline as it's unsupported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,6 @@ matrix:
           # disable default-tls feature since cross-compiling openssl is dragons
           script: cargo build --target "$TARGET" --no-default-features
 
-        # minimum version
-        - rust: 1.31.0
-          script: cargo build
-
 sudo: false
 dist: trusty
 


### PR DESCRIPTION
This build makes every single pipeline fail as we use features that are only stable in newer versions of rust.