### PR TITLE
Change Part::stream to reqwest::r#async::Chunk

### DIFF
--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -165,6 +165,7 @@ impl Chunk {
         }
     }
 }
+
 impl Buf for Chunk {
     fn bytes(&self) -> &[u8] {
         self.inner.bytes()
@@ -210,10 +211,40 @@ impl IntoIterator for Chunk {
     }
 }
 
+impl From<Vec<u8>> for Chunk {
+    fn from(v: Vec<u8>) -> Chunk {
+        Chunk { inner: v.into() }
+    }
+}
+
+impl From<&'static [u8]> for Chunk {
+    fn from(slice: &'static [u8]) -> Chunk {
+        Chunk { inner: slice.into() }
+    }
+}
+
+impl From<String> for Chunk {
+    fn from(s: String) -> Chunk {
+        Chunk { inner: s.into() }
+    }
+}
+
+impl From<&'static str> for Chunk {
+    fn from(slice: &'static str) -> Chunk {
+        Chunk { inner: slice.into() }
+    }
+}
+
+impl From<Bytes> for Chunk {
+    fn from(bytes: Bytes) -> Chunk {
+        Chunk { inner: bytes.into() }
+    }
+}
+
 impl From<Chunk> for hyper::Chunk {
-  fn from(val: Chunk) -> hyper::Chunk {
-    val.inner
-  }
+    fn from(val: Chunk) -> hyper::Chunk {
+        val.inner
+    }
 }
 
 impl fmt::Debug for Body {

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use futures::{Future, Stream};
 use tokio::runtime::current_thread::Runtime;
 
-use reqwest::r#async::Client;
+use reqwest::r#async::{Chunk, Client};
 use reqwest::r#async::multipart::{Form, Part};
 
 use bytes::Bytes;
@@ -105,7 +105,7 @@ fn response_json() {
 fn multipart() {
     let _ = env_logger::try_init();
 
-    let stream = futures::stream::once::<_, hyper::Error>(Ok(hyper::Chunk::from("part1 part2".to_owned())));
+    let stream = futures::stream::once::<_, hyper::Error>(Ok(Chunk::from("part1 part2".to_owned())));
     let part = Part::stream(stream);
 
     let form = Form::new()


### PR DESCRIPTION
Changes `Part::stream` to take a stream of `Into<reqwest::r#async::Chunk>`s instead of `Into<hyper::Chunk>`s, implements more `From` conversions for `reqwest::r#async::Chunk` and updates the relevant tests.

Closes #579.