### PR TITLE
pub use Url::Position for easier slicing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,7 @@ pub use hyper::Method;
 pub use hyper::{StatusCode, Version};
 pub use url::Url;
 pub use url::ParseError as UrlError;
+pub use url::Position as UrlPosition;
 
 pub use self::client::{Client, ClientBuilder};
 pub use self::error::{Error, Result};


### PR DESCRIPTION
Re-export `Url::Position` to easy the usage of the the exposed `Url::Index` traits