### PR TITLE
Add builder function for setting Hyper executor

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -5,6 +5,7 @@ use std::net::IpAddr;
 
 use bytes::Bytes;
 use futures::{Async, Future, Poll};
+use futures::future::Executor;
 use crate::header::{
     Entry,
     HeaderMap,
@@ -73,7 +74,6 @@ struct Config {
     #[cfg(feature = "tls")]
     certs_verification: bool,
     connect_timeout: Option<Duration>,
-    max_idle_per_host: usize,
     #[cfg(feature = "tls")]
     identity: Option<Identity>,
     proxies: Vec<Proxy>,
@@ -85,10 +85,10 @@ struct Config {
     #[cfg(feature = "tls")]
     tls: TlsBackend,
     http2_only: bool,
-    http1_title_case_headers: bool,
     local_address: Option<IpAddr>,
     nodelay: bool,
     cookie_store: Option<cookie::CookieStore>,
+    http_builder: hyper::client::Builder,
 }
 
 impl ClientBuilder {
@@ -109,7 +109,6 @@ impl ClientBuilder {
                 #[cfg(feature = "tls")]
                 certs_verification: true,
                 connect_timeout: None,
-                max_idle_per_host: std::usize::MAX,
                 proxies: Vec::new(),
                 redirect_policy: RedirectPolicy::default(),
                 referer: true,
@@ -121,10 +120,10 @@ impl ClientBuilder {
                 #[cfg(feature = "tls")]
                 tls: TlsBackend::default(),
                 http2_only: false,
-                http1_title_case_headers: false,
                 local_address: None,
                 nodelay: false,
                 cookie_store: None,
+                http_builder: hyper::Client::builder(),
             },
         }
     }
@@ -195,18 +194,7 @@ impl ClientBuilder {
 
         connector.set_timeout(config.connect_timeout);
 
-        let mut builder = hyper::Client::builder();
-        if config.http2_only {
-            builder.http2_only(true);
-        }
-
-        builder.max_idle_per_host(config.max_idle_per_host);
-
-        if config.http1_title_case_headers {
-            builder.http1_title_case_headers(true);
-        }
-
-        let hyper_client = builder.build(connector);
+        let hyper_client = config.http_builder.build(connector);
 
         let proxies_maybe_http_auth = proxies
             .iter()
@@ -381,19 +369,29 @@ impl ClientBuilder {
     ///
     /// Default is usize::MAX (no limit).
     pub fn max_idle_per_host(mut self, max: usize) -> ClientBuilder {
-        self.config.max_idle_per_host = max;
+        self.config.http_builder.max_idle_per_host(max);
         self
     }
 
     /// Only use HTTP/2.
     pub fn h2_prior_knowledge(mut self) -> ClientBuilder {
         self.config.http2_only = true;
+        self.config.http_builder.http2_only(true);
         self
     }
 
     /// Enable case sensitive headers.
     pub fn http1_title_case_headers(mut self) -> ClientBuilder {
-        self.config.http1_title_case_headers = true;
+        self.config.http_builder.http1_title_case_headers(true);
+        self
+    }
+
+    /// Allow changing the Hyper runtime executor
+    pub fn executor<E>(mut self, executor: E) -> ClientBuilder
+    where
+        E: Executor<Box<dyn Future<Item=(), Error=()> + Send>> + Send + Sync + 'static
+    {
+        self.config.http_builder.executor(executor);
         self
     }
 


### PR DESCRIPTION
I ended up having to change some of how the builder worked to get the `Executor` to pass through to Hyper's builder.

NB: I've only made this change for the async builder so far - I wasn't sure if this option should also be exposed on the sync interface.

Closes #557 