### PR TITLE
Put cookie support behind `cookies` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ socks = { version = "0.3.2", optional = true }
 tokio-rustls = { version = "0.9", optional = true }
 trust-dns-resolver = { version = "0.11", optional = true }
 webpki-roots = { version = "0.16", optional = true }
-cookie_store = "0.7.0"
-cookie = "0.12.0"
+cookie_store = { version = "0.7.0", optional = true }
+cookie = { version = "0.12.0", optional = true }
 time = "0.1.42"
 
 [dev-dependencies]
@@ -60,7 +60,9 @@ doc-comment = "0.3"
 bytes = "0.4"
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "cookies"]
+
+cookies = ["cookie_store", "cookie"]
 
 tls = []
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1,5 +1,7 @@
 use std::{fmt, str};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+#[cfg(feature = "cookies")]
+use std::sync::RwLock;
 use std::time::Duration;
 use std::net::IpAddr;
 
@@ -33,6 +35,7 @@ use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use connect::Connector;
 use into_url::{expect_uri, try_uri};
+#[cfg(feature = "cookies")]
 use cookie;
 use redirect::{self, RedirectPolicy, remove_sensitive_headers};
 use {IntoUrl, Method, Proxy, StatusCode, Url};
@@ -86,6 +89,7 @@ struct Config {
     http1_title_case_headers: bool,
     local_address: Option<IpAddr>,
     nodelay: bool,
+    #[cfg(feature = "cookies")]
     cookie_store: Option<cookie::CookieStore>,
 }
 
@@ -122,6 +126,7 @@ impl ClientBuilder {
                 http1_title_case_headers: false,
                 local_address: None,
                 nodelay: false,
+                #[cfg(feature = "cookies")]
                 cookie_store: None,
             },
         }
