### PR TITLE
Upgrade to url v2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,16 @@ flate2 = { version = "^1.0.7", default-features = false, features = ["rust_backe
 log = "0.4"
 mime = "0.3.7"
 mime_guess = "2.0"
+percent-encoding = "2.1"
 serde = "1.0"
 serde_json = "1.0"
-serde_urlencoded = "0.5"
+serde_urlencoded = "0.6.1"
 tokio = { version = "0.1.7", default-features = false, features = ["rt-full", "tcp"] }
 tokio-executor = "0.1.4" # a minimum version so trust-dns-resolver compiles
 tokio-io = "0.1"
 tokio-threadpool = "0.1.8" # a minimum version so tokio compiles
 tokio-timer = "0.2.6" # a minimum version so trust-dns-resolver compiles
-url = "1.2"
+url = "2.1"
 uuid = { version = "0.7", features = ["v4"] }
 
 # Optional deps...
@@ -49,7 +50,7 @@ socks = { version = "0.3.2", optional = true }
 tokio-rustls = { version = "0.10", optional = true }
 trust-dns-resolver = { version = "0.11", optional = true }
 webpki-roots = { version = "0.17", optional = true }
-cookie_store = "0.7.0"
+cookie_store = "0.9.0"
 cookie = "0.12.0"
 time = "0.1.42"
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -4,7 +4,7 @@ use std::io::{self, Cursor, Read};
 
 use bytes::Bytes;
 use futures::{try_ready, Future};
-use hyper::{self};
+use hyper;
 
 use crate::async_impl;
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,16 +1,16 @@
 use std::fmt;
 #[cfg(feature = "socks")]
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::{IntoUrl, Url};
 use http::{header::HeaderValue, Uri};
 use hyper::client::connect::Destination;
+use percent_encoding::percent_decode;
 use std::collections::HashMap;
 use std::env;
 #[cfg(target_os = "windows")]
 use std::error::Error;
-use url::percent_encoding::percent_decode;
 #[cfg(target_os = "windows")]
 use winreg::enums::HKEY_CURRENT_USER;
 #[cfg(target_os = "windows")]
@@ -326,12 +326,14 @@ impl ProxyScheme {
         // Resolve URL to a host and port
         #[cfg(feature = "socks")]
         let to_addr = || {
-            let host_and_port = try_!(url.with_default_port(|url| match url.scheme() {
-                "socks5" | "socks5h" => Ok(1080),
-                _ => Err(()),
+            let addrs = try_!(url.socket_addrs(|| match url.scheme() {
+                "socks5" | "socks5h" => Some(1080),
+                _ => None,
             }));
-            let mut addr = try_!(host_and_port.to_socket_addrs());
-            addr.next().ok_or_else(crate::error::unknown_proxy_scheme)
+            addrs
+                .into_iter()
+                .next()
+                .ok_or_else(crate::error::unknown_proxy_scheme)
         };
 
         let mut scheme = match url.scheme() {


### PR DESCRIPTION
This is dependent on upgrading quite a few other crates in the ecosystem:

PR | Merged | Released
-|-|-
~https://github.com/SergioBenitez/cookie-rs/pull/122~ | ~✓~ | 
 https://github.com/pfernie/cookie_store/pull/8 | ✓ | ✓
https://github.com/nox/serde_urlencoded/pull/59 | ✓ | ✓
rushmorem/publicsuffix#19 | ✓ | ✓

For the moment I've used a Cargo.toml patch block to point at those PRs. We'll need to get actual releases of those dependencies before we can merge this, but wanted to open the PR in the meantime.

Fix #582.