### PR TITLE
Give more useful errors when connection through proxy fails

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -458,8 +458,17 @@ where
                         // else read more
                     } else if read.starts_with(b"HTTP/1.1 407") {
                         return Err(io::Error::new(io::ErrorKind::Other, "proxy authentication required"));
+                    } else if read.starts_with(b"HTTP/1.1 403") {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            "proxy blocked this request",
+                        ));
                     } else {
-                        return Err(io::Error::new(io::ErrorKind::Other, "unsuccessful tunnel"));
+                        let (fst, _) = read.split_at(12);
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("unsuccessful tunnel: {:?}", fst).as_str(),
+                        ));
                     }
                 }
             }


### PR DESCRIPTION
Before the fix anything other than 200 & 407 would throw an unhelpful
`unsuccessful tunnel` error.
After this change,
- Explicit handling of 403, where the proxy forbids a connection.
- All other responses will be part of the error message.