### PR TITLE
Futures 0.3 [WIP, requesting input]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 target
 Cargo.lock
 *.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,13 @@ time = "0.1.42"
 
 [dev-dependencies]
 env_logger = "0.6"
+failure = "0.1"
+failure_derive = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 libflate = "0.1"
 doc-comment = "0.3"
 bytes = "0.4"
+tokio-fs = { version = "0.2.0-alpha.1" }
 
 [features]
 default = ["default-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ all-features = true
 base64 = "0.10"
 bytes = "0.4"
 encoding_rs = "0.8"
-futures-preview = { version = "=0.3.0-alpha.17", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.17", features = ["async-await", "compat", "io-compat", "nightly"] }
 http = "0.1.15"
-hyper = "0.12.22"
+hyper = { git = "https://github.com/hyperium/hyper.git", branch = "master" }
 flate2 = { version = "^1.0.7", default-features = false, features = ["rust_backend"] }
 log = "0.4"
 mime = "0.3.7"
@@ -30,24 +30,20 @@ mime_guess = "2.0"
 serde = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.5"
-tokio = { version = "0.1.7", default-features = false, features = ["rt-full", "tcp"] }
-tokio-executor = "0.1.4" # a minimum version so trust-dns-resolver compiles
-tokio-io = "0.1"
-tokio-threadpool = "0.1.8" # a minimum version so tokio compiles
-tokio-timer = "0.2.6" # a minimum version so trust-dns-resolver compiles
+tokio = { version = "0.2.0-alpha.1", default-features = false, features = ["rt-full", "tcp"] }
 url = "1.2"
 uuid = { version = "0.7", features = ["v4"] }
-futures-timer = "0.3"
 
 # Optional deps...
 
-hyper-old-types = { version = "0.11", optional = true, features = ["compat"] }
-hyper-rustls = { version = "^0.17.1", optional = true }
-hyper-tls = { version = "0.3.2", optional = true }
+#hyper-old-types = { git = "https://github.com/hyperium/hyper.git", branch = "master", optional = true, features = ["compat"] }
+hyper-rustls = { git = "https://github.com/dbcfd/hyper-rustls.git", branch = "master", optional = true }
+hyper-tls = { git = "https://github.com/hyperium/hyper-tls.git", branch = "master", optional = true }
 native-tls = { version = "0.2", optional = true }
 rustls = { version = "0.16", features = ["dangerous_configuration"], optional = true }
 socks = { version = "0.3.2", optional = true }
-tokio-rustls = { version = "0.10", optional = true }
+tokio-tls = { version = "0.3.0-alpha.1", optional = true }
+tokio-rustls = { version = "0.12.0-alpha.1", optional = true }
 trust-dns-resolver = { version = "0.11", optional = true }
 webpki-roots = { version = "0.17", optional = true }
 cookie_store = "0.7.0"
@@ -57,8 +53,6 @@ time = "0.1.42"
 [dev-dependencies]
 env_logger = "0.6"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "0.1.7", default-features = false, features = ["rt-full", "tcp", "fs"] }
-tokio-tcp = "0.1"
 libflate = "0.1"
 doc-comment = "0.3"
 bytes = "0.4"
@@ -68,14 +62,12 @@ default = ["default-tls"]
 
 tls = []
 
-default-tls = ["hyper-tls", "native-tls", "tls"]
+default-tls = ["hyper-tls", "native-tls", "tls", "tokio-tls"]
 default-tls-vendored = ["default-tls", "native-tls/vendored"]
 
 rustls-tls = ["hyper-rustls", "tokio-rustls", "webpki-roots", "rustls", "tls"]
 
 trust-dns = ["trust-dns-resolver"]
-
-hyper-011 = ["hyper-old-types"]
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tokio-threadpool = "0.1.8" # a minimum version so tokio compiles
 tokio-timer = "0.2.6" # a minimum version so trust-dns-resolver compiles
 url = "1.2"
 uuid = { version = "0.7", features = ["v4"] }
+futures-timer = "0.3"
 
 # Optional deps...
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 base64 = "0.10"
 bytes = "0.4"
 encoding_rs = "0.8"
-futures = "0.1.23"
+futures-preview = { version = "=0.3.0-alpha.17", features = ["compat"] }
 http = "0.1.15"
 hyper = "0.12.22"
 flate2 = { version = "^1.0.7", default-features = false, features = ["rust_backend"] }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,11 +1,12 @@
+#![feature(async_await)]
 #![deny(warnings)]
 use std::mem;
 use std::io::{self, Cursor};
-use futures::{Future, Stream, TryStreamExt};
+use futures::TryStreamExt;
 use reqwest::r#async::{Client, Decoder};
 
 #[tokio::main]
-fn main() -> Result<(), reqwest::Error> {
+async fn main() -> Result<(), reqwest::Error> {
     let mut res = Client::new()
         .get("https://hyper.rs")
         .send()
@@ -17,10 +18,9 @@ fn main() -> Result<(), reqwest::Error> {
     let body: Result<_, _> = body.try_concat().await;
 
     let mut body = Cursor::new(body?);
-    io::copy(&mut body, &mut io::stdout())
-        .map_err(|err| {
-            println!("stdout error: {}", err);
-        })?;
+    if let Err(err) = io::copy(&mut body, &mut io::stdout()) {
+        println!("stdout error: {}", err);
+    };
 
     Ok(())
 }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 use std::mem;
 use std::io::{self, Cursor};

--- a/examples/async_multiple_requests.rs
+++ b/examples/async_multiple_requests.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 use reqwest::r#async::{Client, Response};

--- a/examples/async_stream.rs
+++ b/examples/async_stream.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 use std::io::{self, Cursor};
 use std::mem;

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -1,6 +1,7 @@
-extern crate reqwest;
+#![feature(async_await)]
 
-fn main() {
+#[tokio::main]
+async fn main() {
     reqwest::Client::new()
         .post("http://www.baidu.com")
         .form(&[("one", "1")])

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 
 #[tokio::main]
 async fn main() {

--- a/examples/json_dynamic.rs
+++ b/examples/json_dynamic.rs
@@ -3,14 +3,14 @@
 //! This is useful for some ad-hoc experiments and situations when you don't
 //! really care about the structure of the JSON and just need to display it or
 //! process it at runtime.
-extern crate reqwest;
-#[macro_use] extern crate serde_json;
+#![feature(async_await)]
 
-fn main() -> Result<(), reqwest::Error> {
+#[tokio::main]
+async fn main() -> Result<(), reqwest::Error> {
     let echo_json: serde_json::Value = reqwest::Client::new()
         .post("https://jsonplaceholder.typicode.com/posts")
         .json(
-            &json!({
+            &serde_json::json!({
                 "title": "Reqwest.rs",
                 "body": "https://docs.rs/reqwest",
                 "userId": 1

--- a/examples/json_dynamic.rs
+++ b/examples/json_dynamic.rs
@@ -3,7 +3,6 @@
 //! This is useful for some ad-hoc experiments and situations when you don't
 //! really care about the structure of the JSON and just need to display it or
 //! process it at runtime.
-#![feature(async_await)]
 
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {

--- a/examples/json_typed.rs
+++ b/examples/json_typed.rs
@@ -3,7 +3,6 @@
 //! In contrast to the arbitrary JSON example, this brings up the full power of
 //! Rust compile-time type system guaranties though it requires a little bit
 //! more code.
-#![feature(async_await)]
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/examples/json_typed.rs
+++ b/examples/json_typed.rs
@@ -3,10 +3,7 @@
 //! In contrast to the arbitrary JSON example, this brings up the full power of
 //! Rust compile-time type system guaranties though it requires a little bit
 //! more code.
-extern crate reqwest;
-extern crate serde;
-extern crate serde_json;
-
+#![feature(async_await)]
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -18,7 +15,8 @@ struct Post {
     user_id: i32,
 }
 
-fn main() -> Result<(), reqwest::Error> {
+#[tokio::main]
+async fn main() -> Result<(), reqwest::Error> {
     let new_post = Post {
         id: None,
         title: "Reqwest.rs".into(),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,22 +1,30 @@
-#![deny(warnings)]
-
 //! `cargo run --example simple`
+#![feature(async_await)]
+#![deny(warnings)]
+use failure::Fail;
 
-extern crate reqwest;
-extern crate env_logger;
+#[derive(Debug, Fail)]
+pub enum Error {
+    #[fail(display = "Io Error")]
+    Io(#[fail(cause)] std::io::Error),
+    #[fail(display = "Reqwest error")]
+    Reqwest(#[fail(cause)] reqwest::Error),
+}
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Error> {
     env_logger::init();
 
     println!("GET https://www.rust-lang.org");
 
-    let mut res = reqwest::get("https://www.rust-lang.org/")?;
+    let res = reqwest::get("https://www.rust-lang.org/").map_err(Error::Reqwest)?;
 
     println!("Status: {}", res.status());
     println!("Headers:\n{:?}", res.headers());
 
     // copy the response body directly to stdout
-    std::io::copy(&mut res, &mut std::io::stdout())?;
+    //TODO: Read/Write
+//    std::io::copy(&mut res, &mut std::io::stdout()).map_err(Error::Io)?;
 
     println!("\n\nDone.");
     Ok(())

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,4 @@
 //! `cargo run --example simple`
-#![feature(async_await)]
 #![deny(warnings)]
 use failure::Fail;
 

--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -24,7 +24,11 @@ impl Body {
     pub(crate) fn content_length(&self) -> Option<u64> {
         match self.inner {
             Inner::Reusable(ref bytes) => Some(bytes.len() as u64),
-            Inner::Hyper { ref body, .. } => body.content_length(),
+            Inner::Hyper { ref body, .. } => {
+                body.size_hint().exact()
+                //removed from hyper
+//                body.content_length()
+            },
         }
     }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use std::net::IpAddr;
 
 use bytes::Bytes;
-use futures::{Async, Future, Poll};
+use futures::{Future, Poll};
 use crate::header::{
     Entry,
     HeaderMap,
@@ -720,10 +720,10 @@ impl Pending {
 }
 
 impl Future for Pending {
-    type Item = Response;
-    type Error = crate::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    type Output = Result<Response, crate::Error>;
+
+    fn poll(&mut self) -> Poll<Self::Output> {
         match self.inner {
             PendingInner::Request(ref mut req) => req.poll(),
             PendingInner::Error(ref mut err) => Err(err.take().expect("Pending error polled more than once")),
@@ -732,20 +732,19 @@ impl Future for Pending {
 }
 
 impl Future for PendingRequest {
-    type Item = Response;
-    type Error = crate::Error;
+    type Output = Result<Response, crate::Error>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(&mut self) -> Poll<Self::Output> {
         if let Some(ref mut delay) = self.timeout {
-            if let Async::Ready(()) = try_!(delay.poll(), &self.url) {
+            if let Poll::Ready(()) = try_!(delay.poll(), &self.url) {
                 return Err(crate::error::timedout(Some(self.url.clone())));
             }
         }
 
         loop {
             let res = match try_!(self.in_flight.poll(), &self.url) {
-                Async::Ready(res) => res,
-                Async::NotReady => return Ok(Async::NotReady),
+                Poll::Ready(res) => res,
+                Poll::Pending => return Ok(Poll::Pending),
             };
             if let Some(store_wrapper) = self.client.cookie_store.as_ref() {
                 let mut store = store_wrapper.write().unwrap();
@@ -858,7 +857,7 @@ impl Future for PendingRequest {
                 }
             }
             let res = Response::new(res, self.url.clone(), self.client.gzip, self.timeout.take());
-            return Ok(Async::Ready(res));
+            return Ok(Poll::Ready(res));
         }
     }
 }

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -22,13 +22,13 @@ The following types directly support the gzip compression case:
 
 use std::pin::Pin;
 use std::fmt;
-use std::mem;
-use std::cmp;
-use std::io::{self, Read};
-
-use bytes::{Buf, BufMut, BytesMut};
-use flate2::read::GzDecoder;
-use std::future::Future;
+//TODO: Read for ReadableChunks
+//use std::mem;
+//use std::cmp;
+//use std::io::{self, Read};
+//use bytes::{Buf, BufMut, BytesMut};
+//use flate2::read::GzDecoder;
+//use std::future::Future;
 use std::task::{Poll, Context};
 use futures::Stream;
 use hyper::{HeaderMap};
@@ -39,7 +39,8 @@ use log::{warn};
 use super::{Body, Chunk};
 use crate::error;
 
-const INIT_BUFFER_SIZE: usize = 8192;
+//TODO: Needed?
+//const INIT_BUFFER_SIZE: usize = 8192;
 
 /// A response decompressor over a non-blocking stream of chunks.
 ///
@@ -51,23 +52,25 @@ pub struct Decoder {
 enum Inner {
     /// A `PlainText` decoder just returns the response content as is.
     PlainText(Body),
-    /// A `Gzip` decoder will uncompress the gzipped response content before returning it.
-    Gzip(Gzip),
-    /// A decoder that doesn't have a value yet.
-    Pending(Pending)
+    //TODO: Read for ReadableChunks
+//    /// A `Gzip` decoder will uncompress the gzipped response content before returning it.
+//    Gzip(Gzip),
+//    /// A decoder that doesn't have a value yet.
+//    Pending(Pending)
 }
 
 /// A future attempt to poll the response body for EOF so we know whether to use gzip or not.
-struct Pending {
-    body: ReadableChunks<Body>,
-}
+//struct Pending {
+//    body: ReadableChunks<Body>,
+//}
 
+//TODO: Read for ReadableChunks
 /// A gzip decoder that reads from a `flate2::read::GzDecoder` into a `BytesMut` and emits the results
 /// as a `Chunk`.
-struct Gzip {
-    inner: Box<GzDecoder<ReadableChunks<Body>>>,
-    buf: BytesMut,
-}
+//struct Gzip {
+//    inner: Box<GzDecoder<ReadableChunks<Body>>>,
+//    buf: BytesMut,
+//}
 
 impl fmt::Debug for Decoder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -100,12 +103,13 @@ impl Decoder {
     /// A gzip decoder.
     ///
     /// This decoder will buffer and decompress chunks that are gzipped.
-    #[inline]
-    fn gzip(body: Body) -> Decoder {
-        Decoder {
-            inner: Inner::Pending(Pending { body: ReadableChunks::new(body) })
-        }
-    }
+//TODO: Read for ReadableChunks
+//    #[inline]
+//    fn gzip(body: Body) -> Decoder {
+//        Decoder {
+//            inner: Inner::Pending(Pending { body: ReadableChunks::new(body) })
+//        }
+//    }
 
     /// Constructs a Decoder from a hyper request.
     ///
@@ -142,7 +146,9 @@ impl Decoder {
             headers.remove(CONTENT_LENGTH);
         }
         if is_gzip {
-            Decoder::gzip(body)
+            unimplemented!("GZIP not supported yet")
+            //TODO: Read for ReadableChunks
+//            Decoder::gzip(body)
         } else {
             Decoder::plain_text(body)
         }
@@ -152,93 +158,102 @@ impl Decoder {
 impl Stream for Decoder {
     type Item = Result<Chunk, error::Error>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        // Do a read or poll for a pendidng decoder value.
-        let new_value = match self.inner {
-            Inner::Pending(ref mut future) => {
-                match future.poll() {
-                    Ok(Poll::Ready(inner)) => inner,
-                    Ok(Poll::Pending) => return Ok(Poll::Pending),
-                    Err(e) => return Err(e)
-                }
-            },
-            Inner::PlainText(ref mut body) => return body.poll(),
-            Inner::Gzip(ref mut decoder) => return decoder.poll()
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        // Do a read or poll for a pending decoder value.
+        let _new_value = match self.inner {
+//            Inner::Pending(ref mut future) => {
+//                match Pin::new(future).poll(cx) {
+//                    Poll::Ready(Ok(inner)) => inner,
+//                    Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
+//                    Poll::Pending => return Poll::Pending,
+//                }
+//            },
+            Inner::PlainText(ref mut body) => return Pin::new(body).poll_next(cx),
+//            Inner::Gzip(ref mut decoder) => return Pin::new(decoder).poll_next(cx)
         };
 
-        self.inner = new_value;
-        self.poll()
+//        self.inner = new_value;
+//        self.poll_next(cx)
     }
 }
 
-impl Future for Pending {
+//impl Future for Pending {
+//
+//    type Output = Result<Inner, error::Error>;
+//
+//    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+//        let body_state = unsafe {
+//            let p = self.as_mut().map_unchecked_mut(|me| &mut me.body);
+//            match p.poll_next(cx) {
+//                Poll::Pending => return Poll::Pending,
+//                Poll::Ready(None) => return Poll::Ready(Ok(Inner::PlainText(Body::empty()))),
+//                Poll::Ready(Some(Ok(state))) => state,
+//                Poll::Ready(Some(Err(e))) => return Poll::Ready(Err(e))
+//            }
+//        };
+//
+//        let _body = mem::replace(&mut self.body, ReadableChunks::new(Body::empty()));
+//        match body_state {
+//            StreamState::Eof => Poll::Ready(Ok(Inner::PlainText(Body::empty()))),
+//            //TODO: Read for ReadableChunks
+//            StreamState::HasMore => {
+//                unimplemented!("Gzip needs Read + Write over AsyncRead + AsyncWrite")
+////                Poll::Ready(Ok(Inner::Gzip(Gzip::new(body))))
+//            }
+//        }
+//    }
+//}
 
-    type Output = Result<Inner, error::Error>;
-
-    fn poll(&mut self) -> Poll<Self::Output> {
-        let body_state = match self.body.poll_stream() {
-            Ok(Poll::Ready(state)) => state,
-            Ok(Poll::Pending) => return Ok(Poll::Pending),
-            Err(e) => return Err(e)
-        };
-
-        let body = mem::replace(&mut self.body, ReadableChunks::new(Body::empty()));
-        match body_state {
-            StreamState::Eof => Poll::Ready(Inner::PlainText(Body::empty())),
-            StreamState::HasMore => Poll::Ready(Inner::Gzip(Gzip::new(body)))
-        }
-    }
-}
-
-impl Gzip {
-    fn new(stream: ReadableChunks<Body>) -> Self {
-        Gzip {
-            buf: BytesMut::with_capacity(INIT_BUFFER_SIZE),
-            inner: Box::new(GzDecoder::new(stream)),
-        }
-    }
-}
-
-impl Stream for Gzip {
-    type Item = Result<Chunk, error::Error>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        if self.buf.remaining_mut() == 0 {
-            self.buf.reserve(INIT_BUFFER_SIZE);
-        }
-
-        // The buffer contains uninitialised memory so getting a readable slice is unsafe.
-        // We trust the `flate2` and `miniz` writer not to read from the memory given.
-        //
-        // To be safe, this memory could be zeroed before passing to `flate2`.
-        // Otherwise we might need to deal with the case where `flate2` panics.
-        let read = try_io!(self.inner.read(unsafe { self.buf.bytes_mut() }));
-
-        if read == 0 {
-            // If GzDecoder reports EOF, it doesn't necessarily mean the
-            // underlying stream reached EOF (such as the `0\r\n\r\n`
-            // header meaning a chunked transfer has completed). If it
-            // isn't polled till EOF, the connection may not be able
-            // to be re-used.
-            //
-            // See https://github.com/seanmonstar/reqwest/issues/508.
-            let inner_read = try_io!(self.inner.get_mut().read(&mut [0]));
-            if inner_read == 0 {
-                Ok(Poll::Ready(None))
-            } else {
-                Err(error::from(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "unexpected data after gzip decoder signaled end-of-file",
-                )))
-            }
-        } else {
-            unsafe { self.buf.advance_mut(read) };
-            let chunk = Chunk::from_chunk(self.buf.split_to(read).freeze());
-
-            Ok(Poll::Ready(Some(chunk)))
-        }
-    }
-}
+//TODO: Read for ReadableChunks
+//impl Gzip {
+//    fn new(stream: ReadableChunks<Body>) -> Self {
+//        Gzip {
+//            buf: BytesMut::with_capacity(INIT_BUFFER_SIZE),
+//            inner: Box::new(GzDecoder::new(stream)),
+//        }
+//    }
+//}
+//
+//impl Stream for Gzip {
+//    type Item = Result<Chunk, error::Error>;
+//
+//    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+//        if self.buf.remaining_mut() == 0 {
+//            self.buf.reserve(INIT_BUFFER_SIZE);
+//        }
+//
+//        // The buffer contains uninitialised memory so getting a readable slice is unsafe.
+//        // We trust the `flate2` and `miniz` writer not to read from the memory given.
+//        //
+//        // To be safe, this memory could be zeroed before passing to `flate2`.
+//        // Otherwise we might need to deal with the case where `flate2` panics.
+//        let read = try_io!(self.inner.read(unsafe { self.buf.bytes_mut() }));
+//
+//        if read == 0 {
+//            // If GzDecoder reports EOF, it doesn't necessarily mean the
+//            // underlying stream reached EOF (such as the `0\r\n\r\n`
+//            // header meaning a chunked transfer has completed). If it
+//            // isn't polled till EOF, the connection may not be able
+//            // to be re-used.
+//            //
+//            // See https://github.com/seanmonstar/reqwest/issues/508.
+//            let inner_read = try_io!(self.inner.get_mut().read(&mut [0]));
+//            if inner_read == 0 {
+//                Poll::Ready(None)
+//            } else {
+//                Poll::Ready(Some(Err(error::from(io::Error::new(
+//                    io::ErrorKind::InvalidData,
+//                    "unexpected data after gzip decoder signaled end-of-file",
+//                )))))
+//            }
+//        } else {
+//            unsafe { self.buf.advance_mut(read) };
+//            let chunk = Chunk::from_chunk(self.buf.split_to(read).freeze());
+//
+//            Poll::Ready(Some(Ok(chunk)))
+//        }
+//    }
+//}
 
 /// A `Read`able wrapper over a stream of chunks.
 pub struct ReadableChunks<S> {
@@ -249,13 +264,13 @@ pub struct ReadableChunks<S> {
 enum ReadState {
     /// A chunk is ready to be read from.
     Ready(Chunk),
-    /// The next chunk isn't ready yet.
-    NotReady,
+//    /// The next chunk isn't ready yet.
+//    NotReady,
     /// The stream has finished.
     Eof,
 }
 
-enum StreamState {
+pub enum StreamState {
     /// More bytes can be read from the stream.
     HasMore,
     /// No more bytes can be read from the stream.
@@ -270,6 +285,12 @@ impl<S> ReadableChunks<S> {
             stream,
         }
     }
+
+    fn state(self: Pin<&mut Self>) -> &mut ReadState {
+        unsafe {
+            &mut Pin::get_unchecked_mut(self).state
+        }
+    }
 }
 
 impl<S> fmt::Debug for ReadableChunks<S> {
@@ -279,70 +300,77 @@ impl<S> fmt::Debug for ReadableChunks<S> {
     }
 }
 
-impl<S> Read for ReadableChunks<S>
-where
-    S: Stream<Item = Result<Chunk, error::Error>>,
-{
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        loop {
-            let ret;
-            match self.state {
-                ReadState::Ready(ref mut chunk) => {
-                    let len = cmp::min(buf.len(), chunk.remaining());
+//impl<S> Read for ReadableChunks<S>
+//where
+//    S: Stream<Item = Result<Chunk, error::Error>>,
+//{
+//    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+//        loop {
+//            let ret;
+//            match self.state {
+//                ReadState::Ready(ref mut chunk) => {
+//                    let len = cmp::min(buf.len(), chunk.remaining());
+//
+//                    buf[..len].copy_from_slice(&chunk[..len]);
+//                    chunk.advance(len);
+//                    if chunk.is_empty() {
+//                        ret = len;
+//                    } else {
+//                        return Ok(len);
+//                    }
+//                },
+//                ReadState::NotReady => {
+//                    match self.poll_stream(cx) {
+//                        Ok(Poll::Ready(StreamState::HasMore)) => continue,
+//                        Ok(Poll::Ready(StreamState::Eof)) => {
+//                            return Ok(0)
+//                        },
+//                        Ok(Poll::Pending) => {
+//                            return Err(io::ErrorKind::WouldBlock.into())
+//                        },
+//                        Err(e) => {
+//                            return Err(error::into_io(e))
+//                        }
+//                    }
+//                },
+//                ReadState::Eof => return Ok(0),
+//            }
+//            self.state = ReadState::NotReady;
+//            return Ok(ret);
+//        }
+//    }
+//}
 
-                    buf[..len].copy_from_slice(&chunk[..len]);
-                    chunk.advance(len);
-                    if chunk.is_empty() {
-                        ret = len;
-                    } else {
-                        return Ok(len);
-                    }
-                },
-                ReadState::NotReady => {
-                    match self.poll_stream() {
-                        Ok(Poll::Ready(StreamState::HasMore)) => continue,
-                        Ok(Poll::Ready(StreamState::Eof)) => {
-                            return Ok(0)
-                        },
-                        Ok(Poll::Pending) => {
-                            return Err(io::ErrorKind::WouldBlock.into())
-                        },
-                        Err(e) => {
-                            return Err(error::into_io(e))
-                        }
-                    }
-                },
-                ReadState::Eof => return Ok(0),
-            }
-            self.state = ReadState::NotReady;
-            return Ok(ret);
-        }
-    }
-}
-
-impl<S> ReadableChunks<S>
+impl<S> Stream for ReadableChunks<S>
     where S: Stream<Item = Result<Chunk, error::Error>>
 {
+    type Item = Result<StreamState, error::Error>;
+
     /// Poll the readiness of the inner reader.
     ///
     /// This function will update the internal state and return a simplified
     /// version of the `ReadState`.
-    fn poll_stream(&mut self) -> Poll<Result<StreamState, error::Error>> {
-        match self.stream.poll() {
-            Ok(Poll::Ready(Some(chunk))) => {
-                self.state = ReadState::Ready(chunk);
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Result<StreamState, error::Error>>> {
+        let r = unsafe {
+            let p = self.as_mut().map_unchecked_mut(|me| &mut me.stream);
+            p.poll_next(cx)
+        };
 
-                Ok(Poll::Ready(StreamState::HasMore))
-            },
-            Ok(Poll::Ready(None)) => {
-                self.state = ReadState::Eof;
+        match r {
+            Poll::Ready(Some(Ok(chunk))) => {
+                *self.state() = ReadState::Ready(chunk);
 
-                Ok(Poll::Ready(StreamState::Eof))
+                Poll::Ready(Some(Ok(StreamState::HasMore)))
             },
-            Ok(Poll::Pending) => {
-                Ok(Poll::Pending)
+            Poll::Ready(None) => {
+                *self.state() = ReadState::Eof;
+
+                Poll::Ready(Some(Ok(StreamState::Eof)))
             },
-            Err(e) => Err(e)
+            Poll::Pending => {
+                Poll::Pending
+            },
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e)))
         }
     }
 }

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -278,13 +278,13 @@ pub enum StreamState {
 }
 
 impl<S> ReadableChunks<S> {
-    #[inline]
-    pub(crate) fn new(stream: S) -> Self {
-        ReadableChunks {
-            state: ReadState::NotReady,
-            stream,
-        }
-    }
+//    #[inline]
+//    pub(crate) fn new(stream: S) -> Self {
+//        ReadableChunks {
+//            state: ReadState::NotReady,
+//            stream,
+//        }
+//    }
 
     fn state(self: Pin<&mut Self>) -> &mut ReadState {
         unsafe {

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -20,6 +20,7 @@ The following types directly support the gzip compression case:
 - `Pending` is a non-blocking constructor for a `Decoder` in case the body needs to be checked for EOF
 */
 
+use std::pin::Pin;
 use std::fmt;
 use std::mem;
 use std::cmp;
@@ -27,7 +28,9 @@ use std::io::{self, Read};
 
 use bytes::{Buf, BufMut, BytesMut};
 use flate2::read::GzDecoder;
-use futures::{Async, Future, Poll, Stream};
+use std::future::Future;
+use std::task::{Poll, Context};
+use futures::Stream;
 use hyper::{HeaderMap};
 use hyper::header::{CONTENT_ENCODING, CONTENT_LENGTH, TRANSFER_ENCODING};
 
@@ -147,16 +150,15 @@ impl Decoder {
 }
 
 impl Stream for Decoder {
-    type Item = Chunk;
-    type Error = error::Error;
+    type Item = Result<Chunk, error::Error>;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         // Do a read or poll for a pendidng decoder value.
         let new_value = match self.inner {
             Inner::Pending(ref mut future) => {
                 match future.poll() {
-                    Ok(Async::Ready(inner)) => inner,
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
+                    Ok(Poll::Ready(inner)) => inner,
+                    Ok(Poll::Pending) => return Ok(Poll::Pending),
                     Err(e) => return Err(e)
                 }
             },
@@ -170,20 +172,20 @@ impl Stream for Decoder {
 }
 
 impl Future for Pending {
-    type Item = Inner;
-    type Error = error::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    type Output = Result<Inner, error::Error>;
+
+    fn poll(&mut self) -> Poll<Self::Output> {
         let body_state = match self.body.poll_stream() {
-            Ok(Async::Ready(state)) => state,
-            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Poll::Ready(state)) => state,
+            Ok(Poll::Pending) => return Ok(Poll::Pending),
             Err(e) => return Err(e)
         };
 
         let body = mem::replace(&mut self.body, ReadableChunks::new(Body::empty()));
         match body_state {
-            StreamState::Eof => Ok(Async::Ready(Inner::PlainText(Body::empty()))),
-            StreamState::HasMore => Ok(Async::Ready(Inner::Gzip(Gzip::new(body))))
+            StreamState::Eof => Poll::Ready(Inner::PlainText(Body::empty())),
+            StreamState::HasMore => Poll::Ready(Inner::Gzip(Gzip::new(body)))
         }
     }
 }
@@ -198,10 +200,9 @@ impl Gzip {
 }
 
 impl Stream for Gzip {
-    type Item = Chunk;
-    type Error = error::Error;
+    type Item = Result<Chunk, error::Error>;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         if self.buf.remaining_mut() == 0 {
             self.buf.reserve(INIT_BUFFER_SIZE);
         }
@@ -223,7 +224,7 @@ impl Stream for Gzip {
             // See https://github.com/seanmonstar/reqwest/issues/508.
             let inner_read = try_io!(self.inner.get_mut().read(&mut [0]));
             if inner_read == 0 {
-                Ok(Async::Ready(None))
+                Ok(Poll::Ready(None))
             } else {
                 Err(error::from(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -234,7 +235,7 @@ impl Stream for Gzip {
             unsafe { self.buf.advance_mut(read) };
             let chunk = Chunk::from_chunk(self.buf.split_to(read).freeze());
 
-            Ok(Async::Ready(Some(chunk)))
+            Ok(Poll::Ready(Some(chunk)))
         }
     }
 }
@@ -280,7 +281,7 @@ impl<S> fmt::Debug for ReadableChunks<S> {
 
 impl<S> Read for ReadableChunks<S>
 where
-    S: Stream<Item = Chunk, Error = error::Error>,
+    S: Stream<Item = Result<Chunk, error::Error>>,
 {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         loop {
@@ -299,11 +300,11 @@ where
                 },
                 ReadState::NotReady => {
                     match self.poll_stream() {
-                        Ok(Async::Ready(StreamState::HasMore)) => continue,
-                        Ok(Async::Ready(StreamState::Eof)) => {
+                        Ok(Poll::Ready(StreamState::HasMore)) => continue,
+                        Ok(Poll::Ready(StreamState::Eof)) => {
                             return Ok(0)
                         },
-                        Ok(Async::NotReady) => {
+                        Ok(Poll::Pending) => {
                             return Err(io::ErrorKind::WouldBlock.into())
                         },
                         Err(e) => {
@@ -320,26 +321,26 @@ where
 }
 
 impl<S> ReadableChunks<S>
-    where S: Stream<Item = Chunk, Error = error::Error>
+    where S: Stream<Item = Result<Chunk, error::Error>>
 {
     /// Poll the readiness of the inner reader.
     ///
     /// This function will update the internal state and return a simplified
     /// version of the `ReadState`.
-    fn poll_stream(&mut self) -> Poll<StreamState, error::Error> {
+    fn poll_stream(&mut self) -> Poll<Result<StreamState, error::Error>> {
         match self.stream.poll() {
-            Ok(Async::Ready(Some(chunk))) => {
+            Ok(Poll::Ready(Some(chunk))) => {
                 self.state = ReadState::Ready(chunk);
 
-                Ok(Async::Ready(StreamState::HasMore))
+                Ok(Poll::Ready(StreamState::HasMore))
             },
-            Ok(Async::Ready(None)) => {
+            Ok(Poll::Ready(None)) => {
                 self.state = ReadState::Eof;
 
-                Ok(Async::Ready(StreamState::Eof))
+                Ok(Poll::Ready(StreamState::Eof))
             },
-            Ok(Async::NotReady) => {
-                Ok(Async::NotReady)
+            Ok(Poll::Pending) => {
+                Ok(Poll::Pending)
             },
             Err(e) => Err(e)
         }

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -182,11 +182,11 @@ impl Part {
     }
 
     /// Makes a new parameter from an arbitrary stream.
-    pub fn stream<T>(value: T) -> Part
+    pub fn stream<T, I, E>(value: T) -> Part
     where
-        T: Stream + Send + 'static,
-        T::Error: std::error::Error + Send + Sync,
-        hyper::Chunk: std::convert::From<T::Item>,
+        T: Stream<Item = Result<I, E>> + Send + 'static,
+        E: std::error::Error + Send + Sync,
+        hyper::Chunk: std::convert::From<I>,
     {
         Part::new(Body::wrap(hyper::Body::wrap_stream(value)))
     }

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -358,7 +358,7 @@ impl RequestBuilder {
     /// rt.block_on(response)
     /// # }
     /// ```
-    pub fn send(self) -> impl Future<Item = Response, Error = crate::Error> {
+    pub fn send(self) -> impl Future<Output = Result<Response, crate::Error>> {
         match self.request {
             Ok(req) => self.client.execute_request(req),
             Err(err) => Pending::new_err(err),

--- a/src/body.rs
+++ b/src/body.rs
@@ -260,7 +260,7 @@ async fn send_future(sender: Sender) -> Result<(), crate::Error> {
     loop {
         if Some(written) == con_len {
             // Written up to content-length, so stop.
-            return Ok(().into());
+            return Ok(());
         }
 
         // The input stream is read only if the buffer is empty so
@@ -285,7 +285,7 @@ async fn send_future(sender: Sender) -> Result<(), crate::Error> {
                 Ok(0) => {
                     // The buffer was empty and nothing's left to
                     // read. Return.
-                    return Ok(().into());
+                    return Ok(());
                 }
                 Ok(n) => {
                     unsafe { buf.advance_mut(n); }

--- a/src/body.rs
+++ b/src/body.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::io::{self, Cursor, Read};
 
 use bytes::Bytes;
-use futures::{Future, try_ready};
+use futures::Future;
 use hyper::{self};
 
 use crate::{async_impl};
@@ -277,7 +277,7 @@ impl Sender {
 
             // The only way to get here is when the buffer is not empty.
             // We can check the transmission channel
-            try_ready!(tx
+            futures::ready!(tx
                 .as_mut()
                 .expect("tx only taken on error")
                 .poll_ready()

--- a/src/body.rs
+++ b/src/body.rs
@@ -4,7 +4,6 @@ use std::io::{self, Cursor, Read};
 
 use bytes::Bytes;
 use futures::Future;
-use hyper::{self};
 
 use crate::{async_impl};
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -3,7 +3,9 @@ use std::fmt;
 use std::io::{self, Cursor, Read};
 
 use bytes::Bytes;
-use futures::Future;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use crate::{async_impl};
 
@@ -214,80 +216,112 @@ pub(crate) struct Sender {
     tx: hyper::body::Sender,
 }
 
+struct SenderWrapper {
+    inner: hyper::body::Sender
+}
+
+impl SenderWrapper {
+    fn abort(self) {
+        self.inner.abort()
+    }
+
+    pub fn send_data(&mut self, chunk: hyper::Chunk) -> Result<(), hyper::Chunk> {
+        self.inner.send_data(chunk)
+    }
+
+    fn inner(self: Pin<&mut Self>) -> Pin<&mut hyper::body::Sender> {
+        unsafe {
+            Pin::map_unchecked_mut(self, |x| &mut x.inner)
+        }
+    }
+}
+
+impl Future for SenderWrapper {
+    type Output=Result<(), hyper::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner().as_mut().poll_ready(cx)
+    }
+}
+
+async fn send_future(sender: Sender) -> Result<(), crate::Error> {
+    use std::cmp;
+    use bytes::{BufMut, BytesMut};
+
+    let sender_wrapper = SenderWrapper { inner: sender.tx };
+    let con_len = sender.body.1;
+    let cap = cmp::min(sender.body.1.unwrap_or(8192), 8192);
+    let mut written = 0;
+    let mut buf = BytesMut::with_capacity(cap as usize);
+    let mut body = sender.body.0;
+    // Put in an option so that it can be consumed on error to call abort()
+    let mut tx = Some(sender_wrapper);
+
+    loop {
+        if Some(written) == con_len {
+            // Written up to content-length, so stop.
+            return Ok(().into());
+        }
+
+        // The input stream is read only if the buffer is empty so
+        // that there is only one read in the buffer at any time.
+        //
+        // We need to know whether there is any data to send before
+        // we check the transmission channel (with poll_ready below)
+        // because somestimes the receiver disappears as soon as is
+        // considers the data is completely transmitted, which may
+        // be true.
+        //
+        // The use case is a web server that closes its
+        // input stream as soon as the data received is valid JSON.
+        // This behaviour is questionable, but it exists and the
+        // fact is that there is actually no remaining data to read.
+        if buf.is_empty() {
+            if buf.remaining_mut() == 0 {
+                buf.reserve(8192);
+            }
+
+            match body.read(unsafe { buf.bytes_mut() }) {
+                Ok(0) => {
+                    // The buffer was empty and nothing's left to
+                    // read. Return.
+                    return Ok(().into());
+                }
+                Ok(n) => {
+                    unsafe { buf.advance_mut(n); }
+                }
+                Err(e) => {
+                    let ret = io::Error::new(e.kind(), e.to_string());
+                    tx
+                        .take()
+                        .expect("tx only taken on error")
+                        .abort();
+                    return Err(crate::error::from(ret));
+                }
+            }
+        }
+
+        // The only way to get here is when the buffer is not empty.
+        // We can check the transmission channel
+        tx
+            .as_mut()
+            .expect("tx only taken on error")
+            .await
+            .map_err(crate::error::from)?;
+
+        written += buf.len() as u64;
+        let tx = tx.as_mut().expect("tx only taken on error");
+        if tx.send_data(buf.take().freeze().into()).is_err() {
+            return Err(crate::error::timedout(None));
+        }
+    }
+}
+
 impl Sender {
     // A `Future` that may do blocking read calls.
     // As a `Future`, this integrates easily with `wait::timeout`.
-    pub(crate) fn send(self) -> impl Future<Item=(), Error=crate::Error> {
-        use std::cmp;
-        use bytes::{BufMut, BytesMut};
-        use futures::future;
-
-        let con_len = self.body.1;
-        let cap = cmp::min(self.body.1.unwrap_or(8192), 8192);
-        let mut written = 0;
-        let mut buf = BytesMut::with_capacity(cap as usize);
-        let mut body = self.body.0;
-        // Put in an option so that it can be consumed on error to call abort()
-        let mut tx = Some(self.tx);
-
-        future::poll_fn(move || loop {
-            if Some(written) == con_len {
-                // Written up to content-length, so stop.
-                return Ok(().into());
-            }
-
-            // The input stream is read only if the buffer is empty so
-            // that there is only one read in the buffer at any time.
-            //
-            // We need to know whether there is any data to send before
-            // we check the transmission channel (with poll_ready below)
-            // because somestimes the receiver disappears as soon as is
-            // considers the data is completely transmitted, which may
-            // be true.
-            //
-            // The use case is a web server that closes its
-            // input stream as soon as the data received is valid JSON.
-            // This behaviour is questionable, but it exists and the
-            // fact is that there is actually no remaining data to read.
-            if buf.is_empty() {
-                if buf.remaining_mut() == 0 {
-                    buf.reserve(8192);
-                }
-
-                match body.read(unsafe { buf.bytes_mut() }) {
-                    Ok(0) => {
-                        // The buffer was empty and nothing's left to
-                        // read. Return.
-                        return Ok(().into());
-                    }
-                    Ok(n) => {
-                        unsafe { buf.advance_mut(n); }
-                    }
-                    Err(e) => {
-                        let ret = io::Error::new(e.kind(), e.to_string());
-                        tx
-                            .take()
-                            .expect("tx only taken on error")
-                            .abort();
-                        return Err(crate::error::from(ret));
-                    }
-                }
-            }
-
-            // The only way to get here is when the buffer is not empty.
-            // We can check the transmission channel
-            futures::ready!(tx
-                .as_mut()
-                .expect("tx only taken on error")
-                .poll_ready()
-                .map_err(crate::error::from));
-
-            written += buf.len() as u64;
-            let tx = tx.as_mut().expect("tx only taken on error");
-            if tx.send_data(buf.take().freeze().into()).is_err() {
-                return Err(crate::error::timedout(None));
-            }
-        })
+    pub(crate) fn send(self) -> impl Future<Output=Result<(), crate::Error>> {
+        send_future(self)
     }
 }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,24 +1,23 @@
-use futures::Future;
+use futures::FutureExt;
 use http::uri::Scheme;
 use hyper::client::connect::{Connect, Connected, Destination};
-use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_timer::Timeout;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "default-tls")]
 use native_tls::{TlsConnector, TlsConnectorBuilder};
-#[cfg(feature = "tls")]
-use futures::Poll;
-#[cfg(feature = "tls")]
-use bytes::BufMut;
 
 use std::io;
+use std::future::Future;
 use std::sync::Arc;
 use std::net::IpAddr;
+use std::pin::Pin;
 use std::time::Duration;
+use std::task::{Context, Poll};
 
 #[cfg(feature = "trust-dns")]
 use crate::dns::TrustDnsResolver;
 use crate::proxy::{Proxy, ProxyScheme};
+use tokio::future::FutureExt as _;
 
 #[cfg(feature = "trust-dns")]
 type HttpConnector = hyper::client::HttpConnector<TrustDnsResolver>;
@@ -34,6 +33,7 @@ pub(crate) struct Connector {
     nodelay: bool
 }
 
+#[derive(Clone)]
 enum Inner {
     #[cfg(not(feature = "tls"))]
     Http(HttpConnector),
@@ -73,7 +73,7 @@ impl Connector {
         where
             T: Into<Option<IpAddr>>,
     {
-        let tls = try_!(tls.build());
+        let tls = tls.build().map_err(crate::error::from)?;
 
         let mut http = http_connector()?;
         http.set_local_address(local_addr.into());
@@ -122,25 +122,7 @@ impl Connector {
     }
 
     #[cfg(feature = "socks")]
-    fn connect_socks(&self, dst: Destination, proxy: ProxyScheme) -> Connecting {
-        macro_rules! timeout {
-            ($future:expr) => {
-                if let Some(dur) = self.timeout {
-                    Box::new(Timeout::new($future, dur).map_err(|err| {
-                        if err.is_inner() {
-                            err.into_inner().expect("is_inner")
-                        } else if err.is_elapsed() {
-                            io::Error::new(io::ErrorKind::TimedOut, "connect timed out")
-                        } else {
-                            io::Error::new(io::ErrorKind::Other, err)
-                        }
-                    }))
-                } else {
-                    Box::new($future)
-                }
-            }
-        }
-
+    async fn connect_socks(&self, dst: Destination, proxy: ProxyScheme) -> Result<(Conn, Connected), io::Error> {
         let dns = match proxy {
             ProxyScheme::Socks5 { remote_dns: false, .. } => socks::DnsResolve::Local,
             ProxyScheme::Socks5 { remote_dns: true, .. } => socks::DnsResolve::Proxy,
@@ -149,20 +131,19 @@ impl Connector {
             },
         };
 
-
         match &self.inner {
             #[cfg(feature = "default-tls")]
             Inner::DefaultTls(_http, tls) => if dst.scheme() == "https" {
                 use self::native_tls_async::TlsConnectorExt;
 
-                let tls = tls.clone();
                 let host = dst.host().to_owned();
                 let socks_connecting = socks::connect(proxy, dst, dns);
-                return timeout!(socks_connecting.and_then(move |(conn, connected)| {
-                    tls.connect_async(&host, conn)
-                        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-                        .map(move |io| (Box::new(io) as Conn, connected))
-                }));
+                let (conn, connected) = socks::connect(proxy, dst, dns).await?;
+                let tls_connector = tokio_tls::TlsConnector::from(tls.clone());
+                let io = tls_connector.connect(&host, conn)
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                Ok( (Box::new(io) as Conn, connected) )
             },
             #[cfg(feature = "rustls-tls")]
             Inner::RustlsTls { tls_proxy, .. } => if dst.scheme() == "https" {
@@ -171,27 +152,18 @@ impl Connector {
 
                 let tls = tls_proxy.clone();
                 let host = dst.host().to_owned();
-                let socks_connecting = socks::connect(proxy, dst, dns);
-                return timeout!(socks_connecting.and_then(move |(conn, connected)| {
-                    let maybe_dnsname = DNSNameRef::try_from_ascii_str(&host)
-                        .map(|dnsname| dnsname.to_owned())
-                        .map_err(|_| io::Error::new(io::ErrorKind::Other, "Invalid DNS Name"));
-                    futures::future::result(maybe_dnsname)
-                        .and_then(move |dnsname| {
-                            RustlsConnector::from(tls).connect(dnsname.as_ref(), conn)
-                                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-                        })
-                        .map(move |io| {
-                            (Box::new(io) as Conn, connected)
-                        })
-                }));
+                let (conn, connected) = socks::connect(proxy, dst, dns);
+                let dnsname = DNSNameRef::try_from_ascii_str(&host)
+                    .map(|dnsname| dnsname.to_owned())
+                    .map_err(|_| io::Error::new(io::ErrorKind::Other, "Invalid DNS Name"))?;
+                let io = RustlsConnector::from(tls).connect(dnsname.as_ref(), conn)
+                    .await
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                Ok( (Box::new(io) as Conn, connected) )
             },
             #[cfg(not(feature = "tls"))]
-            Inner::Http(_) => ()
+            Inner::Http(_) => socks::connect(proxy, dst, dns),
         }
-
-        // else no TLS
-        socks::connect(proxy, dst, dns)
     }
 }
 
@@ -207,6 +179,151 @@ fn http_connector() -> crate::Result<HttpConnector> {
     Ok(HttpConnector::new(4))
 }
 
+async fn connect_with_maybe_proxy(inner: Inner, dst: Destination, is_proxy: bool, no_delay: bool) -> Result<(Conn, Connected), io::Error> {
+    match inner {
+        #[cfg(not(feature = "tls"))]
+        Inner::Http(http) => {
+            //TODO: timeout?
+            let (io, connected) = http.connect(dst).await;
+            (Box::new(io) as Conn, connected.proxy(is_proxy))
+        },
+        #[cfg(feature = "default-tls")]
+        Inner::DefaultTls(http, tls) => {
+            let mut http = http.clone();
+
+            http.set_nodelay(no_delay || (dst.scheme() == "https"));
+
+            let tls_connector = tokio_tls::TlsConnector::from(tls.clone());
+            let http = hyper_tls::HttpsConnector::from((http, tls_connector));
+            //TODO: timeout
+            let (io, connected) = http.connect(dst).await?;
+            if let hyper_tls::MaybeHttpsStream::Https(_stream) = &io {
+                if !no_delay {
+                    //TODO: where's this at now?
+//                    stream.set_nodelay(false)?;
+                }
+            }
+
+            Ok((Box::new(io) as Conn, connected.proxy(is_proxy)))
+        },
+        #[cfg(feature = "rustls-tls")]
+        Inner::RustlsTls { http, tls, .. } => {
+            let mut http = http.clone();
+
+            // Disable Nagle's algorithm for TLS handshake
+            //
+            // https://www.openssl.org/docs/man1.1.1/man3/SSL_connect.html#NOTES
+            http.set_nodelay(nodelay || (dst.scheme() == "https"));
+
+            let http = hyper_rustls::HttpsConnector::from((http, tls.clone()));
+            //TODO: timeout
+            let (io, connected) = http.connect(dst).await;
+            if let hyper_rustls::MaybeHttpsStream::Https(stream) = &io {
+                if !nodelay {
+                    let (io, _) = stream.get_ref();
+                    io.set_nodelay(false)?;
+                }
+            }
+
+            Ok((Box::new(io) as Conn, connected.proxy(is_proxy)))
+        }
+    }
+}
+
+async fn connect_via_proxy(inner: Inner, dst: Destination, proxy_scheme: ProxyScheme, no_delay: bool) -> Result<(Conn, Connected), io::Error> {
+    log::trace!("proxy({:?}) intercepts {:?}", proxy_scheme, dst);
+
+    let (puri, _auth) = match proxy_scheme {
+        ProxyScheme::Http { uri, auth, .. } => (uri, auth),
+        #[cfg(feature = "socks")]
+        ProxyScheme::Socks5 { .. } => {
+            //TODO: timeout?
+            return this.connect_socks(dst, proxy_scheme)
+        },
+    };
+
+    let mut ndst = dst.clone();
+
+    let new_scheme = puri
+        .scheme_part()
+        .map(Scheme::as_str)
+        .unwrap_or("http");
+    ndst.set_scheme(new_scheme)
+        .expect("proxy target scheme should be valid");
+
+    ndst.set_host(puri.host().expect("proxy target should have host"))
+        .expect("proxy target host should be valid");
+
+    ndst.set_port(puri.port_part().map(|port| port.as_u16()));
+
+    #[cfg(feature = "tls")]
+    let auth = _auth;
+
+    match &inner {
+        #[cfg(feature = "default-tls")]
+        Inner::DefaultTls(http, tls) => if dst.scheme() == "https" {
+            let host = dst.host().to_owned();
+            let port = dst.port().unwrap_or(443);
+            let mut http = http.clone();
+            http.set_nodelay(no_delay);
+            let tls_connector = tokio_tls::TlsConnector::from(tls.clone());
+            let http = hyper_tls::HttpsConnector::from((http, tls_connector));
+            let (conn, connected) = http.connect(ndst).await?;
+            log::trace!("tunneling HTTPS over proxy");
+            let tunneled = tunnel(conn, host.clone(), port, auth).await?;
+            let tls_connector = tokio_tls::TlsConnector::from(tls.clone());
+            let io = tls_connector.connect(&host, tunneled).await
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            return Ok((Box::new(io) as Conn, connected.proxy(true)));
+        },
+        #[cfg(feature = "rustls-tls")]
+        Inner::RustlsTls { http, tls, tls_proxy } => if dst.scheme() == "https" {
+            use rustls::Session;
+            use tokio_rustls::TlsConnector as RustlsConnector;
+            use tokio_rustls::webpki::DNSNameRef;
+
+            let host = dst.host().to_owned();
+            let port = dst.port().unwrap_or(443);
+            let mut http = http.clone();
+            http.set_nodelay(nodelay);
+            let http = hyper_rustls::HttpsConnector::from((http, tls_proxy.clone()));
+            let tls = tls.clone();
+            let (conn, connected) = http.connect(ndst).await;
+            log::trace!("tunneling HTTPS over proxy");
+            let maybe_dnsname = DNSNameRef::try_from_ascii_str(&host)
+                .map(|dnsname| dnsname.to_owned())
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "Invalid DNS Name"));
+            let tunneled = tunnel(conn, host, port, auth).await;
+            let dnsname = maybe_dnsname?;
+            let io = RustlsConnector::from(tls)
+                .connect(dnsname.as_ref(), tunneled)
+                .await
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            let connected = if io.get_ref().1.get_alpn_protocol() == Some(b"h2") {
+                connected.negotiated_h2()
+            } else {
+                connected
+            };
+            return Ok((Box::new(io) as Conn, connected.proxy(true)));
+        },
+        #[cfg(not(feature = "tls"))]
+        Inner::Http(_) => ()
+    }
+
+    return connect_with_maybe_proxy(inner, ndst, true, no_delay).await;
+}
+
+async fn with_timeout<T, F>(f: F, timeout: Option<Duration>) -> Result<T, io::Error> where F: Future<Output=Result<T, io::Error>> {
+    if let Some(to) = timeout {
+        match f.timeout(to).await {
+            Err(_elapsed) => Err(io::Error::new(io::ErrorKind::TimedOut, "connect timed out")),
+            Ok(try_res) => try_res,
+        }
+    } else {
+        f.await
+    }
+}
+
 impl Connect for Connector {
     type Transport = Conn;
     type Error = io::Error;
@@ -214,177 +331,25 @@ impl Connect for Connector {
 
     fn connect(&self, dst: Destination) -> Self::Future {
         #[cfg(feature = "tls")]
-        let nodelay = self.nodelay;
-
-        macro_rules! timeout {
-            ($future:expr) => {
-                if let Some(dur) = self.timeout {
-                    Box::new(Timeout::new($future, dur).map_err(|err| {
-                        if err.is_inner() {
-                            err.into_inner().expect("is_inner")
-                        } else if err.is_elapsed() {
-                            io::Error::new(io::ErrorKind::TimedOut, "connect timed out")
-                        } else {
-                            io::Error::new(io::ErrorKind::Other, err)
-                        }
-                    }))
-                } else {
-                    Box::new($future)
-                }
-            }
-        }
-
-        macro_rules! connect {
-            ( $http:expr, $dst:expr, $proxy:expr ) => {
-                timeout!($http.connect($dst)
-                    .map(|(io, connected)| (Box::new(io) as Conn, connected.proxy($proxy))))
-            };
-            ( $dst:expr, $proxy:expr ) => {
-                match &self.inner {
-                    #[cfg(not(feature = "tls"))]
-                    Inner::Http(http) => connect!(http, $dst, $proxy),
-                    #[cfg(feature = "default-tls")]
-                    Inner::DefaultTls(http, tls) => {
-                        let mut http = http.clone();
-
-                        http.set_nodelay(nodelay || ($dst.scheme() == "https"));
-
-                        let http = hyper_tls::HttpsConnector::from((http, tls.clone()));
-                        timeout!(http.connect($dst)
-                            .and_then(move |(io, connected)| {
-                                if let hyper_tls::MaybeHttpsStream::Https(stream) = &io {
-                                    if !nodelay {
-                                        stream.get_ref().get_ref().set_nodelay(false)?;
-                                    }
-                                }
-
-                                Ok((Box::new(io) as Conn, connected.proxy($proxy)))
-                            }))
-                    },
-                    #[cfg(feature = "rustls-tls")]
-                    Inner::RustlsTls { http, tls, .. } => {
-                        let mut http = http.clone();
-
-                        // Disable Nagle's algorithm for TLS handshake
-                        //
-                        // https://www.openssl.org/docs/man1.1.1/man3/SSL_connect.html#NOTES
-                        http.set_nodelay(nodelay || ($dst.scheme() == "https"));
-
-                        let http = hyper_rustls::HttpsConnector::from((http, tls.clone()));
-                        timeout!(http.connect($dst)
-                            .and_then(move |(io, connected)| {
-                                if let hyper_rustls::MaybeHttpsStream::Https(stream) = &io {
-                                    if !nodelay {
-                                        let (io, _) = stream.get_ref();
-                                        io.set_nodelay(false)?;
-                                    }
-                                }
-
-                                Ok((Box::new(io) as Conn, connected.proxy($proxy)))
-                            }))
-                    }
-                }
-            };
-        }
-
+        let no_delay = self.nodelay;
+        #[cfg(not(feature = "tls"))]
+        let no_delay = false;
+        let timeout = self.timeout.clone();
         for prox in self.proxies.iter() {
             if let Some(proxy_scheme) = prox.intercept(&dst) {
-                log::trace!("proxy({:?}) intercepts {:?}", proxy_scheme, dst);
-
-                let (puri, _auth) = match proxy_scheme {
-                    ProxyScheme::Http { uri, auth, .. } => (uri, auth),
-                    #[cfg(feature = "socks")]
-                    ProxyScheme::Socks5 { .. } => return self.connect_socks(dst, proxy_scheme),
-                };
-
-                let mut ndst = dst.clone();
-
-                let new_scheme = puri
-                    .scheme_part()
-                    .map(Scheme::as_str)
-                    .unwrap_or("http");
-                ndst.set_scheme(new_scheme)
-                    .expect("proxy target scheme should be valid");
-
-                ndst.set_host(puri.host().expect("proxy target should have host"))
-                    .expect("proxy target host should be valid");
-
-                ndst.set_port(puri.port_part().map(|port| port.as_u16()));
-
-                #[cfg(feature = "tls")]
-                let auth = _auth;
-
-                match &self.inner {
-                    #[cfg(feature = "default-tls")]
-                    Inner::DefaultTls(http, tls) => if dst.scheme() == "https" {
-                        use self::native_tls_async::TlsConnectorExt;
-
-                        let host = dst.host().to_owned();
-                        let port = dst.port().unwrap_or(443);
-                        let mut http = http.clone();
-                        http.set_nodelay(nodelay);
-                        let http = hyper_tls::HttpsConnector::from((http, tls.clone()));
-                        let tls = tls.clone();
-                        return timeout!(http.connect(ndst).and_then(move |(conn, connected)| {
-                            log::trace!("tunneling HTTPS over proxy");
-                            tunnel(conn, host.clone(), port, auth)
-                                .and_then(move |tunneled| {
-                                    tls.connect_async(&host, tunneled)
-                                        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-                                })
-                                .map(|io| (Box::new(io) as Conn, connected.proxy(true)))
-                        }));
-                    },
-                    #[cfg(feature = "rustls-tls")]
-                    Inner::RustlsTls { http, tls, tls_proxy } => if dst.scheme() == "https" {
-                        use rustls::Session;
-                        use tokio_rustls::TlsConnector as RustlsConnector;
-                        use tokio_rustls::webpki::DNSNameRef;
-
-                        let host = dst.host().to_owned();
-                        let port = dst.port().unwrap_or(443);
-                        let mut http = http.clone();
-                        http.set_nodelay(nodelay);
-                        let http = hyper_rustls::HttpsConnector::from((http, tls_proxy.clone()));
-                        let tls = tls.clone();
-                        return timeout!(http.connect(ndst).and_then(move |(conn, connected)| {
-                            log::trace!("tunneling HTTPS over proxy");
-                            let maybe_dnsname = DNSNameRef::try_from_ascii_str(&host)
-                                .map(|dnsname| dnsname.to_owned())
-                                .map_err(|_| io::Error::new(io::ErrorKind::Other, "Invalid DNS Name"));
-                            tunnel(conn, host, port, auth)
-                                .and_then(move |tunneled| Ok((maybe_dnsname?, tunneled)))
-                                .and_then(move |(dnsname, tunneled)| {
-                                    RustlsConnector::from(tls).connect(dnsname.as_ref(), tunneled)
-                                        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-                                })
-                                .map(|io| {
-                                    let connected = if io.get_ref().1.get_alpn_protocol() == Some(b"h2") {
-                                        connected.negotiated_h2()
-                                    } else {
-                                        connected
-                                    };
-                                    (Box::new(io) as Conn, connected.proxy(true))
-                                })
-                        }));
-                    },
-                    #[cfg(not(feature = "tls"))]
-                    Inner::Http(_) => ()
-                }
-
-                return connect!(ndst, true);
+                return with_timeout(connect_via_proxy(self.inner.clone(), dst, proxy_scheme, no_delay), timeout).boxed();
             }
         }
 
-        connect!(dst, false)
+        with_timeout(connect_with_maybe_proxy(self.inner.clone(), dst, false, no_delay), timeout).boxed()
     }
 }
 
 pub(crate) trait AsyncConn: AsyncRead + AsyncWrite {}
 impl<T: AsyncRead + AsyncWrite> AsyncConn for T {}
-pub(crate) type Conn = Box<dyn AsyncConn + Send + Sync + 'static>;
+pub(crate) type Conn = Box<dyn AsyncConn + Send + Sync + Unpin + 'static>;
 
-pub(crate) type Connecting = Box<dyn Future<Output=Result<(Conn, Connected), io::Error>> + Send>;
+pub(crate) type Connecting = Pin<Box<dyn Future<Output=Result<(Conn, Connected), io::Error>> + Send>>;
 
 #[cfg(feature = "tls")]
 fn tunnel<T>(conn: T, host: String, port: u16, auth: Option<http::header::HeaderValue>) -> Tunnel<T> {
@@ -393,18 +358,18 @@ fn tunnel<T>(conn: T, host: String, port: u16, auth: Option<http::header::Header
         Host: {0}:{1}\r\n\
     ", host, port).into_bytes();
 
-        if let Some(value) = auth {
-            log::debug!("tunnel to {}:{} using basic auth", host, port);
-            buf.extend_from_slice(b"Proxy-Authorization: ");
-            buf.extend_from_slice(value.as_bytes());
-            buf.extend_from_slice(b"\r\n");
-        }
+    if let Some(value) = auth {
+        log::debug!("tunnel to {}:{} using basic auth", host, port);
+        buf.extend_from_slice(b"Proxy-Authorization: ");
+        buf.extend_from_slice(value.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
 
     // headers end
     buf.extend_from_slice(b"\r\n");
 
     Tunnel {
-        buf: io::Cursor::new(buf),
+        buf: buf,
         conn: Some(conn),
         state: TunnelState::Writing,
     }
@@ -412,7 +377,7 @@ fn tunnel<T>(conn: T, host: String, port: u16, auth: Option<http::header::Header
 
 #[cfg(feature = "tls")]
 struct Tunnel<T> {
-    buf: io::Cursor<Vec<u8>>,
+    buf: Vec<u8>,
     conn: Option<T>,
     state: TunnelState,
 }
@@ -423,47 +388,71 @@ enum TunnelState {
     Reading
 }
 
+impl<T> Tunnel<T> {
+    fn conn(self: Pin<&mut Self>) -> Pin<&mut Option<T>> {
+        unsafe {
+            Pin::map_unchecked_mut(self, |x| &mut x.conn)
+        }
+    }
+
+    fn buf(self: Pin<&mut Self>) -> &mut Vec<u8> {
+        unsafe {
+            &mut Pin::get_unchecked_mut(self).buf
+        }
+    }
+}
+
 #[cfg(feature = "tls")]
-impl<T> Future for Tunnel<T>
+impl<T: AsyncRead + AsyncWrite> Future for Tunnel<T>
 where
-    T: AsyncRead + AsyncWrite,
+    T: AsyncRead + AsyncWrite + Unpin,
 {
     type Output = Result<T, io::Error>;
 
-    fn poll(&mut self) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut buf = std::mem::replace(self.as_mut().buf(), vec![]);
         loop {
             if let TunnelState::Writing = self.state {
-                let n = futures::ready!(self.conn.as_mut().unwrap().write_buf(&mut self.buf));
-                if !self.buf.has_remaining_mut() {
-                    self.state = TunnelState::Reading;
-                    self.buf.get_mut().truncate(0);
-                } else if n == 0 {
-                    return Err(tunnel_eof());
+                let inner = self.as_mut().conn().as_pin_mut().unwrap();
+                match inner.poll_write(cx, &buf) {
+                    Poll::Pending => {
+                        std::mem::replace(self.as_mut().buf(), vec![]);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Ready(Ok(n)) => {
+                        if n == 0 {
+                            return Poll::Ready(Err(tunnel_eof()));
+                        }
+                        buf = buf.split_off(n);
+                        if buf.is_empty() {
+                            self.state = TunnelState::Reading;
+                        }
+                    }
                 }
             } else {
-                let n = futures::ready!(self.conn.as_mut().unwrap().read_buf(&mut self.buf.get_mut()));
-                let read = &self.buf.get_ref()[..];
-                if n == 0 {
-                    return Err(tunnel_eof());
-                } else if read.len() > 12 {
-                    if read.starts_with(b"HTTP/1.1 200") || read.starts_with(b"HTTP/1.0 200") {
-                        if read.ends_with(b"\r\n\r\n") {
-                            return Ok(self.conn.take().unwrap().into());
+                let inner = self.as_mut().conn().as_pin_mut().unwrap();
+                match inner.poll_read(cx, &mut buf) {
+                    Poll::Pending => {
+                        std::mem::replace(self.as_mut().buf(), vec![]);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Ready(Ok(n)) => {
+                        if n == 0 {
+                            return Poll::Ready(Err(tunnel_eof()));
+                        } else if buf.len() > 12 {
+                            if buf.starts_with(b"HTTP/1.1 200") || buf.starts_with(b"HTTP/1.0 200") {
+                                if buf.ends_with(b"\r\n\r\n") {
+                                    return Poll::Ready(Ok(self.as_mut().conn().get_mut().take().unwrap()));
+                                }
+                                // else read more
+                            } else if buf.starts_with(b"HTTP/1.1 407") {
+                                return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "proxy authentication required")));
+                            } else {
+                                return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "unsuccessful tunnel")));
+                            }
                         }
-                        // else read more
-                    } else if read.starts_with(b"HTTP/1.1 407") {
-                        return Err(io::Error::new(io::ErrorKind::Other, "proxy authentication required"));
-                    } else if read.starts_with(b"HTTP/1.1 403") {
-                        return Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            "proxy blocked this request",
-                        ));
-                    } else {
-                        let (fst, _) = read.split_at(12);
-                        return Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            format!("unsuccessful tunnel: {:?}", fst).as_str(),
-                        ));
                     }
                 }
             }
@@ -479,142 +468,6 @@ fn tunnel_eof() -> io::Error {
         "unexpected eof while tunneling"
     )
 }
-
-#[cfg(feature = "default-tls")]
-mod native_tls_async {
-    use std::io::{self, Read, Write};
-
-    use futures::Future;
-    use std::task::{Poll, Context};
-    use std::pin::Pin;
-    use native_tls::{self, HandshakeError, Error, TlsConnector};
-    use tokio_io::{AsyncRead, AsyncWrite};
-
-    /// A wrapper around an underlying raw stream which implements the TLS or SSL
-    /// protocol.
-    ///
-    /// A `TlsStream<S>` represents a handshake that has been completed successfully
-    /// and both the server and the client are ready for receiving and sending
-    /// data. Bytes read from a `TlsStream` are decrypted from `S` and bytes written
-    /// to a `TlsStream` are encrypted when passing through to `S`.
-    #[derive(log::debug)]
-    pub struct TlsStream<S> {
-        inner: native_tls::TlsStream<S>,
-    }
-
-    /// Future returned from `TlsConnectorExt::connect_async` which will resolve
-    /// once the connection handshake has finished.
-    pub struct ConnectAsync<S> {
-        inner: MidHandshake<S>,
-    }
-
-    struct MidHandshake<S> {
-        inner: Option<Result<native_tls::TlsStream<S>, HandshakeError<S>>>,
-    }
-
-    /// Extension trait for the `TlsConnector` type in the `native_tls` crate.
-    pub trait TlsConnectorExt: sealed::Sealed {
-        /// Connects the provided stream with this connector, assuming the provided
-        /// domain.
-        ///
-        /// This function will internally call `TlsConnector::connect` to connect
-        /// the stream and returns a future representing the resolution of the
-        /// connection operation. The returned future will resolve to either
-        /// `TlsStream<S>` or `Error` depending if it's successful or not.
-        ///
-        /// This is typically used for clients who have already established, for
-        /// example, a TCP connection to a remote server. That stream is then
-        /// provided here to perform the client half of a connection to a
-        /// TLS-powered server.
-        ///
-        /// # Compatibility notes
-        ///
-        /// Note that this method currently requires `S: Read + Write` but it's
-        /// highly recommended to ensure that the object implements the `AsyncRead`
-        /// and `AsyncWrite` traits as well, otherwise this function will not work
-        /// properly.
-        fn connect_async<S>(&self, domain: &str, stream: S) -> ConnectAsync<S>
-            where S: Read + Write; // TODO: change to AsyncRead + AsyncWrite
-    }
-
-    mod sealed {
-        pub trait Sealed {}
-    }
-
-    impl<S: Read + Write> Read for TlsStream<S> {
-        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-            self.inner.read(buf)
-        }
-    }
-
-    impl<S: Read + Write> Write for TlsStream<S> {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.inner.write(buf)
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            self.inner.flush()
-        }
-    }
-
-
-    impl<S: AsyncRead + AsyncWrite> AsyncRead for TlsStream<S> {
-    }
-
-    impl<S: AsyncRead + AsyncWrite> AsyncWrite for TlsStream<S> {
-        fn shutdown(&mut self) -> Poll<Result<(), io::Error>> {
-            //try_nb!(self.inner.shutdown());
-
-            self.inner.get_mut().shutdown()
-        }
-    }
-
-    impl TlsConnectorExt for TlsConnector {
-        fn connect_async<S>(&self, domain: &str, stream: S) -> ConnectAsync<S>
-            where S: Read + Write,
-        {
-            ConnectAsync {
-                inner: MidHandshake {
-                    inner: Some(self.connect(domain, stream)),
-                },
-            }
-        }
-    }
-
-    impl sealed::Sealed for TlsConnector {}
-
-    // TODO: change this to AsyncRead/AsyncWrite on next major version
-    impl<S: Read + Write> Future for ConnectAsync<S> {
-        type Output = Result<TlsStream<S>, Error>;
-
-        fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-            self.inner.poll()
-        }
-    }
-
-    // TODO: change this to AsyncRead/AsyncWrite on next major version
-    impl<S: Read + Write> Future for MidHandshake<S> {
-        type Output = crate::Result<TlsStream<S>>;
-
-        fn poll(&mut self) -> Poll<Self::Output> {
-            match self.inner.take().expect("cannot poll MidHandshake twice") {
-                Ok(stream) => Ok(TlsStream { inner: stream }.into()),
-                Err(HandshakeError::Failure(e)) => Err(e),
-                Err(HandshakeError::WouldBlock(s)) => {
-                    match s.handshake() {
-                        Ok(stream) => Ok(TlsStream { inner: stream }.into()),
-                        Err(HandshakeError::Failure(e)) => Err(e),
-                        Err(HandshakeError::WouldBlock(s)) => {
-                            self.inner = Some(Err(HandshakeError::WouldBlock(s)));
-                            Ok(Poll::Pending)
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 
 #[cfg(feature = "socks")]
 mod socks {
@@ -634,11 +487,11 @@ mod socks {
         Proxy,
     }
 
-    pub(super) fn connect(
+    pub(super) async fn connect(
         proxy: ProxyScheme,
         dst: Destination,
         dns: DnsResolve,
-    ) -> Connecting {
+    ) -> Result<(super::Conn, Connected), io::Error> {
         let https = dst.scheme() == "https";
         let original_host = dst.host().to_owned();
         let mut host = original_host.clone();
@@ -647,12 +500,7 @@ mod socks {
         });
 
         if let DnsResolve::Local = dns {
-            let maybe_new_target = match (host.as_str(), port).to_socket_addrs() {
-                Ok(mut iter) => iter.next(),
-                Err(err) => {
-                    return Box::new(future::err(err));
-                }
-            };
+            let maybe_new_target = (host.as_str(), port).to_socket_addrs()?.next();
             if let Some(new_target) = maybe_new_target {
                 host = new_target.ip().to_string();
             }
@@ -664,33 +512,28 @@ mod socks {
         };
 
         // Get a Tokio TcpStream
-        let stream = future::result(if let Some((username, password)) = auth {
+        let stream = if let Some((username, password)) = auth {
             Socks5Stream::connect_with_password(
                 socket_addr, (host.as_str(), port), &username, &password
-            )
+            ).await
         } else {
-            Socks5Stream::connect(socket_addr, (host.as_str(), port))
-        }.and_then(|s| {
+            let s = Socks5Stream::connect(socket_addr, (host.as_str(), port)).await;
             TcpStream::from_std(s.into_inner(), &reactor::Handle::default())
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-        }));
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+        };
 
-        Box::new(
-            stream.map(|s| (Box::new(s) as super::Conn, Connected::new()))
-        )
+        Ok( (Box::new(s) as super::Conn, Connected::new()) )
     }
 }
 
 #[cfg(feature = "tls")]
 #[cfg(test)]
 mod tests {
-    extern crate tokio_tcp;
-
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
     use tokio::runtime::current_thread::Runtime;
-    use self::tokio_tcp::TcpStream;
+    use tokio::net::tcp::TcpStream;
     use super::tunnel;
     use crate::proxy;
 
@@ -733,14 +576,14 @@ mod tests {
         let addr = mock_tunnel!();
 
         let mut rt = Runtime::new().unwrap();
-        let work = TcpStream::connect(&addr);
-        let host = addr.ip().to_string();
-        let port = addr.port();
-        let work = work.and_then(|tcp| {
-            tunnel(tcp, host, port, None)
-        });
+        let f = async move {
+            let tcp = TcpStream::connect(&addr).await?;
+            let host = addr.ip().to_string();
+            let port = addr.port();
+            tunnel(tcp, host, port, None).await
+        };
 
-        rt.block_on(work).unwrap();
+        rt.block_on(f).unwrap();
     }
 
     #[test]
@@ -748,14 +591,14 @@ mod tests {
         let addr = mock_tunnel!(b"HTTP/1.1 200 OK");
 
         let mut rt = Runtime::new().unwrap();
-        let work = TcpStream::connect(&addr);
-        let host = addr.ip().to_string();
-        let port = addr.port();
-        let work = work.and_then(|tcp| {
-            tunnel(tcp, host, port, None)
-        });
+        let f = async move {
+            let tcp = TcpStream::connect(&addr).await?;
+            let host = addr.ip().to_string();
+            let port = addr.port();
+            tunnel(tcp, host, port, None).await
+        };
 
-        rt.block_on(work).unwrap_err();
+        rt.block_on(f).unwrap();
     }
 
     #[test]
@@ -763,14 +606,14 @@ mod tests {
         let addr = mock_tunnel!(b"foo bar baz hallo");
 
         let mut rt = Runtime::new().unwrap();
-        let work = TcpStream::connect(&addr);
-        let host = addr.ip().to_string();
-        let port = addr.port();
-        let work = work.and_then(|tcp| {
-            tunnel(tcp, host, port, None)
-        });
+        let f = async move {
+            let tcp = TcpStream::connect(&addr).await?;
+            let host = addr.ip().to_string();
+            let port = addr.port();
+            tunnel(tcp, host, port, None).await
+        };
 
-        rt.block_on(work).unwrap_err();
+        rt.block_on(f).unwrap_err();
     }
 
     #[test]
@@ -782,14 +625,14 @@ mod tests {
         ");
 
         let mut rt = Runtime::new().unwrap();
-        let work = TcpStream::connect(&addr);
-        let host = addr.ip().to_string();
-        let port = addr.port();
-        let work = work.and_then(|tcp| {
-            tunnel(tcp, host, port, None)
-        });
+        let f = async move {
+            let tcp = TcpStream::connect(&addr).await?;
+            let host = addr.ip().to_string();
+            let port = addr.port();
+            tunnel(tcp, host, port, None).await
+        };
 
-        let error = rt.block_on(work).unwrap_err();
+        let error = rt.block_on(f).unwrap_err();
         assert_eq!(error.to_string(), "proxy authentication required");
     }
 
@@ -801,13 +644,13 @@ mod tests {
         );
 
         let mut rt = Runtime::new().unwrap();
-        let work = TcpStream::connect(&addr);
-        let host = addr.ip().to_string();
-        let port = addr.port();
-        let work = work.and_then(|tcp| {
-            tunnel(tcp, host, port, Some(proxy::encode_basic_auth("Aladdin", "open sesame")))
-        });
+        let f = async move {
+            let tcp = TcpStream::connect(&addr).await?;
+            let host = addr.ip().to_string();
+            let port = addr.port();
+            tunnel(tcp, host, port, Some(proxy::encode_basic_auth("Aladdin", "open sesame"))).await
+        };
 
-        rt.block_on(work).unwrap();
+        rt.block_on(f).unwrap();
     }
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -310,7 +310,7 @@ async fn connect_via_proxy(inner: Inner, dst: Destination, proxy_scheme: ProxySc
         Inner::Http(_) => ()
     }
 
-    return connect_with_maybe_proxy(inner, ndst, true, no_delay).await;
+    connect_with_maybe_proxy(inner, ndst, true, no_delay).await
 }
 
 async fn with_timeout<T, F>(f: F, timeout: Option<Duration>) -> Result<T, io::Error> where F: Future<Output=Result<T, io::Error>> {
@@ -334,7 +334,7 @@ impl Connect for Connector {
         let no_delay = self.nodelay;
         #[cfg(not(feature = "tls"))]
         let no_delay = false;
-        let timeout = self.timeout.clone();
+        let timeout = self.timeout;
         for prox in self.proxies.iter() {
             if let Some(proxy_scheme) = prox.intercept(&dst) {
                 return with_timeout(connect_via_proxy(self.inner.clone(), dst, proxy_scheme, no_delay), timeout).boxed();
@@ -369,7 +369,7 @@ fn tunnel<T>(conn: T, host: String, port: u16, auth: Option<http::header::Header
     buf.extend_from_slice(b"\r\n");
 
     Tunnel {
-        buf: buf,
+        buf,
         conn: Some(conn),
         state: TunnelState::Writing,
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -394,7 +394,7 @@ fn tunnel<T>(conn: T, host: String, port: u16, auth: Option<http::header::Header
     ", host, port).into_bytes();
 
         if let Some(value) = auth {
-            debug!("tunnel to {}:{} using basic auth", host, port);
+            log::debug!("tunnel to {}:{} using basic auth", host, port);
             buf.extend_from_slice(b"Proxy-Authorization: ");
             buf.extend_from_slice(value.as_bytes());
             buf.extend_from_slice(b"\r\n");
@@ -496,7 +496,7 @@ mod native_tls_async {
     /// and both the server and the client are ready for receiving and sending
     /// data. Bytes read from a `TlsStream` are decrypted from `S` and bytes written
     /// to a `TlsStream` are encrypted when passing through to `S`.
-    #[derive(Debug)]
+    #[derive(log::debug)]
     pub struct TlsStream<S> {
         inner: native_tls::TlsStream<S>,
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -394,7 +394,7 @@ fn tunnel<T>(conn: T, host: String, port: u16, auth: Option<http::header::Header
     ", host, port).into_bytes();
 
         if let Some(value) = auth {
-            log::debug!("tunnel to {}:{} using basic auth", host, port);
+            debug!("tunnel to {}:{} using basic auth", host, port);
             buf.extend_from_slice(b"Proxy-Authorization: ");
             buf.extend_from_slice(value.as_bytes());
             buf.extend_from_slice(b"\r\n");

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -49,7 +49,7 @@ impl TrustDnsResolver {
 
 impl hyper_dns::Resolve for TrustDnsResolver {
     type Addrs = vec::IntoIter<IpAddr>;
-    type Future = Box<dyn Future<Item=Self::Addrs, Error=io::Error> + Send>;
+    type Future = Box<dyn Future<Output=Result<Self::Addrs, io::Error>> + Send>;
 
     fn resolve(&self, name: hyper_dns::Name) -> Self::Future {
         let inner = self.inner.clone();

--- a/src/error.rs
+++ b/src/error.rs
@@ -606,6 +606,9 @@ pub(crate) fn unknown_proxy_scheme() -> Error {
 mod tests {
     use super::*;
 
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
     #[allow(deprecated)]
     #[test]
     fn test_cause_chain() {
@@ -652,6 +655,8 @@ mod tests {
         let err = Error::new(Kind::Io(io), None);
         assert!(err.cause().is_some());
         assert_eq!(err.to_string(), "chain: root");
+        assert_send::<Error>();
+        assert_sync::<Error>();
     }
 
     #[test]

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -27,7 +27,8 @@ impl PolyfillTryInto for Url {
 
 impl<'a> PolyfillTryInto for &'a str {
     fn into_url(self) -> crate::Result<Url> {
-        try_!(Url::parse(self))
+        Url::parse(self)
+            .map_err(crate::error::from)?
             .into_url()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/reqwest/0.9.19")]
+#![feature(async_await)]
 
 //! # reqwest
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/reqwest/0.9.19")]
-#![feature(async_await)]
 
 //! # reqwest
 //!

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -207,9 +207,7 @@ impl Part {
     /// Errors when the file cannot be opened.
     pub fn file<T: AsRef<Path>>(path: T) -> io::Result<Part> {
         let path = path.as_ref();
-        let file_name = path.file_name().and_then(|filename| {
-            Some(filename.to_string_lossy().into_owned())
-        });
+        let file_name = path.file_name().map(|filename| filename.to_string_lossy().into_owned());
         let ext = path.extension()
             .and_then(|ext| ext.to_str())
             .unwrap_or("");

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -234,7 +234,7 @@ impl Part {
 
     /// Tries to set the mime of this part.
     pub fn mime_str(self, mime: &str) -> crate::Result<Part> {
-        Ok(self.mime(try_!(mime.parse())))
+        Ok(self.mime(mime.parse().map_err(crate::error::from)?))
     }
 
     // Re-export when mime 0.4 is available, with split MediaType/MediaRange.

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,10 +1,12 @@
+use std::task::Context;
+use std::pin::Pin;
 use std::mem;
 use std::fmt;
 use std::io::{self, Read};
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use futures::{Async, Poll, Stream};
+use futures::{Poll, Stream};
 use http;
 use serde::de::DeserializeOwned;
 
@@ -370,11 +372,10 @@ struct WaitBody {
 
 impl Stream for WaitBody {
     type Item = <async_impl::Decoder as Stream>::Item;
-    type Error = <async_impl::Decoder as Stream>::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         match self.inner.next() {
-            Some(Ok(chunk)) => Ok(Async::Ready(Some(chunk))),
+            Some(Ok(chunk)) => Ok(Poll::Ready(Some(chunk))),
             Some(Err(e)) => {
                 let req_err = match e {
                     wait::Waited::TimedOut => crate::error::timedout(None),
@@ -384,7 +385,7 @@ impl Stream for WaitBody {
 
                 Err(req_err)
             },
-            None => Ok(Async::Ready(None)),
+            None => Ok(Poll::Ready(None)),
         }
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -55,7 +55,7 @@ impl Certificate {
     pub fn from_der(der: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
             #[cfg(feature = "default-tls")]
-            native: try_!(native_tls::Certificate::from_der(der)),
+            native: native_tls::Certificate::from_der(der).map_err(crate::error::from)?,
             #[cfg(feature = "rustls-tls")]
             original: Cert::Der(der.to_owned()),
         })
@@ -81,7 +81,7 @@ impl Certificate {
     pub fn from_pem(pem: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
             #[cfg(feature = "default-tls")]
-            native: try_!(native_tls::Certificate::from_pem(pem)),
+            native: native_tls::Certificate::from_pem(pem).map_err(crate::error::from)?,
             #[cfg(feature = "rustls-tls")]
             original: Cert::Pem(pem.to_owned())
         })
@@ -152,7 +152,7 @@ impl Identity {
     pub fn from_pkcs12_der(der: &[u8], password: &str) -> crate::Result<Identity> {
         Ok(Identity {
             inner: ClientCert::Pkcs12(
-                try_!(native_tls::Identity::from_pkcs12(der, password))
+                native_tls::Identity::from_pkcs12(der, password).map_err(crate::error::from)?
             ),
         })
     }
@@ -183,10 +183,11 @@ impl Identity {
 
         let (key, certs) = {
             let mut pem = Cursor::new(buf);
-            let certs = try_!(pemfile::certs(&mut pem)
-                .map_err(|_| TLSError::General(String::from("No valid certificate was found"))));
+            let certs = pemfile::certs(&mut pem)
+                .map_err(|_| TLSError::General(String::from("No valid certificate was found")))
+                .map_err(crate::error::from)?;
             pem.set_position(0);
-            let mut sk = try_!(pemfile::pkcs8_private_keys(&mut pem)
+            let mut sk = pemfile::pkcs8_private_keys(&mut pem)
                 .and_then(|pkcs8_keys| {
                     if pkcs8_keys.is_empty() {
                         Err(())
@@ -198,7 +199,8 @@ impl Identity {
                     pem.set_position(0);
                     pemfile::rsa_private_keys(&mut pem)
                 })
-                .map_err(|_| TLSError::General(String::from("No valid private key was found"))));
+                .map_err(|_| TLSError::General(String::from("No valid private key was found")))
+                .map_err(crate::error::from)?;
             if let (Some(sk), false) = (sk.pop(), certs.is_empty()) {
                 (sk, certs)
             } else {

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -1,12 +1,8 @@
-use std::sync::Arc;
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use futures_timer::TryFutureExt as TryFutureTimerExt;
 use futures::future::TryFutureExt;
 
-use futures::{Future, Poll, Stream};
-use std::pin::Pin;
-use std::task::Context;
+use futures::{Future, Stream, task};
 
 async fn timeout_fut<F, I, E>(fut: F, timeout: Option<Duration>) -> Result<I, Waited<E>>
     where F: Future<Output = Result<I,E>> {
@@ -34,7 +30,7 @@ pub(crate) fn timeout<F, I, E>(fut: F, timeout : Option<Duration>) -> Result<I, 
 pub(crate) fn stream<S>(stream: S, timeout: Option<Duration>) -> WaitStream<S>
 where S: Stream {
     WaitStream {
-        stream: executor::spawn(stream),
+        stream: task::spawn(stream),
         timeout,
     }
 }
@@ -52,84 +48,7 @@ impl<E> From<std::io::Error> for Waited<E> {
     }
 }
 
-pub(crate) struct WaitFuture<F> 
-where F: Future
-{
-    future: F,
-    timeout: Option<Duration>,
-}
-
-impl<F, I, E> Future for WaitFuture<F>
-where F: Future<Output = Result<I,E>>
-{
-    type Output = Result<I, E>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        
-    }
-}
-
 pub(crate) struct WaitStream<S> {
-    stream: executor::Spawn<S>,
+    stream: task::spawn<S>,
     timeout: Option<Duration>,
 }
-
-impl<S> Iterator for WaitStream<S>
-where S: Stream {
-    type Item = Result<S::Item, Waited<S::Error>>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let res = block_on(self.timeout, |notify| {
-            self.stream.poll_stream_notify(notify, 0)
-        });
-
-        match res {
-            Ok(Some(val)) => Some(Ok(val)),
-            Ok(None) => None,
-            Err(err) => Some(Err(err)),
-        }
-    }
-}
-
-struct ThreadNotify {
-    thread: thread::Thread,
-}
-
-impl Notify for ThreadNotify {
-    fn notify(&self, _id: usize) {
-        self.thread.unpark();
-    }
-}
-
-fn block_on<F, U, E>(timeout: Option<Duration>, mut poll: F) -> Result<U, Waited<E>>
-where
-    F: FnMut(&Arc<ThreadNotify>) -> Poll<U, E>,
-{
-    let _entered = enter().map_err(Waited::Executor)?;
-    let deadline = timeout.map(|d| {
-        Instant::now() + d
-    });
-    let notify = Arc::new(ThreadNotify {
-        thread: thread::current(),
-    });
-
-    loop {
-        match poll(&notify)? {
-            Poll::Ready(val) => return Ok(val),
-            Poll::Pending => {}
-        }
-
-        if let Some(deadline) = deadline {
-            let now = Instant::now();
-            if now >= deadline {
-                return Err(Waited::TimedOut);
-            }
-
-            thread::park_timeout(deadline - now);
-        } else {
-            thread::park();
-        }
-    }
-}
-
-

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -1,14 +1,20 @@
-use std::time::Duration;
-use futures_timer::TryFutureExt as TryFutureTimerExt;
+use std::time::{Duration, Instant};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use futures::future::TryFutureExt;
+use tokio::future::FutureExt;
 
-use futures::{Future, Stream, task};
+use futures::{Future, Stream};
+use tokio::timer::Delay;
 
 async fn timeout_fut<F, I, E>(fut: F, timeout: Option<Duration>) -> Result<I, Waited<E>>
     where F: Future<Output = Result<I,E>> {
 
     let result: Result<I, Waited<E>> = if let Some(duration) = timeout {
-        fut.map_err(|e| Waited::Inner(e)).timeout(duration).await
+        match fut.map_err(|e| Waited::Inner(e)).timeout(duration).await {
+            Err(_e) => Err(Waited::TimedOut),
+            Ok(r) => r,
+        }
     } else {
         fut.map_err(|e| Waited::Inner(e)).await
     };
@@ -18,37 +24,79 @@ async fn timeout_fut<F, I, E>(fut: F, timeout: Option<Duration>) -> Result<I, Wa
 
 pub(crate) fn timeout<F, I, E>(fut: F, timeout : Option<Duration>) -> Result<I, Waited<E>>
     where F: Future<Output = Result<I,E>> {
-        let future03 = timeout_fut::<F, I, E>();
+        let f = timeout_fut::<F, I, E>(fut, timeout);
 
-        let future01 = future03.compat();
-
-        tokio::runtime::Runtime::new()
-        .map_err(|e| Waited::Executor(e))
-        .map(|runtime| runtime.block_on(future01))
+        match tokio::runtime::Runtime::new() {
+            Err(e) => Err(Waited::Executor(e)),
+            Ok(rt) => rt.block_on(f),
+        }
     }
 
-pub(crate) fn stream<S>(stream: S, timeout: Option<Duration>) -> WaitStream<S>
-where S: Stream {
-    WaitStream {
-        stream: task::spawn(stream),
-        timeout,
-    }
-}
+//TODO: Needed?
+//pub(crate) fn stream<S>(stream: S, timeout: Option<Duration>) -> WaitStream<S>
+//where S: Stream {
+//    WaitStream {
+//        inner: stream,
+//        pending: None,
+//        timeout: timeout,
+//    }
+//}
 
 #[derive(Debug)]
 pub(crate) enum Waited<E> {
     TimedOut,
+    Executor(std::io::Error),
     Inner(E),
-    Executor(E),
-}
-
-impl<E> From<std::io::Error> for Waited<E> {
-    fn from(err: std::io::Error) -> Waited<E> {
-        Waited::Executor
-    }
 }
 
 pub(crate) struct WaitStream<S> {
-    stream: task::spawn<S>,
+    inner: S,
+    pending: Option<Delay>,
     timeout: Option<Duration>,
+}
+
+impl<S> WaitStream<S> {
+    fn inner(self: Pin<&mut Self>) -> Pin<&mut S> {
+        unsafe {
+            Pin::map_unchecked_mut(self, |x| &mut x.inner)
+        }
+    }
+    fn pending(self: Pin<&mut Self>) -> Pin<&mut Option<Delay>> {
+        unsafe {
+            Pin::map_unchecked_mut(self, |x| &mut x.pending)
+        }
+    }
+}
+
+impl<S, T, E> Stream for WaitStream<S> where S: Stream<Item=Result<T, E>> {
+    type Item = Result<T, Waited<E>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        if let Poll::Ready(v) = self.as_mut().inner().as_mut().poll_next(cx) {
+            let r = match v {
+                None => Poll::Ready(None),
+                Some(Err(e)) => Poll::Ready(Some(Err(Waited::Inner(e)))),
+                Some(Ok(v)) => Poll::Ready(Some(Ok(v))),
+            };
+            return r;
+        }
+
+        if let Some(to) = self.timeout.clone() {
+            match self.as_mut().pending().as_pin_mut() {
+                None => {
+                    self.as_mut().pending().get_mut().replace(tokio::timer::Delay::new(Instant::now() + to));
+                    Poll::Pending
+                }
+                Some(pending) => {
+                    let r = match pending.poll(cx) {
+                        Poll::Pending => Poll::Pending,
+                        Poll::Ready(_) => Poll::Ready(Some(Err(Waited::TimedOut))),
+                    };
+                    r
+                }
+            }
+        } else {
+            Poll::Pending
+        }
+    }
 }

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -6,6 +6,8 @@ use futures::{Future, Poll, Stream};
 use futures::executor::{self, Notify};
 use futures::spawn::Spawn;
 use tokio_executor::{enter, EnterError};
+use std::pin::Pin;
+use std::task::Context;
 
 pub(crate) fn timeout<F, I, E>(fut: F, timeout: Option<Duration>) -> Result<I, Waited<E>>
 where
@@ -35,6 +37,23 @@ pub(crate) enum Waited<E> {
 impl<E> From<E> for Waited<E> {
     fn from(err: E) -> Waited<E> {
         Waited::Inner(err)
+    }
+}
+
+pub(crate) struct WaitFuture<F, I, E> 
+where F: Future<Output = Result<I, E>>
+{
+    future: F,
+    timeout: Option<Duration>,
+}
+
+impl<F, I, E> Future for WaitFuture<F, I, E>
+where F: Future<Output = Result<I,E>>
+{
+    type Output = Result<I, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        
     }
 }
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,36 +1,31 @@
-extern crate futures;
-extern crate libflate;
-extern crate reqwest;
-extern crate hyper;
-extern crate tokio;
-extern crate bytes;
+#![feature(async_await)]
 
 #[macro_use]
 mod support;
 
-use std::io::{self, Write};
+//use std::io::Write;
 use std::time::Duration;
 
-use futures::{Future, Stream};
-use tokio::runtime::current_thread::Runtime;
+use futures::TryStreamExt;
+//use tokio::runtime::current_thread::Runtime;
 
-use reqwest::r#async::Client;
+use reqwest::r#async::{Body, Client};
 use reqwest::r#async::multipart::{Form, Part};
 
 use bytes::Bytes;
 
-#[test]
-fn gzip_response() {
-    gzip_case(10_000, 4096);
-}
+//#[test]
+//fn gzip_response() {
+//    gzip_case(10_000, 4096);
+//}
+//
+//#[test]
+//fn gzip_single_byte_chunks() {
+//    gzip_case(10, 1);
+//}
 
-#[test]
-fn gzip_single_byte_chunks() {
-    gzip_case(10, 1);
-}
-
-#[test]
-fn response_text() {
+#[tokio::test]
+async fn response_text() {
     let _ = env_logger::try_init();
 
     let server = server! {
@@ -50,23 +45,17 @@ fn response_text() {
             "
     };
 
-    let mut rt = Runtime::new().expect("new rt");
-
     let client = Client::new();
 
-    let res_future = client.get(&format!("http://{}/text", server.addr()))
+    let mut res = client.get(&format!("http://{}/text", server.addr()))
         .send()
-        .and_then(|mut res| res.text())
-        .and_then(|text| {
-            assert_eq!("Hello", text);
-            Ok(())
-        });
-
-    rt.block_on(res_future).unwrap();
+        .await.expect("Failed to get");
+    let text = res.text().await.expect("Failed to get text");
+    assert_eq!("Hello", text);
 }
 
-#[test]
-fn response_json() {
+#[tokio::test]
+async fn response_json() {
     let _ = env_logger::try_init();
 
     let server = server! {
@@ -86,26 +75,23 @@ fn response_json() {
             "
     };
 
-    let mut rt = Runtime::new().expect("new rt");
-
     let client = Client::new();
 
-    let res_future = client.get(&format!("http://{}/json", server.addr()))
+    let mut res = client.get(&format!("http://{}/json", server.addr()))
         .send()
-        .and_then(|mut res| res.json::<String>())
-        .and_then(|text| {
-            assert_eq!("Hello", text);
-            Ok(())
-        });
-
-    rt.block_on(res_future).unwrap();
+        .await
+        .expect("Failed to get");
+    let text = res.json::<String>().await.expect("Failed to get json");
+    assert_eq!("Hello", text);
 }
 
-#[test]
-fn multipart() {
+#[tokio::test]
+async fn multipart() {
     let _ = env_logger::try_init();
 
-    let stream = futures::stream::once::<_, hyper::Error>(Ok(hyper::Chunk::from("part1 part2".to_owned())));
+    let stream = futures::stream::once(
+        futures::future::ready::<Result<_, hyper::Error>>(Ok(hyper::Chunk::from("part1 part2".to_owned())))
+    );
     let part = Part::stream(stream);
 
     let form = Form::new()
@@ -156,25 +142,19 @@ fn multipart() {
 
     let url = format!("http://{}/multipart/1", server.addr());
 
-    let mut rt = Runtime::new().expect("new rt");
-
     let client = Client::new();
 
-    let res_future = client.post(&url)
+    let res = client.post(&url)
         .multipart(form)
         .send()
-        .and_then(|res| {
-            assert_eq!(res.url().as_str(), &url);
-            assert_eq!(res.status(), reqwest::StatusCode::OK);
-
-            Ok(())
-        });
-
-    rt.block_on(res_future).unwrap();
+        .await
+        .expect("Failed to post multipart");
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
 }
 
-#[test]
-fn request_timeout() {
+#[tokio::test]
+async fn request_timeout() {
     let _ = env_logger::try_init();
 
     let server = server! {
@@ -195,26 +175,25 @@ fn request_timeout() {
         read_timeout: Duration::from_secs(2)
     };
 
-    let mut rt = Runtime::new().expect("new rt");
-
     let client = Client::builder()
         .timeout(Duration::from_millis(500))
         .build()
         .unwrap();
 
     let url = format!("http://{}/slow", server.addr());
-    let fut = client
+    let res = client
         .get(&url)
-        .send();
+        .send()
+        .await;
 
-    let err = rt.block_on(fut).unwrap_err();
+    let err = res.unwrap_err();
 
     assert!(err.is_timeout());
     assert_eq!(err.url().map(|u| u.as_str()), Some(url.as_str()));
 }
 
-#[test]
-fn response_timeout() {
+#[tokio::test]
+async fn response_timeout() {
     let _ = env_logger::try_init();
 
     let server = server! {
@@ -235,85 +214,88 @@ fn response_timeout() {
         write_timeout: Duration::from_secs(2)
     };
 
-    let mut rt = Runtime::new().expect("new rt");
-
     let client = Client::builder()
         .timeout(Duration::from_millis(500))
         .build()
         .unwrap();
 
     let url = format!("http://{}/slow", server.addr());
-    let fut = client
+    let res = client
         .get(&url)
         .send()
-        .and_then(|res| res.into_body().concat2());
+        .await
+        .expect("Failed to get");
+    let body: Result<_, _> = res.into_body().try_concat().await;
 
-    let err = rt.block_on(fut).unwrap_err();
+    let err = body.unwrap_err();
 
     assert!(err.is_timeout());
 }
 
-fn gzip_case(response_size: usize, chunk_size: usize) {
-    let content: String = (0..response_size).into_iter().map(|i| format!("test {}", i)).collect();
-    let mut encoder = libflate::gzip::Encoder::new(Vec::new()).unwrap();
-    match encoder.write(content.as_bytes()) {
-        Ok(n) => assert!(n > 0, "Failed to write to encoder."),
-        _ => panic!("Failed to gzip encode string."),
-    };
+//fn gzip_case(response_size: usize, chunk_size: usize) {
+//    let content: String = (0..response_size).into_iter().map(|i| format!("test {}", i)).collect();
+//    let mut encoder = libflate::gzip::Encoder::new(Vec::new()).unwrap();
+//    match encoder.write(content.as_bytes()) {
+//        Ok(n) => assert!(n > 0, "Failed to write to encoder."),
+//        _ => panic!("Failed to gzip encode string."),
+//    };
+//
+//    let gzipped_content = encoder.finish().into_result().unwrap();
+//
+//    let mut response = format!("\
+//            HTTP/1.1 200 OK\r\n\
+//            Server: test-accept\r\n\
+//            Content-Encoding: gzip\r\n\
+//            Content-Length: {}\r\n\
+//            \r\n", &gzipped_content.len())
+//        .into_bytes();
+//    response.extend(&gzipped_content);
+//
+//    let server = server! {
+//        request: b"\
+//            GET /gzip HTTP/1.1\r\n\
+//            user-agent: $USERAGENT\r\n\
+//            accept: */*\r\n\
+//            accept-encoding: gzip\r\n\
+//            host: $HOST\r\n\
+//            \r\n\
+//            ",
+//        chunk_size: chunk_size,
+//        write_timeout: Duration::from_millis(10),
+//        response: response
+//    };
+//
+//    let mut rt = Runtime::new().expect("new rt");
+//
+//    let client = Client::new();
+//
+//    let res_future = client.get(&format!("http://{}/gzip", server.addr()))
+//        .send()
+//        .and_then(|res| {
+//            let body = res.into_body();
+//            body.concat2()
+//        })
+//        .and_then(|buf| {
+//            let body = std::str::from_utf8(&buf).unwrap();
+//
+//            assert_eq!(body, &content);
+//
+//            Ok(())
+//        });
+//
+//    rt.block_on(res_future).unwrap();
+//}
 
-    let gzipped_content = encoder.finish().into_result().unwrap();
-
-    let mut response = format!("\
-            HTTP/1.1 200 OK\r\n\
-            Server: test-accept\r\n\
-            Content-Encoding: gzip\r\n\
-            Content-Length: {}\r\n\
-            \r\n", &gzipped_content.len())
-        .into_bytes();
-    response.extend(&gzipped_content);
-
-    let server = server! {
-        request: b"\
-            GET /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        chunk_size: chunk_size,
-        write_timeout: Duration::from_millis(10),
-        response: response
-    };
-
-    let mut rt = Runtime::new().expect("new rt");
-
-    let client = Client::new();
-
-    let res_future = client.get(&format!("http://{}/gzip", server.addr()))
-        .send()
-        .and_then(|res| {
-            let body = res.into_body();
-            body.concat2()
-        })
-        .and_then(|buf| {
-            let body = std::str::from_utf8(&buf).unwrap();
-
-            assert_eq!(body, &content);
-
-            Ok(())
-        });
-
-    rt.block_on(res_future).unwrap();
-}
-
-#[test]
-fn body_stream() {
+#[tokio::test]
+async fn body_stream() {
     let _ = env_logger::try_init();
 
-    let source: Box<dyn Stream<Item = Bytes, Error = io::Error> + Send>
-        = Box::new(futures::stream::iter_ok::<_, io::Error>(
-            vec![Bytes::from_static(b"123"), Bytes::from_static(b"4567")]));
+    let source = futures::stream::iter::<Vec<Result<Bytes, std::io::Error>>>(
+        vec![
+            Ok(Bytes::from_static(b"123")),
+            Ok(Bytes::from_static(b"4567")),
+        ]
+    );
 
     let expected_body = "3\r\n123\r\n4\r\n4567\r\n0\r\n\r\n";
 
@@ -338,19 +320,14 @@ fn body_stream() {
 
     let url = format!("http://{}/post", server.addr());
 
-    let mut rt = Runtime::new().expect("new rt");
-
     let client = Client::new();
 
-    let res_future = client.post(&url)
-        .body(source)
+    let res = client.post(&url)
+        .body(Body::wrap_stream(source))
         .send()
-        .and_then(|res| {
-            assert_eq!(res.url().as_str(), &url);
-            assert_eq!(res.status(), reqwest::StatusCode::OK);
+        .await
+        .expect("Failed to post");
 
-            Ok(())
-        });
-
-    rt.block_on(res_future).unwrap();
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,9 +1,5 @@
-extern crate reqwest;
-
 #[macro_use]
 mod support;
-
-use std::io::Read;
 
 #[test]
 fn test_response_text() {
@@ -127,9 +123,7 @@ fn test_response_copy_to() {
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"5");
 
-    let mut buf: Vec<u8> = vec![];
-    res.copy_to(&mut buf).unwrap();
-    assert_eq!(b"Hello", buf.as_slice());
+    assert_eq!("Hello".to_owned(), res.text().unwrap());
 }
 
 #[test]
@@ -160,9 +154,7 @@ fn test_get() {
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
     assert_eq!(res.remote_addr(), Some(server.addr()));
 
-    let mut buf = [0; 1024];
-    let n = res.read(&mut buf).unwrap();
-    assert_eq!(n, 0)
+    assert_eq!(res.text().unwrap().len(), 0)
 }
 
 #[test]
@@ -198,9 +190,7 @@ fn test_post() {
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"post");
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
 
-    let mut buf = [0; 1024];
-    let n = res.read(&mut buf).unwrap();
-    assert_eq!(n, 0)
+    assert_eq!(res.text().unwrap().len(), 0)
 }
 
 #[test]

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,10 +1,6 @@
-extern crate env_logger;
-extern crate reqwest;
-
 #[macro_use]
 mod support;
 
-use std::io::Read;
 use std::time::Duration;
 
 #[test]
@@ -160,7 +156,6 @@ fn test_read_timeout() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"5");
 
-    let mut buf = [0; 1024];
-    let err = res.read(&mut buf).unwrap_err();
+    let err = res.text().unwrap_err();
     assert_eq!(err.to_string(), "timed out");
 }

--- a/tests_disabled/gzip.rs
+++ b/tests_disabled/gzip.rs
@@ -1,6 +1,3 @@
-extern crate reqwest;
-extern crate libflate;
-
 #[macro_use]
 mod support;
 


### PR DESCRIPTION
# Port to Futures 0.3

## What?

The point of this exercise is twofold-

1. refactor the external API to use futures 0.3 such that this crate is compatible with the async/await syntax
2. use the async/await syntax internally to refactor this crate


## Why?
I currently depend on this crate for my crate [chesterfield](https://github.com/danieleades/chesterfield) and i've had to use the compat layer to get futures 0.3. This means that there's about 4 places in my codebase where i've had to use the word `compat()`. For just a few dozen hours of work refactoring reqwest, i can remove these 4 calls. It really is that easy.
In all seriousness it should massively contribute to the maintainability of this crate, and make the learning curve a little more shallow for people hoping to contribute features or fix bugs.

## How?

I've done all the easy parts swapping the old Future and Stream implementations to the new style. I've also moved the crate to the 2018 edition (see  #589) to allow to use async/await syntax.

I'm at a point now where I'd really appreciate some input, both from someone more familiar with this crate, and someone more familiar with the new futures crate.

- [x] port all the obvious bits from futures 0.1 to futures 0.3
- [ ] rewrite the 'wait' module with the spawning API (*Some help here would be appreciated!*)
- [ ] refactor the tests as required
- [ ] rewrite the examples using async/await syntax
- [ ] look for opportunities to refactor internally using async/await syntax. Some obvious candidates include-

    - ClientHandle::new
    - ClientHandle::execute_request
    - "impl Connect for Connector"

## Notes
I humbly suggest that the best way to start using tokio and hyper 0.1 futures is to use the futures compat layer to convert them to futures 0.3, and vice versa to run 0.3 futures on tokio executors. When tokio and hyper futures 0.3 stabilises, we can switch to the new releases and simply remove the .compat() methods.
This way we skip the whole hell of depending on the master version of every dependency.

**ANY INPUT GREATLY APPRECIATED!!**