@@ -210,10 +215,12 @@ impl ClientBuilder {
             .iter()
             .any(|p| p.maybe_has_http_auth());
 
+        #[cfg(feature = "cookies")]
         let cookie_store = config.cookie_store.map(RwLock::new);
 
         Ok(Client {
             inner: Arc::new(ClientRef {
+                #[cfg(feature = "cookies")]
                 cookie_store,
                 gzip: config.gzip,
                 hyper: hyper_client,
@@ -429,6 +436,7 @@ impl ClientBuilder {
     /// additional requests.
     ///
     /// By default, no cookie store is used.
+    #[cfg(feature = "cookies")]
     pub fn cookie_store(mut self, enable: bool) -> ClientBuilder {
         self.config.cookie_store = if enable {
             Some(cookie::CookieStore::default())
@@ -567,10 +575,13 @@ impl Client {
         }
 
         // Add cookies from the cookie store.
-        if let Some(cookie_store_wrapper) = self.inner.cookie_store.as_ref() {
-            if headers.get(::header::COOKIE).is_none() {
-                let cookie_store = cookie_store_wrapper.read().unwrap();
-                add_cookie_header(&mut headers, &cookie_store, &url);
+        #[cfg(feature = "cookies")]
+        {
+            if let Some(cookie_store_wrapper) = self.inner.cookie_store.as_ref() {
+                if headers.get(::header::COOKIE).is_none() {
+                    let cookie_store = cookie_store_wrapper.read().unwrap();
+                    add_cookie_header(&mut headers, &cookie_store, &url);
+                }
             }
         }
 
@@ -678,6 +689,7 @@ impl fmt::Debug for ClientBuilder {
 }
 
 struct ClientRef {
+    #[cfg(feature = "cookies")]
     cookie_store: Option<RwLock<cookie::CookieStore>>,
     gzip: bool,
     headers: HeaderMap,
@@ -748,12 +760,16 @@ impl Future for PendingRequest {
                 Async::Ready(res) => res,
                 Async::NotReady => return Ok(Async::NotReady),
             };
-            if let Some(store_wrapper) = self.client.cookie_store.as_ref() {
-                let mut store = store_wrapper.write().unwrap();
-                let cookies = cookie::extract_response_cookies(&res.headers())
-                    .filter_map(|res| res.ok())
-                    .map(|cookie| cookie.into_inner().into_owned());
-                store.0.store_response_cookies(cookies, &self.url);
+
+            #[cfg(feature = "cookies")]
+            {
+                if let Some(store_wrapper) = self.client.cookie_store.as_ref() {
+                    let mut store = store_wrapper.write().unwrap();
+                    let cookies = cookie::extract_response_cookies(&res.headers())
+                        .filter_map(|res| res.ok())
+                        .map(|cookie| cookie.into_inner().into_owned());
+                    store.0.store_response_cookies(cookies, &self.url);
+                }
             }
             let should_redirect = match res.status() {
                 StatusCode::MOVED_PERMANENTLY |
@@ -837,9 +853,13 @@ impl Future for PendingRequest {
                                 .expect("valid request parts");
 
                             // Add cookies from the cookie store.
-                            if let Some(cookie_store_wrapper) = self.client.cookie_store.as_ref() {
-                                let cookie_store = cookie_store_wrapper.read().unwrap();
-                                add_cookie_header(&mut self.headers, &cookie_store, &self.url);
+                            //
+                            #[cfg(feature = "cookies")]
+                            {
+                                if let Some(cookie_store_wrapper) = self.client.cookie_store.as_ref() {
+                                    let cookie_store = cookie_store_wrapper.read().unwrap();
+                                    add_cookie_header(&mut self.headers, &cookie_store, &self.url);
+                                }
                             }
 
                             *req.headers_mut() = self.headers.clone();
@@ -894,6 +914,7 @@ fn make_referer(next: &Url, previous: &Url) -> Option<HeaderValue> {
     referer.as_str().parse().ok()
 }
 
+#[cfg(feature = "cookies")]
 fn add_cookie_header(headers: &mut HeaderMap, cookie_store: &cookie::CookieStore, url: &Url) {
     let header = cookie_store
         .0

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -18,6 +18,7 @@ use serde_json;
 use url::Url;
 
 
+#[cfg(feature = "cookies")]
 use cookie;
 use super::Decoder;
 use super::body::Body;
@@ -78,6 +79,7 @@ impl Response {
     /// Retrieve the cookies contained in the response.
     /// 
     /// Note that invalid 'Set-Cookie' headers will be ignored.
+    #[cfg(feature = "cookies")]
     pub fn cookies<'a>(&'a self) -> impl Iterator<Item = cookie::Cookie<'a>> + 'a {
         cookie::extract_response_cookies(&self.headers)
             .filter_map(Result::ok)

--- a/src/client.rs
+++ b/src/client.rs
@@ -392,6 +392,7 @@ impl ClientBuilder {
     ///     .build()
     ///     .unwrap();
     /// ```
+    #[cfg(feature = "cookies")]
     pub fn cookie_store(self, enable: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.cookie_store(enable))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
-#![cfg_attr(test, deny(warnings))]
+//#![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/reqwest/0.9.19")]
 
 //! # reqwest
@@ -175,7 +175,9 @@
 
 extern crate base64;
 extern crate bytes;
+#[cfg(feature = "cookies")]
 extern crate cookie as cookie_crate;
+#[cfg(feature = "cookies")]
 extern crate cookie_store;
 extern crate encoding_rs;
 #[macro_use]
@@ -252,6 +254,7 @@ mod async_impl;
 mod connect;
 mod body;
 mod client;
+#[cfg(feature = "cookies")]
 pub mod cookie;
 #[cfg(feature = "trust-dns")]
 mod dns;

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,6 +8,7 @@ use futures::{Async, Poll, Stream};
 use http;
 use serde::de::DeserializeOwned;
 
+#[cfg(feature = "cookies")]
 use cookie;
 use client::KeepCoreThreadAlive;
 use hyper::header::HeaderMap;
@@ -116,6 +117,7 @@ impl Response {
     /// Retrieve the cookies contained in the response.
     ///
     /// Note that invalid 'Set-Cookie' headers will be ignored.
+    #[cfg(feature = "cookies")]
     pub fn cookies<'a>(&'a self) -> impl Iterator< Item = cookie::Cookie<'a> > + 'a {
         cookie::extract_response_cookies(self.headers())
             .filter_map(Result::ok)

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -4,6 +4,7 @@ extern crate reqwest;
 mod support;
 
 #[test]
+#[cfg(feature = "cookies")]
 fn cookie_response_accessor() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
     let client = reqwest::async::Client::new();
@@ -79,6 +80,7 @@ fn cookie_response_accessor() {
 }
 
 #[test]
+#[cfg(feature = "cookies")]
 fn cookie_store_simple() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
     let client = reqwest::async::Client::builder().cookie_store(true).build().unwrap();
@@ -123,6 +125,7 @@ fn cookie_store_simple() {
 }
 
 #[test]
+#[cfg(feature = "cookies")]
 fn cookie_store_overwrite_existing() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
     let client = reqwest::async::Client::builder().cookie_store(true).build().unwrap();
@@ -187,6 +190,7 @@ fn cookie_store_overwrite_existing() {
 }
 
 #[test]
+#[cfg(feature = "cookies")]
 fn cookie_store_max_age() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
     let client = reqwest::async::Client::builder().cookie_store(true).build().unwrap();
@@ -230,6 +234,7 @@ fn cookie_store_max_age() {
 }
 
 #[test]
+#[cfg(feature = "cookies")]
 fn cookie_store_expires() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
     let client = reqwest::async::Client::builder().cookie_store(true).build().unwrap();
@@ -273,6 +278,7 @@ fn cookie_store_expires() {
 }
 
 #[test]
+#[cfg(feature = "cookies")]
 fn cookie_store_path() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
     let client = reqwest::async::Client::builder().cookie_store(true).build().unwrap();

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -389,6 +389,7 @@ fn test_invalid_location_stops_redirect_gh484() {
 }
 
 #[test]
+#[cfg(feature = "cookies")]
 fn test_redirect_302_with_set_cookies() {
     let code = 302;
     let client = reqwest::ClientBuilder::new().cookie_store(true).build().unwrap();


### PR DESCRIPTION
At least in my case I've never wanted cookies, and this removes some dependencies, build size and a little bit of build time as well.

Fair enough if this doesn't align with the batteries-included approach of this library, but I would like to try to chop of unused features (I also have a gzip feature in the pipeline, but fixing the tests for that is very annoying, due to the `accept-encoding: gzip`-s everywhere).

Let me know if there are any style matters I should consider, thanks!