### PR TITLE
Fix doc links

### DIFF
--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -1,7 +1,7 @@
 //! multipart/form-data
 //!
-//! To send a `multipart/form-data` body, a [`Form`](Form) is built up, adding
-//! fields or customized [`Part`](Part)s, and then calling the
+//! To send a `multipart/form-data` body, a [`Form`](crate::multipart::Form) is built up, adding
+//! fields or customized [`Part`](crate::multipart::Part)s, and then calling the
 //! [`multipart`][builder] method on the `RequestBuilder`.
 //!
 //! # Example

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -40,6 +40,14 @@ use winreg::RegKey;
 /// check each `Proxy` in the order it was added. This could mean that a
 /// `Proxy` added first with eager intercept rules, such as `Proxy::all`,
 /// would prevent a `Proxy` later in the list from ever working, so take care.
+///
+/// By enabling the `"socks"` feature it is possible to use a socks proxy:
+/// ```rust
+/// # fn run() -> Result<(), Box<std::error::Error>> {
+/// let proxy = reqwest::Proxy::http("socks5://192.168.1.1:9000")?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug)]
 pub struct Proxy {
     intercept: Intercept,


### PR DESCRIPTION
Compiling the documentation caused some warnings;
```
warning: `[Form]` cannot be resolved, ignoring it...
 --> src/multipart.rs:3:54
  |
3 | //! To send a `multipart/form-data` body, a [`Form`](Form) is built up, adding
  |                                                      ^^^^ cannot be resolved, ignoring
  |
  = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
  = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[Part]` cannot be resolved, ignoring it...
 --> src/multipart.rs:4:35
  |
4 | //! fields or customized [`Part`](Part)s, and then calling the
  |                                   ^^^^ cannot be resolved, ignoring
  |
  = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

    Finished dev [unoptimized + debuginfo] target(s) in 45.34s
```