### PR TITLE
add ability to create a client with own tls connector

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -88,6 +88,28 @@ impl Connector {
         })
     }
 
+    #[cfg(feature = "default-tls")]
+    pub(crate) fn from_built_default<T> (
+        tls: TlsConnector,
+        proxies: Arc<Vec<Proxy>>,
+        local_addr: T,
+        nodelay: bool) -> ::Result<Connector>
+        where
+            T: Into<Option<IpAddr>>,
+    {
+
+        let mut http = http_connector()?;
+        http.set_local_address(local_addr.into());
+        http.enforce_http(false);
+
+        Ok(Connector {
+            inner: Inner::DefaultTls(http, tls),
+            proxies,
+            timeout: None,
+            nodelay
+        })
+    }
+
     #[cfg(feature = "rustls-tls")]
     pub(crate) fn new_rustls_tls<T>(
         tls: rustls::ClientConfig,

--- a/src/error.rs
+++ b/src/error.rs
@@ -148,6 +148,8 @@ impl Error {
             Kind::Io(ref e) => Some(e),
             Kind::UrlEncoded(ref e) => Some(e),
             Kind::Json(ref e) => Some(e),
+            #[cfg(feature = "tls")]
+            Kind::UnknownPreconfiguredTls => None,
             Kind::UrlBadScheme |
             Kind::TooManyRedirects |
             Kind::RedirectLoop |
@@ -290,6 +292,8 @@ impl fmt::Display for Error {
             Kind::UnknownProxyScheme => f.write_str("Unknown proxy scheme"),
             Kind::Timer => f.write_str("timer unavailable"),
             Kind::BlockingClientInFutureContext => f.write_str(BLOCK_IN_FUTURE),
+            #[cfg(feature = "tls")]
+            Kind::UnknownPreconfiguredTls => f.write_str("Unknown TLS backend passed to `use_preconfigured_tls`"),
         }
     }
 }
@@ -327,6 +331,8 @@ impl StdError for Error {
             Kind::UnknownProxyScheme => "Unknown proxy scheme",
             Kind::Timer => "timer unavailable",
             Kind::BlockingClientInFutureContext => BLOCK_IN_FUTURE,
+            #[cfg(feature = "tls")]
+            Kind::UnknownPreconfiguredTls => "Unknown TLS backend passed to `use_preconfigured_tls`",
         }
     }
 
@@ -349,6 +355,8 @@ impl StdError for Error {
             Kind::Io(ref e) => e.cause(),
             Kind::UrlEncoded(ref e) => e.cause(),
             Kind::Json(ref e) => e.cause(),
+            #[cfg(feature = "tls")]
+            Kind::UnknownPreconfiguredTls => None,
             Kind::UrlBadScheme |
             Kind::TooManyRedirects |
             Kind::RedirectLoop |
@@ -376,6 +384,8 @@ impl StdError for Error {
             Kind::Io(ref e) => e.source(),
             Kind::UrlEncoded(ref e) => e.source(),
             Kind::Json(ref e) => e.source(),
+            #[cfg(feature = "tls")]
+            Kind::UnknownPreconfiguredTls => None,
             Kind::UrlBadScheme |
             Kind::TooManyRedirects |
             Kind::RedirectLoop |
@@ -411,6 +421,8 @@ pub(crate) enum Kind {
     UnknownProxyScheme,
     Timer,
     BlockingClientInFutureContext,
+    #[cfg(feature = "tls")]
+    UnknownPreconfiguredTls,
 }
 
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -262,8 +262,13 @@ impl fmt::Debug for Identity {
 pub(crate) enum TlsBackend {
     #[cfg(feature = "default-tls")]
     Default,
+    #[cfg(feature = "default-tls")]
+    BuiltDefault(native_tls::TlsConnector),
     #[cfg(feature = "rustls-tls")]
-    Rustls
+    Rustls,
+    #[cfg(feature = "rustls-tls")]
+    BuiltRustls(rustls::ClientConfig),
+    UnknownPreconfigured,
 }
 
 impl Default for TlsBackend {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -459,3 +459,42 @@ fn test_appended_headers_not_overwritten() {
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
     assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
 }
+
+#[cfg(feature = "tls")]
+#[test]
+fn use_preconfigured_tls_with_bogus_backend() {
+    struct DefinitelyNotTls;
+
+    reqwest::Client::builder()
+        .use_preconfigured_tls(DefinitelyNotTls)
+        .build()
+        .expect_err("definitely is not TLS");
+}
+
+#[cfg(feature = "default-tls")]
+#[test]
+fn use_preconfigured_tls_default() {
+    extern crate native_tls;
+
+    let tls = native_tls::TlsConnector::builder()
+        .build()
+        .expect("tls builder");
+
+    reqwest::Client::builder()
+        .use_preconfigured_tls(tls)
+        .build()
+        .expect("preconfigured default tls");
+}
+
+#[cfg(feature = "rustls-tls")]
+#[test]
+fn use_preconfigured_tls_default() {
+    extern crate rustls;
+
+    let tls = rustls::ClientConfig::new();
+
+    reqwest::Client::builder()
+        .use_preconfigured_tls(tls)
+        .build()
+        .expect("preconfigured rustls tls");
+}


### PR DESCRIPTION
Adapts #562. Instead of the builder method returning a `bool`, the `build` call will return an error if it didn't understand the `Any` value.