### PR TITLE
cargo: update to rustls 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,14 @@ uuid = { version = "0.7", features = ["v4"] }
 # Optional deps...
 
 hyper-old-types = { version = "0.11", optional = true, features = ["compat"] }
-hyper-rustls = { version = "0.16", optional = true }
+hyper-rustls = { version = "^0.17.1", optional = true }
 hyper-tls = { version = "0.3.2", optional = true }
 native-tls = { version = "0.2", optional = true }
-rustls = { version = "0.15", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.16", features = ["dangerous_configuration"], optional = true }
 socks = { version = "0.3.2", optional = true }
-tokio-rustls = { version = "0.9", optional = true }
+tokio-rustls = { version = "0.10", optional = true }
 trust-dns-resolver = { version = "0.11", optional = true }
-webpki-roots = { version = "0.16", optional = true }
+webpki-roots = { version = "0.17", optional = true }
 cookie_store = "0.7.0"
 cookie = "0.12.0"
 time = "0.1.42"

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -10,6 +10,19 @@ fn test_badssl_modern() {
     assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
 }
 
+#[cfg(feature = "rustls-tls")]
+#[test]
+fn test_rustls_badssl_modern() {
+    let text = reqwest::Client::builder()
+        .use_rustls_tls()
+        .build().unwrap()
+        .get("https://mozilla-modern.badssl.com/")
+        .send().unwrap()
+        .text().unwrap();
+
+    assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
+}
+
 #[cfg(feature = "tls")]
 #[test]
 fn test_badssl_self_signed() {


### PR DESCRIPTION
This updates rustls to latest 0.16 version (plus all interdependent crates). It also fixes a minor deprecation warning which was triggering on tests.

Closes #594