### PR TITLE
added is_network_error to error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -213,6 +213,27 @@ impl Error {
         }
     }
 
+    /// Returns true, if a network error occured.
+    #[inline]
+    pub fn is_network_error(&self) -> bool {
+        match self.inner.kind {
+            Kind::Hyper(ref e) => {
+                if e.is_canceled() {
+                    true
+                } else if e.is_closed() {
+                    true
+                } else if e.is_connect() {
+                    true
+                } else if e.is_incomplete_message() {
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
     /// Returns the status code, if the error was generated from a response.
     #[inline]
     pub fn status(&self) -> Option<StatusCode> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -218,13 +218,7 @@ impl Error {
     pub fn is_network_error(&self) -> bool {
         match self.inner.kind {
             Kind::Hyper(ref e) => {
-                if e.is_canceled() {
-                    true
-                } else if e.is_closed() {
-                    true
-                } else if e.is_connect() {
-                    true
-                } else if e.is_incomplete_message() {
+                if e.is_canceled() || e.is_closed() || e.is_connect() || e.is_incomplete_message() {
                     true
                 } else {
                     false


### PR DESCRIPTION
The issue wasn't very specific, on what exactly can be considered a network error, so I used [this](https://qr.ae/TWylsy) answer as a guideline.

The following errors can occur:
- `http::Error`
- `hyper::Error`
- `mime::FromStrError`
- `url::ParseError`
- `TlsIncompatible`
- `native_tls::Error`
- `io::Error` (for dns)
- `io::Error` (for io)
- `serde_urlencoded::ser::Error`
- `serde_json::Error`
- `TooManyRedirects`
- `RedirectLoop`
- `Status(StatusCode)`
- `UnknownProxyScheme`
- `Timer`
- `BlockingClientInFutureContext`

I narrowed the relevant errors down to
- `hyper::Error`
- `native_tls::Error`
- `io::Error` (for dns)
- `io::Error` (for io)

Because I don't know how you should match (idiomatically) against string errors, that are returned by `native_tls::Error` and the `io::Error`,
I only matched [hyper::Error](https://docs.rs/hyper/0.13.0-alpha.1/hyper/error/struct.Error.html)s.

closes #560 
