### PR TITLE
Revert cargo fmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,7 @@ dist: trusty
 env:
   global:
     - REQWEST_TEST_BODY_FULL=1
-before_script:
-  - rustup component add rustfmt
+
 script:
-  - cargo fmt -- --check
   - cargo build $FEATURES
   - cargo test -v $FEATURES -- --test-threads=1

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,11 +1,16 @@
 #![deny(warnings)]
 
+extern crate futures;
+extern crate reqwest;
+extern crate tokio;
+
+use std::mem;
+use std::io::{self, Cursor};
 use futures::{Future, Stream};
 use reqwest::r#async::{Client, Decoder};
-use std::io::{self, Cursor};
-use std::mem;
 
-fn fetch() -> impl Future<Item = (), Error = ()> {
+
+fn fetch() -> impl Future<Item=(), Error=()> {
     Client::new()
         .get("https://hyper.rs")
         .send()
@@ -18,9 +23,10 @@ fn fetch() -> impl Future<Item = (), Error = ()> {
         .map_err(|err| println!("request error: {}", err))
         .map(|body| {
             let mut body = Cursor::new(body);
-            let _ = io::copy(&mut body, &mut io::stdout()).map_err(|err| {
-                println!("stdout error: {}", err);
-            });
+            let _ = io::copy(&mut body, &mut io::stdout())
+                .map_err(|err| {
+                    println!("stdout error: {}", err);
+                });
         })
 }
 

--- a/examples/async_multiple_requests.rs
+++ b/examples/async_multiple_requests.rs
@@ -1,5 +1,11 @@
 #![deny(warnings)]
 
+extern crate futures;
+extern crate reqwest;
+extern crate tokio;
+extern crate serde;
+extern crate serde_json;
+
 use futures::Future;
 use reqwest::r#async::{Client, Response};
 use serde::Deserialize;
@@ -15,18 +21,27 @@ struct SlideshowContainer {
     slideshow: Slideshow,
 }
 
-fn fetch() -> impl Future<Item = (), Error = ()> {
+fn fetch() -> impl Future<Item=(), Error=()> {
     let client = Client::new();
 
-    let json = |mut res: Response| res.json::<SlideshowContainer>();
+    let json = |mut res : Response | {
+        res.json::<SlideshowContainer>()
+    };
 
-    let request1 = client.get("https://httpbin.org/json").send().and_then(json);
+    let request1 =
+        client
+            .get("https://httpbin.org/json")
+            .send()
+            .and_then(json);
 
-    let request2 = client.get("https://httpbin.org/json").send().and_then(json);
+    let request2 =
+        client
+            .get("https://httpbin.org/json")
+            .send()
+            .and_then(json);
 
-    request1
-        .join(request2)
-        .map(|(res1, res2)| {
+    request1.join(request2)
+        .map(|(res1, res2)|{
             println!("{:?}", res1);
             println!("{:?}", res2);
         })

--- a/examples/async_stream.rs
+++ b/examples/async_stream.rs
@@ -1,11 +1,18 @@
 #![deny(warnings)]
 
+#[macro_use]
+extern crate futures;
+extern crate bytes;
+extern crate reqwest;
+extern crate tokio;
+extern crate tokio_threadpool;
+
 use std::io::{self, Cursor};
 use std::mem;
 use std::path::Path;
 
 use bytes::Bytes;
-use futures::{try_ready, Async, Future, Poll, Stream};
+use futures::{Async, Future, Poll, Stream};
 use reqwest::r#async::{Client, Decoder};
 use tokio::fs::File;
 use tokio::io::AsyncRead;

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -1,3 +1,5 @@
+extern crate reqwest;
+
 fn main() {
     reqwest::Client::new()
         .post("http://www.baidu.com")

--- a/examples/json_dynamic.rs
+++ b/examples/json_dynamic.rs
@@ -3,16 +3,19 @@
 //! This is useful for some ad-hoc experiments and situations when you don't
 //! really care about the structure of the JSON and just need to display it or
 //! process it at runtime.
-use serde_json::json;
+extern crate reqwest;
+#[macro_use] extern crate serde_json;
 
 fn main() -> Result<(), reqwest::Error> {
     let echo_json: serde_json::Value = reqwest::Client::new()
         .post("https://jsonplaceholder.typicode.com/posts")
-        .json(&json!({
-            "title": "Reqwest.rs",
-            "body": "https://docs.rs/reqwest",
-            "userId": 1
-        }))
+        .json(
+            &json!({
+                "title": "Reqwest.rs",
+                "body": "https://docs.rs/reqwest",
+                "userId": 1
+            })
+        )
         .send()?
         .json()?;
 

--- a/examples/json_typed.rs
+++ b/examples/json_typed.rs
@@ -3,6 +3,9 @@
 //! In contrast to the arbitrary JSON example, this brings up the full power of
 //! Rust compile-time type system guaranties though it requires a little bit
 //! more code.
+extern crate reqwest;
+extern crate serde;
+extern crate serde_json;
 
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +23,7 @@ fn main() -> Result<(), reqwest::Error> {
         id: None,
         title: "Reqwest.rs".into(),
         body: "https://docs.rs/reqwest".into(),
-        user_id: 1,
+        user_id: 1
     };
     let new_post: Post = reqwest::Client::new()
         .post("https://jsonplaceholder.typicode.com/posts")

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,6 +2,9 @@
 
 //! `cargo run --example simple`
 
+extern crate reqwest;
+extern crate env_logger;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -1,6 +1,6 @@
 pub use self::body::{Body, Chunk};
-pub use self::client::{Client, ClientBuilder};
 pub use self::decoder::{Decoder, ReadableChunks};
+pub use self::client::{Client, ClientBuilder};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::{Response, ResponseBuilderExt};
 

--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
+use futures::{Future, Stream, Poll, Async, try_ready};
 use bytes::{Buf, Bytes};
-use futures::{try_ready, Async, Future, Poll, Stream};
 use hyper::body::Payload;
 use tokio::timer::Delay;
 
@@ -15,7 +15,7 @@ enum Inner {
     Hyper {
         body: hyper::Body,
         timeout: Option<Delay>,
-    },
+    }
 }
 
 impl Body {
@@ -29,7 +29,10 @@ impl Body {
     #[inline]
     pub(crate) fn response(body: hyper::Body, timeout: Option<Delay>) -> Body {
         Body {
-            inner: Inner::Hyper { body, timeout },
+            inner: Inner::Hyper {
+                body,
+                timeout,
+            },
         }
     }
 
@@ -62,7 +65,7 @@ impl Body {
             Inner::Hyper { body, timeout } => {
                 debug_assert!(timeout.is_none());
                 (None, body)
-            }
+            },
         }
     }
 }
@@ -74,17 +77,14 @@ impl Stream for Body {
     #[inline]
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         let opt = match self.inner {
-            Inner::Hyper {
-                ref mut body,
-                ref mut timeout,
-            } => {
+            Inner::Hyper { ref mut body, ref mut timeout } => {
                 if let Some(ref mut timeout) = timeout {
                     if let Async::Ready(()) = try_!(timeout.poll()) {
                         return Err(crate::error::timedout(None));
                     }
                 }
                 try_ready!(body.poll_data().map_err(crate::error::from))
-            }
+            },
             Inner::Reusable(ref mut bytes) => {
                 return if bytes.is_empty() {
                     Ok(Async::Ready(None))
@@ -93,10 +93,12 @@ impl Stream for Body {
                     *bytes = Bytes::new();
                     Ok(Async::Ready(Some(chunk)))
                 };
-            }
+            },
         };
 
-        Ok(Async::Ready(opt.map(|chunk| Chunk { inner: chunk })))
+        Ok(Async::Ready(opt.map(|chunk| Chunk {
+            inner: chunk,
+        })))
     }
 }
 
@@ -159,7 +161,7 @@ impl Chunk {
     #[inline]
     pub(crate) fn from_chunk(chunk: Bytes) -> Chunk {
         Chunk {
-            inner: hyper::Chunk::from(chunk),
+            inner: hyper::Chunk::from(chunk)
         }
     }
 }
@@ -195,9 +197,7 @@ impl std::ops::Deref for Chunk {
 
 impl Extend<u8> for Chunk {
     fn extend<T>(&mut self, iter: T)
-    where
-        T: IntoIterator<Item = u8>,
-    {
+    where T: IntoIterator<Item=u8> {
         self.inner.extend(iter)
     }
 }
@@ -219,9 +219,7 @@ impl From<Vec<u8>> for Chunk {
 
 impl From<&'static [u8]> for Chunk {
     fn from(slice: &'static [u8]) -> Chunk {
-        Chunk {
-            inner: slice.into(),
-        }
+        Chunk { inner: slice.into() }
     }
 }
 
@@ -233,17 +231,13 @@ impl From<String> for Chunk {
 
 impl From<&'static str> for Chunk {
     fn from(slice: &'static str) -> Chunk {
-        Chunk {
-            inner: slice.into(),
-        }
+        Chunk { inner: slice.into() }
     }
 }
 
 impl From<Bytes> for Chunk {
     fn from(bytes: Bytes) -> Chunk {
-        Chunk {
-            inner: bytes.into(),
-        }
+        Chunk { inner: bytes.into() }
     }
 }
 
@@ -255,7 +249,8 @@ impl From<Chunk> for hyper::Chunk {
 
 impl fmt::Debug for Body {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Body").finish()
+        f.debug_struct("Body")
+            .finish()
     }
 }
 

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -2,10 +2,10 @@
 use std::borrow::Cow;
 use std::fmt;
 
-use http::HeaderMap;
 use mime_guess::Mime;
 use percent_encoding::{self, AsciiSet, NON_ALPHANUMERIC};
 use uuid::Uuid;
+use http::HeaderMap;
 
 use futures::Stream;
 
@@ -98,7 +98,7 @@ impl Form {
 
     /// Consume this instance and transform into an instance of hyper::Body for use in a request.
     pub(crate) fn stream(mut self) -> hyper::Body {
-        if self.inner.fields.is_empty() {
+        if self.inner.fields.is_empty(){
             return hyper::Body::empty();
         }
 
@@ -117,7 +117,7 @@ impl Form {
         hyper::Body::wrap_stream(stream.chain(last))
     }
 
-    /// Generate a hyper::Body stream for a single Part instance of a Form request.
+    /// Generate a hyper::Body stream for a single Part instance of a Form request. 
     pub(crate) fn part_stream<T>(&mut self, name: T, part: Part) -> hyper::Body
     where
         T: Into<Cow<'static, str>>,
@@ -126,20 +126,12 @@ impl Form {
         let boundary = hyper::Body::from(format!("--{}\r\n", self.boundary()));
         // append headers
         let header = hyper::Body::from({
-            let mut h = self
-                .inner
-                .percent_encoding
-                .encode_headers(&name.into(), &part.meta);
+            let mut h = self.inner.percent_encoding.encode_headers(&name.into(), &part.meta);
             h.extend_from_slice(b"\r\n\r\n");
             h
         });
         // then append form data followed by terminating CRLF
-        hyper::Body::wrap_stream(
-            boundary
-                .chain(header)
-                .chain(hyper::Body::wrap_stream(part.value))
-                .chain(hyper::Body::from("\r\n".to_owned())),
-        )
+        hyper::Body::wrap_stream(boundary.chain(header).chain(hyper::Body::wrap_stream(part.value)).chain(hyper::Body::from("\r\n".to_owned())))
     }
 
     pub(crate) fn compute_length(&mut self) -> Option<u64> {
@@ -196,9 +188,7 @@ impl Part {
         T::Item: Into<Chunk>,
         T::Error: std::error::Error + Send + Sync,
     {
-        Part::new(Body::wrap(hyper::Body::wrap_stream(
-            value.map(|chunk| chunk.into()),
-        )))
+        Part::new(Body::wrap(hyper::Body::wrap_stream(value.map(|chunk| chunk.into()))))
     }
 
     fn new(value: Body) -> Part {
@@ -316,13 +306,7 @@ impl<P: PartProps> FormParts<P> {
                     // in Reader. Not the cleanest solution because if that format string is
                     // ever changed then this formula needs to be changed too which is not an
                     // obvious dependency in the code.
-                    length += 2
-                        + self.boundary().len() as u64
-                        + 2
-                        + header_length as u64
-                        + 4
-                        + value_length
-                        + 2
+                    length += 2 + self.boundary().len() as u64 + 2 + header_length as u64 + 4 + value_length + 2
                 }
                 _ => return None,
             }
@@ -356,7 +340,7 @@ impl PartMetadata {
         PartMetadata {
             mime: None,
             file_name: None,
-            headers: HeaderMap::default(),
+            headers: HeaderMap::default()
         }
     }
 
@@ -374,10 +358,11 @@ impl PartMetadata {
     }
 }
 
+
 impl PartMetadata {
     pub(crate) fn fmt_fields<'f, 'fa, 'fb>(
         &self,
-        debug_struct: &'f mut fmt::DebugStruct<'fa, 'fb>,
+        debug_struct: &'f mut fmt::DebugStruct<'fa, 'fb>
     ) -> &'f mut fmt::DebugStruct<'fa, 'fb> {
         debug_struct
             .field("mime", &self.mime)
@@ -434,34 +419,31 @@ impl PercentEncoding {
                 None => "".to_string(),
             },
         );
-        field
-            .headers
-            .iter()
-            .fold(s.into_bytes(), |mut header, (k, v)| {
-                header.extend_from_slice(b"\r\n");
-                header.extend_from_slice(k.as_str().as_bytes());
-                header.extend_from_slice(b": ");
-                header.extend_from_slice(v.as_bytes());
-                header
-            })
+        field.headers.iter().fold(s.into_bytes(), |mut header, (k,v)| {
+            header.extend_from_slice(b"\r\n");
+            header.extend_from_slice(k.as_str().as_bytes());
+            header.extend_from_slice(b": ");
+            header.extend_from_slice(v.as_bytes());
+            header
+        })
     }
 
     // According to RFC7578 Section 4.2, `filename*=` syntax is invalid.
     // See https://github.com/seanmonstar/reqwest/issues/419.
     fn format_filename(&self, filename: &str) -> String {
-        let legal_filename = filename
-            .replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\r", "\\\r")
-            .replace("\n", "\\\n");
+        let legal_filename = filename.replace("\\", "\\\\")
+                                     .replace("\"", "\\\"")
+                                     .replace("\r", "\\\r")
+                                     .replace("\n", "\\\n");
         format!("filename=\"{}\"", legal_filename)
     }
 
     fn format_parameter(&self, name: &str, value: &str) -> String {
         let legal_value = match *self {
             PercentEncoding::PathSegment => {
-                percent_encoding::utf8_percent_encode(value, PATH_SEGMENT_ENCODE_SET).to_string()
-            }
+                percent_encoding::utf8_percent_encode(value, PATH_SEGMENT_ENCODE_SET)
+                    .to_string()
+            },
             PercentEncoding::AttrChar => {
                 percent_encoding::utf8_percent_encode(value, ATTR_CHAR_ENCODE_SET).to_string()
             }
@@ -496,45 +478,38 @@ mod tests {
     #[test]
     fn stream_to_end() {
         let mut form = Form::new()
-            .part(
-                "reader1",
-                Part::stream(futures::stream::once::<_, hyper::Error>(Ok(Chunk::from(
-                    "part1".to_owned(),
-                )))),
-            )
+            .part("reader1", Part::stream(futures::stream::once::<_, hyper::Error>(Ok(Chunk::from("part1".to_owned())))))
             .part("key1", Part::text("value1"))
-            .part("key2", Part::text("value2").mime(mime::IMAGE_BMP))
             .part(
-                "reader2",
-                Part::stream(futures::stream::once::<_, hyper::Error>(Ok(Chunk::from(
-                    "part2".to_owned(),
-                )))),
+                "key2",
+                Part::text("value2").mime(mime::IMAGE_BMP),
             )
-            .part("key3", Part::text("value3").file_name("filename"));
+            .part("reader2", Part::stream(futures::stream::once::<_, hyper::Error>(Ok(Chunk::from("part2".to_owned())))))
+            .part(
+                "key3",
+                Part::text("value3").file_name("filename"),
+            );
         form.inner.boundary = "boundary".to_string();
-        let expected =
-            "--boundary\r\n\
-             Content-Disposition: form-data; name=\"reader1\"\r\n\r\n\
-             part1\r\n\
-             --boundary\r\n\
-             Content-Disposition: form-data; name=\"key1\"\r\n\r\n\
-             value1\r\n\
-             --boundary\r\n\
-             Content-Disposition: form-data; name=\"key2\"\r\n\
-             Content-Type: image/bmp\r\n\r\n\
-             value2\r\n\
-             --boundary\r\n\
-             Content-Disposition: form-data; name=\"reader2\"\r\n\r\n\
-             part2\r\n\
-             --boundary\r\n\
-             Content-Disposition: form-data; name=\"key3\"; filename=\"filename\"\r\n\r\n\
-             value3\r\n--boundary--\r\n";
+        let expected = "--boundary\r\n\
+                        Content-Disposition: form-data; name=\"reader1\"\r\n\r\n\
+                        part1\r\n\
+                        --boundary\r\n\
+                        Content-Disposition: form-data; name=\"key1\"\r\n\r\n\
+                        value1\r\n\
+                        --boundary\r\n\
+                        Content-Disposition: form-data; name=\"key2\"\r\n\
+                        Content-Type: image/bmp\r\n\r\n\
+                        value2\r\n\
+                        --boundary\r\n\
+                        Content-Disposition: form-data; name=\"reader2\"\r\n\r\n\
+                        part2\r\n\
+                        --boundary\r\n\
+                        Content-Disposition: form-data; name=\"key3\"; filename=\"filename\"\r\n\r\n\
+                        value3\r\n--boundary--\r\n";
         let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
         let body_ft = form.stream();
 
-        let out = rt
-            .block_on(body_ft.map(|c| c.into_bytes()).concat2())
-            .unwrap();
+        let out = rt.block_on(body_ft.map(|c| c.into_bytes()).concat2()).unwrap();
         // These prints are for debug purposes in case the test fails
         println!(
             "START REAL\n{}\nEND REAL",
@@ -560,9 +535,7 @@ mod tests {
         let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
         let body_ft = form.stream();
 
-        let out = rt
-            .block_on(body_ft.map(|c| c.into_bytes()).concat2())
-            .unwrap();
+        let out = rt.block_on(body_ft.map(|c| c.into_bytes()).concat2()).unwrap();
         // These prints are for debug purposes in case the test fails
         println!(
             "START REAL\n{}\nEND REAL",

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,12 +1,12 @@
-use std::fmt;
 use std::fs::File;
+use std::fmt;
 use std::io::{self, Cursor, Read};
 
 use bytes::Bytes;
 use futures::{try_ready, Future};
 use hyper;
 
-use crate::async_impl;
+use crate::{async_impl};
 
 /// The body of a `Request`.
 ///
@@ -102,7 +102,7 @@ impl Body {
                     tx,
                 };
                 (Some(tx), async_impl::Body::wrap(rx), len)
-            }
+            },
             Kind::Bytes(chunk) => {
                 let len = chunk.len() as u64;
                 (None, async_impl::Body::reusable(chunk), Some(len))
@@ -111,9 +111,11 @@ impl Body {
     }
 
     pub(crate) fn try_clone(&self) -> Option<Body> {
-        self.kind.try_clone().map(|kind| Body { kind })
+        self.kind.try_clone()
+            .map(|kind| Body { kind })
     }
 }
+
 
 enum Kind {
     Reader(Box<dyn Read + Send>, Option<u64>),
@@ -145,6 +147,7 @@ impl From<String> for Body {
     }
 }
 
+
 impl From<&'static [u8]> for Body {
     #[inline]
     fn from(s: &'static [u8]) -> Body {
@@ -174,8 +177,7 @@ impl From<File> for Body {
 impl fmt::Debug for Kind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Kind::Reader(_, ref v) => f
-                .debug_struct("Reader")
+            Kind::Reader(_, ref v) => f.debug_struct("Reader")
                 .field("length", &DebugLength(v))
                 .finish(),
             Kind::Bytes(ref v) => fmt::Debug::fmt(v, f),
@@ -216,10 +218,10 @@ pub(crate) struct Sender {
 impl Sender {
     // A `Future` that may do blocking read calls.
     // As a `Future`, this integrates easily with `wait::timeout`.
-    pub(crate) fn send(self) -> impl Future<Item = (), Error = crate::Error> {
+    pub(crate) fn send(self) -> impl Future<Item=(), Error=crate::Error> {
+        use std::cmp;
         use bytes::{BufMut, BytesMut};
         use futures::future;
-        use std::cmp;
 
         let con_len = self.body.1;
         let cap = cmp::min(self.body.1.unwrap_or(8192), 8192);
@@ -259,12 +261,15 @@ impl Sender {
                         // read. Return.
                         return Ok(().into());
                     }
-                    Ok(n) => unsafe {
-                        buf.advance_mut(n);
-                    },
+                    Ok(n) => {
+                        unsafe { buf.advance_mut(n); }
+                    }
                     Err(e) => {
                         let ret = io::Error::new(e.kind(), e.to_string());
-                        tx.take().expect("tx only taken on error").abort();
+                        tx
+                            .take()
+                            .expect("tx only taken on error")
+                            .abort();
                         return Err(crate::error::from(ret));
                     }
                 }
@@ -292,8 +297,8 @@ impl Sender {
 pub(crate) fn read_to_string(mut body: Body) -> io::Result<String> {
     let mut s = String::new();
     match body.kind {
-        Kind::Reader(ref mut reader, _) => reader.read_to_string(&mut s),
-        Kind::Bytes(ref mut bytes) => (&**bytes).read_to_string(&mut s),
-    }
-    .map(|_| s)
+            Kind::Reader(ref mut reader, _) => reader.read_to_string(&mut s),
+            Kind::Bytes(ref mut bytes) => (&**bytes).read_to_string(&mut s),
+        }
+        .map(|_| s)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,18 +1,18 @@
 use std::fmt;
-use std::net::IpAddr;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
+use std::thread;
+use std::net::IpAddr;
 
+use futures::{Async, Future, Stream};
 use futures::future::{self, Either};
 use futures::sync::{mpsc, oneshot};
-use futures::{Async, Future, Stream};
 
-use log::trace;
+use log::{trace};
 
 use crate::request::{Request, RequestBuilder};
 use crate::response::Response;
-use crate::{async_impl, header, wait, IntoUrl, Method, Proxy, RedirectPolicy};
+use crate::{async_impl, header, Method, IntoUrl, Proxy, RedirectPolicy, wait};
 #[cfg(feature = "tls")]
 use crate::{Certificate, Identity};
 
@@ -81,7 +81,9 @@ impl ClientBuilder {
     /// This method fails if TLS backend cannot be initialized, or the resolver
     /// cannot load the system configuration.
     pub fn build(self) -> crate::Result<Client> {
-        ClientHandle::new(self).map(|handle| Client { inner: handle })
+        ClientHandle::new(self).map(|handle| Client {
+            inner: handle,
+        })
     }
 
     /// Disable proxy setting.
@@ -181,6 +183,7 @@ impl ClientBuilder {
     pub fn identity(self, identity: Identity) -> ClientBuilder {
         self.with_inner(move |inner| inner.identity(identity))
     }
+
 
     /// Controls the use of hostname verification.
     ///
@@ -396,6 +399,7 @@ impl ClientBuilder {
     }
 }
 
+
 impl Client {
     /// Constructs a new `Client`.
     ///
@@ -407,7 +411,9 @@ impl Client {
     /// Use `Client::builder()` if you wish to handle the failure as an `Error`
     /// instead of panicking.
     pub fn new() -> Client {
-        ClientBuilder::new().build().expect("Client::new()")
+        ClientBuilder::new()
+            .build()
+            .expect("Client::new()")
     }
 
     /// Creates a `ClientBuilder` to configure a `Client`.
@@ -480,7 +486,9 @@ impl Client {
     ///
     /// This method fails whenever supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
-        let req = url.into_url().map(move |url| Request::new(method, url));
+        let req = url
+            .into_url()
+            .map(move |url| Request::new(method, url));
         RequestBuilder::new(self.clone(), req)
     }
 
@@ -513,24 +521,22 @@ impl fmt::Debug for Client {
 
 impl fmt::Debug for ClientBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("ClientBuilder").finish()
+        f.debug_struct("ClientBuilder")
+            .finish()
     }
 }
 
 #[derive(Clone)]
 struct ClientHandle {
     timeout: Timeout,
-    inner: Arc<InnerClientHandle>,
+    inner: Arc<InnerClientHandle>
 }
 
-type ThreadSender = mpsc::UnboundedSender<(
-    async_impl::Request,
-    oneshot::Sender<crate::Result<async_impl::Response>>,
-)>;
+type ThreadSender = mpsc::UnboundedSender<(async_impl::Request, oneshot::Sender<crate::Result<async_impl::Response>>)>;
 
 struct InnerClientHandle {
     tx: Option<ThreadSender>,
-    thread: Option<thread::JoinHandle<()>>,
+    thread: Option<thread::JoinHandle<()>>
 }
 
 impl Drop for InnerClientHandle {
@@ -546,64 +552,66 @@ impl ClientHandle {
         let builder = builder.inner;
         let (tx, rx) = mpsc::unbounded();
         let (spawn_tx, spawn_rx) = oneshot::channel::<crate::Result<()>>();
-        let handle = try_!(thread::Builder::new()
-            .name("reqwest-internal-sync-runtime".into())
-            .spawn(move || {
-                use tokio::runtime::current_thread::Runtime;
+        let handle = try_!(thread::Builder::new().name("reqwest-internal-sync-runtime".into()).spawn(move || {
+            use tokio::runtime::current_thread::Runtime;
 
-                let built = (|| {
-                    let rt = try_!(Runtime::new());
-                    let client = builder.build()?;
-                    Ok((rt, client))
-                })();
+            let built = (|| {
+                let rt = try_!(Runtime::new());
+                let client = builder.build()?;
+                Ok((rt, client))
+            })();
 
-                let (mut rt, client) = match built {
-                    Ok((rt, c)) => {
-                        if spawn_tx.send(Ok(())).is_err() {
-                            return;
-                        }
-                        (rt, c)
-                    }
-                    Err(e) => {
-                        let _ = spawn_tx.send(Err(e));
+            let (mut rt, client) = match built {
+                Ok((rt, c)) => {
+                    if spawn_tx.send(Ok(())).is_err() {
                         return;
                     }
-                };
+                    (rt, c)
+                },
+                Err(e) => {
+                    let _ = spawn_tx.send(Err(e));
+                    return;
+                }
+            };
 
-                let work = rx.for_each(move |(req, tx)| {
-                    let mut tx_opt: Option<oneshot::Sender<crate::Result<async_impl::Response>>> =
-                        Some(tx);
-                    let mut res_fut = client.execute(req);
+            let work = rx.for_each(move |(req, tx)| {
+                let mut tx_opt: Option<oneshot::Sender<crate::Result<async_impl::Response>>> = Some(tx);
+                let mut res_fut = client.execute(req);
 
-                    let task = future::poll_fn(move || {
-                        let canceled = tx_opt
-                            .as_mut()
+                let task = future::poll_fn(move || {
+                    let canceled = tx_opt
+                        .as_mut()
+                        .expect("polled after complete")
+                        .poll_cancel()
+                        .expect("poll_cancel cannot error")
+                        .is_ready();
+
+                    if canceled {
+                        trace!("response receiver is canceled");
+                        Ok(Async::Ready(()))
+                    } else {
+                        let result = match res_fut.poll() {
+                            Ok(Async::NotReady) => return Ok(Async::NotReady),
+                            Ok(Async::Ready(res)) => Ok(res),
+                            Err(err) => Err(err),
+                        };
+
+                        let _ = tx_opt
+                            .take()
                             .expect("polled after complete")
-                            .poll_cancel()
-                            .expect("poll_cancel cannot error")
-                            .is_ready();
-
-                        if canceled {
-                            trace!("response receiver is canceled");
-                            Ok(Async::Ready(()))
-                        } else {
-                            let result = match res_fut.poll() {
-                                Ok(Async::NotReady) => return Ok(Async::NotReady),
-                                Ok(Async::Ready(res)) => Ok(res),
-                                Err(err) => Err(err),
-                            };
-
-                            let _ = tx_opt.take().expect("polled after complete").send(result);
-                            Ok(Async::Ready(()))
-                        }
-                    });
-                    tokio::spawn(task);
-                    Ok(())
+                            .send(result);
+                        Ok(Async::Ready(()))
+                    }
                 });
+                tokio::spawn(task);
+                Ok(())
+            });
 
-                // work is Future<(), ()>, and our closure will never return Err
-                rt.block_on(work).expect("runtime unexpected error");
-            }));
+
+            // work is Future<(), ()>, and our closure will never return Err
+            rt.block_on(work)
+                .expect("runtime unexpected error");
+        }));
 
         // Wait for the runtime thread to start up...
         match spawn_rx.wait() {
@@ -612,10 +620,12 @@ impl ClientHandle {
             Err(_canceled) => event_loop_panicked(),
         }
 
+
         let inner_handle = Arc::new(InnerClientHandle {
             tx: Some(tx),
-            thread: Some(handle),
+            thread: Some(handle)
         });
+
 
         Ok(ClientHandle {
             timeout,
@@ -627,8 +637,7 @@ impl ClientHandle {
         let (tx, rx) = oneshot::channel();
         let (req, body) = req.into_async();
         let url = req.url().clone();
-        self.inner
-            .tx
+        self.inner.tx
             .as_ref()
             .expect("core thread exited early")
             .unbounded_send((req, tx))
@@ -636,7 +645,7 @@ impl ClientHandle {
 
         let write = if let Some(body) = body {
             Either::A(body.send())
-        //try_!(body.send(self.timeout.0), &url);
+            //try_!(body.send(self.timeout.0), &url);
         } else {
             Either::B(future::ok(()))
         };
@@ -648,17 +657,15 @@ impl ClientHandle {
         let res = match wait::timeout(fut, self.timeout.0) {
             Ok(res) => res,
             Err(wait::Waited::TimedOut) => return Err(crate::error::timedout(Some(url))),
-            Err(wait::Waited::Executor(err)) => return Err(crate::error::from(err).with_url(url)),
+            Err(wait::Waited::Executor(err)) => {
+                return Err(crate::error::from(err).with_url(url))
+            },
             Err(wait::Waited::Inner(err)) => {
                 return Err(err.with_url(url));
-            }
+            },
         };
         res.map(|res| {
-            Response::new(
-                res,
-                self.timeout.0,
-                KeepCoreThreadAlive(Some(self.inner.clone())),
-            )
+            Response::new(res, self.timeout.0, KeepCoreThreadAlive(Some(self.inner.clone())))
         })
     }
 }

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -109,9 +109,7 @@ impl<'a> Cookie<'a> {
 
     /// Get the Max-Age information.
     pub fn max_age(&self) -> Option<std::time::Duration> {
-        self.0
-            .max_age()
-            .map(|d| std::time::Duration::new(d.num_seconds() as u64, 0))
+        self.0.max_age().map(|d| std::time::Duration::new(d.num_seconds() as u64, 0))
     }
 
     /// The cookie expiration time.

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,6 +1,6 @@
+use std::{io, vec};
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex, Once};
-use std::{io, vec};
 
 use futures::{future, Future};
 use hyper::client::connect::dns as hyper_dns;
@@ -13,7 +13,7 @@ use trust_dns_resolver::{system_conf, AsyncResolver, BackgroundLookupIp};
 //
 // "Erasing" the internal resolver type saves us from this limit.
 type ErasedResolver = Box<dyn Fn(hyper_dns::Name) -> BackgroundLookupIp + Send + Sync>;
-type Background = Box<dyn Future<Item = (), Error = ()> + Send>;
+type Background = Box<dyn Future<Item=(), Error=()> + Send>;
 
 #[derive(Clone)]
 pub(crate) struct TrustDnsResolver {
@@ -31,7 +31,9 @@ impl TrustDnsResolver {
         let (conf, opts) = system_conf::read_system_conf()?;
         let (resolver, bg) = AsyncResolver::new(conf, opts);
 
-        let resolver: ErasedResolver = Box::new(move |name| resolver.lookup_ip(name.as_str()));
+        let resolver: ErasedResolver = Box::new(move |name| {
+            resolver.lookup_ip(name.as_str())
+        });
         let background = Mutex::new(Some(Box::new(bg) as Background));
         let once = Once::new();
 
@@ -47,7 +49,7 @@ impl TrustDnsResolver {
 
 impl hyper_dns::Resolve for TrustDnsResolver {
     type Addrs = vec::IntoIter<IpAddr>;
-    type Future = Box<dyn Future<Item = Self::Addrs, Error = io::Error> + Send>;
+    type Future = Box<dyn Future<Item=Self::Addrs, Error=io::Error> + Send>;
 
     fn resolve(&self, name: hyper_dns::Name) -> Self::Future {
         let inner = self.inner.clone();
@@ -68,8 +70,16 @@ impl hyper_dns::Resolve for TrustDnsResolver {
             });
 
             (inner.resolver)(name)
-                .map(|lookup| lookup.iter().collect::<Vec<_>>().into_iter())
-                .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))
+                .map(|lookup| {
+                    lookup
+                        .iter()
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                })
+                .map_err(|err| {
+                    io::Error::new(io::ErrorKind::Other, err.to_string())
+                })
         }))
     }
 }
+

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,13 +62,17 @@ struct Inner {
     url: Option<Url>,
 }
 
+
 /// A `Result` alias where the `Err` case is `reqwest::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl Error {
     fn new(kind: Kind, url: Option<Url>) -> Error {
         Error {
-            inner: Box::new(Inner { kind, url }),
+            inner: Box::new(Inner {
+                kind,
+                url,
+            }),
         }
     }
 
@@ -144,13 +148,13 @@ impl Error {
             Kind::Io(ref e) => Some(e),
             Kind::UrlEncoded(ref e) => Some(e),
             Kind::Json(ref e) => Some(e),
-            Kind::UrlBadScheme
-            | Kind::TooManyRedirects
-            | Kind::RedirectLoop
-            | Kind::Status(_)
-            | Kind::UnknownProxyScheme
-            | Kind::Timer
-            | Kind::BlockingClientInFutureContext => None,
+            Kind::UrlBadScheme |
+            Kind::TooManyRedirects |
+            Kind::RedirectLoop |
+            Kind::Status(_) |
+            Kind::UnknownProxyScheme |
+            Kind::Timer |
+            Kind::BlockingClientInFutureContext => None,
         }
     }
 
@@ -168,11 +172,15 @@ impl Error {
     pub fn is_timeout(&self) -> bool {
         match self.inner.kind {
             Kind::Io(ref io) => io.kind() == io::ErrorKind::TimedOut,
-            Kind::Hyper(ref error) => error
-                .source()
-                .and_then(|cause| cause.downcast_ref::<io::Error>())
-                .map(|io| io.kind() == io::ErrorKind::TimedOut)
-                .unwrap_or(false),
+            Kind::Hyper(ref error) => {
+                error
+                    .source()
+                    .and_then(|cause| {
+                        cause.downcast_ref::<io::Error>()
+                    })
+                    .map(|io| io.kind() == io::ErrorKind::TimedOut)
+                    .unwrap_or(false)
+            },
             _ => false,
         }
     }
@@ -181,7 +189,8 @@ impl Error {
     #[inline]
     pub fn is_serialization(&self) -> bool {
         match self.inner.kind {
-            Kind::Json(_) | Kind::UrlEncoded(_) => true,
+            Kind::Json(_) |
+            Kind::UrlEncoded(_) => true,
             _ => false,
         }
     }
@@ -190,7 +199,8 @@ impl Error {
     #[inline]
     pub fn is_redirect(&self) -> bool {
         match self.inner.kind {
-            Kind::TooManyRedirects | Kind::RedirectLoop => true,
+            Kind::TooManyRedirects |
+            Kind::RedirectLoop => true,
             _ => false,
         }
     }
@@ -231,7 +241,9 @@ impl fmt::Debug for Error {
                 .field(url)
                 .finish()
         } else {
-            f.debug_tuple("Error").field(&self.inner.kind).finish()
+            f.debug_tuple("Error")
+                .field(&self.inner.kind)
+                .finish()
         }
     }
 }
@@ -257,7 +269,9 @@ impl fmt::Display for Error {
             #[cfg(feature = "rustls-tls")]
             Kind::Rustls(ref e) => fmt::Display::fmt(e, f),
             #[cfg(feature = "trust-dns")]
-            Kind::DnsSystemConf(ref e) => write!(f, "failed to load DNS system conf: {}", e),
+            Kind::DnsSystemConf(ref e) => {
+                write!(f, "failed to load DNS system conf: {}", e)
+            },
             Kind::Io(ref e) => fmt::Display::fmt(e, f),
             Kind::UrlEncoded(ref e) => fmt::Display::fmt(e, f),
             Kind::Json(ref e) => fmt::Display::fmt(e, f),
@@ -335,13 +349,13 @@ impl StdError for Error {
             Kind::Io(ref e) => e.cause(),
             Kind::UrlEncoded(ref e) => e.cause(),
             Kind::Json(ref e) => e.cause(),
-            Kind::UrlBadScheme
-            | Kind::TooManyRedirects
-            | Kind::RedirectLoop
-            | Kind::Status(_)
-            | Kind::UnknownProxyScheme
-            | Kind::Timer
-            | Kind::BlockingClientInFutureContext => None,
+            Kind::UrlBadScheme |
+            Kind::TooManyRedirects |
+            Kind::RedirectLoop |
+            Kind::Status(_) |
+            Kind::UnknownProxyScheme |
+            Kind::Timer |
+            Kind::BlockingClientInFutureContext => None,
         }
     }
 
@@ -362,13 +376,13 @@ impl StdError for Error {
             Kind::Io(ref e) => e.source(),
             Kind::UrlEncoded(ref e) => e.source(),
             Kind::Json(ref e) => e.source(),
-            Kind::UrlBadScheme
-            | Kind::TooManyRedirects
-            | Kind::RedirectLoop
-            | Kind::Status(_)
-            | Kind::UnknownProxyScheme
-            | Kind::Timer
-            | Kind::BlockingClientInFutureContext => None,
+            Kind::UrlBadScheme |
+            Kind::TooManyRedirects |
+            Kind::RedirectLoop |
+            Kind::Status(_) |
+            Kind::UnknownProxyScheme |
+            Kind::Timer |
+            Kind::BlockingClientInFutureContext => None,
         }
     }
 }
@@ -398,6 +412,7 @@ pub(crate) enum Kind {
     Timer,
     BlockingClientInFutureContext,
 }
+
 
 impl From<http::Error> for Kind {
     #[inline]
@@ -463,12 +478,10 @@ impl From<rustls::TLSError> for Kind {
 }
 
 impl<T> From<crate::wait::Waited<T>> for Kind
-where
-    T: Into<Kind>,
-{
+where T: Into<Kind> {
     fn from(err: crate::wait::Waited<T>) -> Kind {
         match err {
-            crate::wait::Waited::TimedOut => io_timeout().into(),
+            crate::wait::Waited::TimedOut =>  io_timeout().into(),
             crate::wait::Waited::Executor(e) => e.into(),
             crate::wait::Waited::Inner(e) => e.into(),
         }
@@ -529,7 +542,8 @@ pub(crate) fn into_io(e: Error) -> io::Error {
 
 pub(crate) fn from_io(e: io::Error) -> Error {
     if e.get_ref().map(|r| r.is::<Error>()).unwrap_or(false) {
-        *e.into_inner()
+        *e
+            .into_inner()
             .expect("io::Error::get_ref was Some(_)")
             .downcast::<Error>()
             .expect("StdError::is() was true")
@@ -538,30 +552,28 @@ pub(crate) fn from_io(e: io::Error) -> Error {
     }
 }
 
+
 macro_rules! try_ {
-    ($e:expr) => {
+    ($e:expr) => (
         match $e {
             Ok(v) => v,
             Err(err) => {
                 return Err(crate::error::from(err));
             }
         }
-    };
-    ($e:expr, $url:expr) => {
+    );
+    ($e:expr, $url:expr) => (
         match $e {
             Ok(v) => v,
             Err(err) => {
-                return Err(crate::Error::from(crate::error::InternalFrom(
-                    err,
-                    Some($url.clone()),
-                )));
+                return Err(crate::Error::from(crate::error::InternalFrom(err, Some($url.clone()))));
             }
         }
-    };
+    )
 }
 
 macro_rules! try_io {
-    ($e:expr) => {
+    ($e:expr) => (
         match $e {
             Ok(v) => v,
             Err(ref err) if err.kind() == std::io::ErrorKind::WouldBlock => {
@@ -571,7 +583,7 @@ macro_rules! try_io {
                 return Err(crate::error::from_io(err));
             }
         }
-    };
+    )
 }
 
 pub(crate) fn loop_detected(url: Url) -> Error {
@@ -613,7 +625,7 @@ mod tests {
         #[derive(Debug)]
         struct Chain<T>(Option<T>);
 
-        impl<T: fmt::Display> fmt::Display for Chain<T> {
+        impl<T: fmt::Display> fmt::Display  for Chain<T> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 if let Some(ref link) = self.0 {
                     write!(f, "chain: {}", link)
@@ -645,6 +657,7 @@ mod tests {
         let err = Error::new(Kind::Io(io), None);
         assert!(err.cause().is_none());
         assert_eq!(err.to_string(), "root");
+
 
         let root = std::io::Error::new(std::io::ErrorKind::Other, Chain(None::<Error>));
         let link = Chain(Some(root));

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -27,7 +27,8 @@ impl PolyfillTryInto for Url {
 
 impl<'a> PolyfillTryInto for &'a str {
     fn into_url(self) -> crate::Result<Url> {
-        try_!(Url::parse(self)).into_url()
+        try_!(Url::parse(self))
+            .into_url()
     }
 }
 
@@ -38,9 +39,7 @@ impl<'a> PolyfillTryInto for &'a String {
 }
 
 pub(crate) fn expect_uri(url: &Url) -> hyper::Uri {
-    url.as_str()
-        .parse()
-        .expect("a parsed Url should always be a valid Uri")
+    url.as_str().parse().expect("a parsed Url should always be a valid Uri")
 }
 
 pub(crate) fn try_uri(url: &Url) -> Option<hyper::Uri> {
@@ -53,10 +52,9 @@ mod tests {
 
     #[test]
     fn into_url_file_scheme() {
-        let err = "file:///etc/hosts".into_url().unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "file:///etc/hosts: URL scheme is not allowed"
-        );
+        let err = "file:///etc/hosts"
+            .into_url()
+            .unwrap_err();
+        assert_eq!(err.to_string(), "file:///etc/hosts: URL scheme is not allowed");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,12 +187,12 @@ doctest!("../README.md");
 pub use hyper::header;
 pub use hyper::Method;
 pub use hyper::{StatusCode, Version};
-pub use url::ParseError as UrlError;
 pub use url::Url;
+pub use url::ParseError as UrlError;
 
-pub use self::body::Body;
 pub use self::client::{Client, ClientBuilder};
 pub use self::error::{Error, Result};
+pub use self::body::Body;
 pub use self::into_url::IntoUrl;
 pub use self::proxy::Proxy;
 pub use self::redirect::{RedirectAction, RedirectAttempt, RedirectPolicy};
@@ -206,9 +206,9 @@ pub use self::tls::{Certificate, Identity};
 mod error;
 
 mod async_impl;
+mod connect;
 mod body;
 mod client;
-mod connect;
 pub mod cookie;
 #[cfg(feature = "trust-dns")]
 mod dns;
@@ -226,8 +226,16 @@ pub mod multipart;
 /// An 'async' implementation of the reqwest `Client`.
 pub mod r#async {
     pub use crate::async_impl::{
-        multipart, Body, Chunk, Client, ClientBuilder, Decoder, Request, RequestBuilder, Response,
+        Body,
+        Chunk,
+        Decoder,
+        Client,
+        ClientBuilder,
+        Request,
+        RequestBuilder,
+        Response,
         ResponseBuilderExt,
+        multipart
     };
 }
 
@@ -261,7 +269,10 @@ pub mod r#async {
 /// - redirect loop was detected
 /// - redirect limit was exhausted
 pub fn get<T: IntoUrl>(url: T) -> crate::Result<Response> {
-    Client::builder().build()?.get(url).send()
+    Client::builder()
+        .build()?
+        .get(url)
+        .send()
 }
 
 fn _assert_impls() {

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,6 +1,13 @@
 use std::fmt;
 
-use crate::header::{HeaderMap, AUTHORIZATION, COOKIE, PROXY_AUTHORIZATION, WWW_AUTHENTICATE};
+use crate::header::{
+    HeaderMap,
+    AUTHORIZATION,
+    COOKIE,
+    PROXY_AUTHORIZATION,
+    WWW_AUTHENTICATE,
+
+};
 use hyper::StatusCode;
 
 use crate::Url;
@@ -134,13 +141,19 @@ impl RedirectPolicy {
         }
     }
 
-    pub(crate) fn check(&self, status: StatusCode, next: &Url, previous: &[Url]) -> Action {
-        self.redirect(RedirectAttempt {
-            status,
-            next,
-            previous,
-        })
-        .inner
+    pub(crate) fn check(
+        &self,
+        status: StatusCode,
+        next: &Url,
+        previous: &[Url],
+    ) -> Action {
+        self
+            .redirect(RedirectAttempt {
+                status,
+                next,
+                previous,
+            })
+            .inner
     }
 }
 
@@ -226,10 +239,11 @@ pub(crate) enum Action {
     TooManyRedirects,
 }
 
+
 pub(crate) fn remove_sensitive_headers(headers: &mut HeaderMap, next: &Url, previous: &[Url]) {
     if let Some(previous) = previous.last() {
-        let cross_host = next.host_str() != previous.host_str()
-            || next.port_or_known_default() != previous.port_or_known_default();
+        let cross_host = next.host_str() != previous.host_str() ||
+                         next.port_or_known_default() != previous.port_or_known_default();
         if cross_host {
             headers.remove(AUTHORIZATION);
             headers.remove(COOKIE);
@@ -290,15 +304,21 @@ fn test_redirect_policy_custom() {
     });
 
     let next = Url::parse("http://bar/baz").unwrap();
-    assert_eq!(policy.check(StatusCode::FOUND, &next, &[]), Action::Follow);
+    assert_eq!(
+        policy.check(StatusCode::FOUND, &next, &[]),
+        Action::Follow
+    );
 
     let next = Url::parse("http://foo/baz").unwrap();
-    assert_eq!(policy.check(StatusCode::FOUND, &next, &[]), Action::Stop);
+    assert_eq!(
+        policy.check(StatusCode::FOUND, &next, &[]),
+        Action::Stop
+    );
 }
 
 #[test]
 fn test_remove_sensitive_headers() {
-    use hyper::header::{HeaderValue, ACCEPT, AUTHORIZATION, COOKIE};
+    use hyper::header::{ACCEPT, AUTHORIZATION, COOKIE, HeaderValue};
 
     let mut headers = HeaderMap::new();
     headers.insert(ACCEPT, HeaderValue::from_static("*/*"));

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,3 +1,10 @@
+extern crate futures;
+extern crate libflate;
+extern crate reqwest;
+extern crate hyper;
+extern crate tokio;
+extern crate bytes;
+
 #[macro_use]
 mod support;
 
@@ -7,8 +14,8 @@ use std::time::Duration;
 use futures::{Future, Stream};
 use tokio::runtime::current_thread::Runtime;
 
-use reqwest::r#async::multipart::{Form, Part};
 use reqwest::r#async::{Chunk, Client};
+use reqwest::r#async::multipart::{Form, Part};
 
 use bytes::Bytes;
 
@@ -47,8 +54,7 @@ fn response_text() {
 
     let client = Client::new();
 
-    let res_future = client
-        .get(&format!("http://{}/text", server.addr()))
+    let res_future = client.get(&format!("http://{}/text", server.addr()))
         .send()
         .and_then(|mut res| res.text())
         .and_then(|text| {
@@ -84,8 +90,7 @@ fn response_json() {
 
     let client = Client::new();
 
-    let res_future = client
-        .get(&format!("http://{}/json", server.addr()))
+    let res_future = client.get(&format!("http://{}/json", server.addr()))
         .send()
         .and_then(|mut res| res.json::<String>())
         .and_then(|text| {
@@ -100,36 +105,34 @@ fn response_json() {
 fn multipart() {
     let _ = env_logger::try_init();
 
-    let stream =
-        futures::stream::once::<_, hyper::Error>(Ok(Chunk::from("part1 part2".to_owned())));
+    let stream = futures::stream::once::<_, hyper::Error>(Ok(Chunk::from("part1 part2".to_owned())));
     let part = Part::stream(stream);
 
-    let form = Form::new().text("foo", "bar").part("part_stream", part);
+    let form = Form::new()
+        .text("foo", "bar")
+        .part("part_stream", part);
 
-    let expected_body = format!(
-        "\
-         24\r\n\
-         --{0}\r\n\r\n\
-         2E\r\n\
-         Content-Disposition: form-data; name=\"foo\"\r\n\r\n\r\n\
-         3\r\n\
-         bar\r\n\
-         2\r\n\
-         \r\n\r\n\
-         24\r\n\
-         --{0}\r\n\r\n\
-         36\r\n\
-         Content-Disposition: form-data; name=\"part_stream\"\r\n\r\n\r\n\
-         B\r\n\
-         part1 part2\r\n\
-         2\r\n\
-         \r\n\r\n\
-         26\r\n\
-         --{0}--\r\n\r\n\
-         0\r\n\r\n\
-         ",
-        form.boundary()
-    );
+    let expected_body = format!("\
+        24\r\n\
+        --{0}\r\n\r\n\
+        2E\r\n\
+        Content-Disposition: form-data; name=\"foo\"\r\n\r\n\r\n\
+        3\r\n\
+        bar\r\n\
+        2\r\n\
+        \r\n\r\n\
+        24\r\n\
+        --{0}\r\n\r\n\
+        36\r\n\
+        Content-Disposition: form-data; name=\"part_stream\"\r\n\r\n\r\n\
+        B\r\n\
+        part1 part2\r\n\
+        2\r\n\
+        \r\n\r\n\
+        26\r\n\
+        --{0}--\r\n\r\n\
+        0\r\n\r\n\
+    ", form.boundary());
 
     let server = server! {
         request: format!("\
@@ -157,12 +160,15 @@ fn multipart() {
 
     let client = Client::new();
 
-    let res_future = client.post(&url).multipart(form).send().and_then(|res| {
-        assert_eq!(res.url().as_str(), &url);
-        assert_eq!(res.status(), reqwest::StatusCode::OK);
+    let res_future = client.post(&url)
+        .multipart(form)
+        .send()
+        .and_then(|res| {
+            assert_eq!(res.url().as_str(), &url);
+            assert_eq!(res.status(), reqwest::StatusCode::OK);
 
-        Ok(())
-    });
+            Ok(())
+        });
 
     rt.block_on(res_future).unwrap();
 }
@@ -197,7 +203,9 @@ fn request_timeout() {
         .unwrap();
 
     let url = format!("http://{}/slow", server.addr());
-    let fut = client.get(&url).send();
+    let fut = client
+        .get(&url)
+        .send();
 
     let err = rt.block_on(fut).unwrap_err();
 
@@ -246,10 +254,7 @@ fn response_timeout() {
 }
 
 fn gzip_case(response_size: usize, chunk_size: usize) {
-    let content: String = (0..response_size)
-        .into_iter()
-        .map(|i| format!("test {}", i))
-        .collect();
+    let content: String = (0..response_size).into_iter().map(|i| format!("test {}", i)).collect();
     let mut encoder = libflate::gzip::Encoder::new(Vec::new()).unwrap();
     match encoder.write(content.as_bytes()) {
         Ok(n) => assert!(n > 0, "Failed to write to encoder."),
@@ -258,16 +263,13 @@ fn gzip_case(response_size: usize, chunk_size: usize) {
 
     let gzipped_content = encoder.finish().into_result().unwrap();
 
-    let mut response = format!(
-        "\
-         HTTP/1.1 200 OK\r\n\
-         Server: test-accept\r\n\
-         Content-Encoding: gzip\r\n\
-         Content-Length: {}\r\n\
-         \r\n",
-        &gzipped_content.len()
-    )
-    .into_bytes();
+    let mut response = format!("\
+            HTTP/1.1 200 OK\r\n\
+            Server: test-accept\r\n\
+            Content-Encoding: gzip\r\n\
+            Content-Length: {}\r\n\
+            \r\n", &gzipped_content.len())
+        .into_bytes();
     response.extend(&gzipped_content);
 
     let server = server! {
@@ -288,8 +290,7 @@ fn gzip_case(response_size: usize, chunk_size: usize) {
 
     let client = Client::new();
 
-    let res_future = client
-        .get(&format!("http://{}/gzip", server.addr()))
+    let res_future = client.get(&format!("http://{}/gzip", server.addr()))
         .send()
         .and_then(|res| {
             let body = res.into_body();
@@ -310,11 +311,9 @@ fn gzip_case(response_size: usize, chunk_size: usize) {
 fn body_stream() {
     let _ = env_logger::try_init();
 
-    let source: Box<dyn Stream<Item = Bytes, Error = io::Error> + Send> =
-        Box::new(futures::stream::iter_ok::<_, io::Error>(vec![
-            Bytes::from_static(b"123"),
-            Bytes::from_static(b"4567"),
-        ]));
+    let source: Box<dyn Stream<Item = Bytes, Error = io::Error> + Send>
+        = Box::new(futures::stream::iter_ok::<_, io::Error>(
+            vec![Bytes::from_static(b"123"), Bytes::from_static(b"4567")]));
 
     let expected_body = "3\r\n123\r\n4\r\n4567\r\n0\r\n\r\n";
 
@@ -343,12 +342,15 @@ fn body_stream() {
 
     let client = Client::new();
 
-    let res_future = client.post(&url).body(source).send().and_then(|res| {
-        assert_eq!(res.url().as_str(), &url);
-        assert_eq!(res.status(), reqwest::StatusCode::OK);
+    let res_future = client.post(&url)
+        .body(source)
+        .send()
+        .and_then(|res| {
+            assert_eq!(res.url().as_str(), &url);
+            assert_eq!(res.status(), reqwest::StatusCode::OK);
 
-        Ok(())
-    });
+            Ok(())
+        });
 
     rt.block_on(res_future).unwrap();
 }

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -1,10 +1,11 @@
+extern crate reqwest;
+
+
 #[cfg(feature = "tls")]
 #[test]
 fn test_badssl_modern() {
-    let text = reqwest::get("https://mozilla-modern.badssl.com/")
-        .unwrap()
-        .text()
-        .unwrap();
+    let text = reqwest::get("https://mozilla-modern.badssl.com/").unwrap()
+        .text().unwrap();
 
     assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
 }
@@ -14,13 +15,10 @@ fn test_badssl_modern() {
 fn test_rustls_badssl_modern() {
     let text = reqwest::Client::builder()
         .use_rustls_tls()
-        .build()
-        .unwrap()
+        .build().unwrap()
         .get("https://mozilla-modern.badssl.com/")
-        .send()
-        .unwrap()
-        .text()
-        .unwrap();
+        .send().unwrap()
+        .text().unwrap();
 
     assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
 }
@@ -30,13 +28,10 @@ fn test_rustls_badssl_modern() {
 fn test_badssl_self_signed() {
     let text = reqwest::Client::builder()
         .danger_accept_invalid_certs(true)
-        .build()
-        .unwrap()
+        .build().unwrap()
         .get("https://self-signed.badssl.com/")
-        .send()
-        .unwrap()
-        .text()
-        .unwrap();
+        .send().unwrap()
+        .text().unwrap();
 
     assert!(text.contains("<title>self-signed.badssl.com</title>"));
 }
@@ -46,20 +41,17 @@ fn test_badssl_self_signed() {
 fn test_badssl_wrong_host() {
     let text = reqwest::Client::builder()
         .danger_accept_invalid_hostnames(true)
-        .build()
-        .unwrap()
+        .build().unwrap()
         .get("https://wrong.host.badssl.com/")
-        .send()
-        .unwrap()
-        .text()
-        .unwrap();
+        .send().unwrap()
+        .text().unwrap();
 
     assert!(text.contains("<title>wrong.host.badssl.com</title>"));
 
+
     let result = reqwest::Client::builder()
         .danger_accept_invalid_hostnames(true)
-        .build()
-        .unwrap()
+        .build().unwrap()
         .get("https://self-signed.badssl.com/")
         .send();
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,3 +1,5 @@
+extern crate reqwest;
+
 #[macro_use]
 mod support;
 
@@ -28,10 +30,7 @@ fn test_response_text() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"5"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"5");
 
     let body = res.text().unwrap();
     assert_eq!(b"Hello", body.as_bytes());
@@ -63,14 +62,11 @@ fn test_response_non_utf_8_text() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"4"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"4");
 
     let body = res.text().unwrap();
     assert_eq!("你好", &body);
-    assert_eq!(b"\xe4\xbd\xa0\xe5\xa5\xbd", body.as_bytes()); // Now it's utf-8
+    assert_eq!(b"\xe4\xbd\xa0\xe5\xa5\xbd", body.as_bytes());  // Now it's utf-8
 }
 
 #[test]
@@ -98,10 +94,7 @@ fn test_response_json() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"7"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"7");
 
     let body = res.json::<String>().unwrap();
     assert_eq!("Hello", body);
@@ -132,10 +125,7 @@ fn test_response_copy_to() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"5"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"5");
 
     let mut buf: Vec<u8> = vec![];
     res.copy_to(&mut buf).unwrap();
@@ -167,10 +157,7 @@ fn test_get() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"0"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
     assert_eq!(res.remote_addr(), Some(server.addr()));
 
     let mut buf = [0; 1024];
@@ -209,10 +196,7 @@ fn test_post() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"post");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"0"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
 
     let mut buf = [0; 1024];
     let n = res.read(&mut buf).unwrap();
@@ -309,10 +293,7 @@ fn test_error_for_status_5xx() {
 
     let err = res.error_for_status().err().unwrap();
     assert!(err.is_server_error());
-    assert_eq!(
-        err.status(),
-        Some(reqwest::StatusCode::INTERNAL_SERVER_ERROR)
-    );
+    assert_eq!(err.status(), Some(reqwest::StatusCode::INTERNAL_SERVER_ERROR));
 }
 
 #[test]
@@ -322,8 +303,7 @@ fn test_default_headers() {
     headers.insert(header::COOKIE, header::HeaderValue::from_static("a=b;c=d"));
     let client = reqwest::Client::builder()
         .default_headers(headers)
-        .build()
-        .unwrap();
+        .build().unwrap();
 
     let server = server! {
         request: b"\
@@ -349,10 +329,7 @@ fn test_default_headers() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"0"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
 
     let server = server! {
         request: b"\
@@ -378,24 +355,17 @@ fn test_default_headers() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"0"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
 }
 
 #[test]
 fn test_override_default_headers() {
     use reqwest::header;
     let mut headers = header::HeaderMap::with_capacity(1);
-    headers.insert(
-        header::AUTHORIZATION,
-        header::HeaderValue::from_static("iamatoken"),
-    );
+    headers.insert(header::AUTHORIZATION, header::HeaderValue::from_static("iamatoken"));
     let client = reqwest::Client::builder()
         .default_headers(headers)
-        .build()
-        .unwrap();
+        .build().unwrap();
 
     let server = server! {
         request: b"\
@@ -416,22 +386,13 @@ fn test_override_default_headers() {
     };
 
     let url = format!("http://{}/3", server.addr());
-    let res = client
-        .get(&url)
-        .header(
-            header::AUTHORIZATION,
-            header::HeaderValue::from_static("secret"),
-        )
-        .send()
-        .unwrap();
+    let res = client.get(&url).header(header::AUTHORIZATION, header::HeaderValue::from_static("secret")).send().unwrap();
 
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"0"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
+
 }
 
 #[test]
@@ -457,32 +418,20 @@ fn test_appended_headers_not_overwritten() {
     };
 
     let url = format!("http://{}/4", server.addr());
-    let res = client
-        .get(&url)
-        .header(header::ACCEPT, "application/json")
-        .header(header::ACCEPT, "application/json+hal")
-        .send()
-        .unwrap();
+    let res = client.get(&url).header(header::ACCEPT, "application/json").header(header::ACCEPT, "application/json+hal").send().unwrap();
 
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"0"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
 
     // make sure this also works with default headers
     use reqwest::header;
     let mut headers = header::HeaderMap::with_capacity(1);
-    headers.insert(
-        header::ACCEPT,
-        header::HeaderValue::from_static("text/html"),
-    );
+    headers.insert(header::ACCEPT, header::HeaderValue::from_static("text/html"));
     let client = reqwest::Client::builder()
         .default_headers(headers)
-        .build()
-        .unwrap();
+        .build().unwrap();
 
     let server = server! {
         request: b"\
@@ -503,18 +452,10 @@ fn test_appended_headers_not_overwritten() {
     };
 
     let url = format!("http://{}/4", server.addr());
-    let res = client
-        .get(&url)
-        .header(header::ACCEPT, "application/json")
-        .header(header::ACCEPT, "application/json+hal")
-        .send()
-        .unwrap();
+    let res = client.get(&url).header(header::ACCEPT, "application/json").header(header::ACCEPT, "application/json+hal").send().unwrap();
 
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"0"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"0");
 }

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -1,3 +1,5 @@
+extern crate reqwest;
+
 #[macro_use]
 mod support;
 
@@ -43,7 +45,7 @@ fn cookie_response_accessor() {
     // expires
     assert_eq!(cookies[1].name(), "expires");
     assert_eq!(
-        cookies[1].expires().unwrap(),
+        cookies[1].expires().unwrap(), 
         std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1445412480)
     );
 
@@ -53,10 +55,7 @@ fn cookie_response_accessor() {
 
     // max-age
     assert_eq!(cookies[3].name(), "maxage");
-    assert_eq!(
-        cookies[3].max_age().unwrap(),
-        std::time::Duration::from_secs(100)
-    );
+    assert_eq!(cookies[3].max_age().unwrap(), std::time::Duration::from_secs(100));
 
     // domain
     assert_eq!(cookies[4].name(), "domain");
@@ -82,10 +81,7 @@ fn cookie_response_accessor() {
 #[test]
 fn cookie_store_simple() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
-    let client = reqwest::r#async::Client::builder()
-        .cookie_store(true)
-        .build()
-        .unwrap();
+    let client = reqwest::r#async::Client::builder().cookie_store(true).build().unwrap();
 
     let server = server! {
         request: b"\
@@ -129,10 +125,7 @@ fn cookie_store_simple() {
 #[test]
 fn cookie_store_overwrite_existing() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
-    let client = reqwest::r#async::Client::builder()
-        .cookie_store(true)
-        .build()
-        .unwrap();
+    let client = reqwest::r#async::Client::builder().cookie_store(true).build().unwrap();
 
     let server = server! {
         request: b"\
@@ -196,10 +189,7 @@ fn cookie_store_overwrite_existing() {
 #[test]
 fn cookie_store_max_age() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
-    let client = reqwest::r#async::Client::builder()
-        .cookie_store(true)
-        .build()
-        .unwrap();
+    let client = reqwest::r#async::Client::builder().cookie_store(true).build().unwrap();
 
     let server = server! {
         request: b"\
@@ -242,10 +232,7 @@ fn cookie_store_max_age() {
 #[test]
 fn cookie_store_expires() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
-    let client = reqwest::r#async::Client::builder()
-        .cookie_store(true)
-        .build()
-        .unwrap();
+    let client = reqwest::r#async::Client::builder().cookie_store(true).build().unwrap();
 
     let server = server! {
         request: b"\
@@ -288,10 +275,7 @@ fn cookie_store_expires() {
 #[test]
 fn cookie_store_path() {
     let mut rt = tokio::runtime::current_thread::Runtime::new().expect("new rt");
-    let client = reqwest::r#async::Client::builder()
-        .cookie_store(true)
-        .build()
-        .unwrap();
+    let client = reqwest::r#async::Client::builder().cookie_store(true).build().unwrap();
 
     let server = server! {
         request: b"\

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -1,8 +1,11 @@
+extern crate reqwest;
+extern crate libflate;
+
 #[macro_use]
 mod support;
 
-use std::io::{Read, Write};
 use std::time::Duration;
+use std::io::{Read, Write};
 
 #[test]
 fn test_gzip_response() {
@@ -16,16 +19,13 @@ fn test_gzip_response() {
 
     let gzipped_content = encoder.finish().into_result().unwrap();
 
-    let mut response = format!(
-        "\
-         HTTP/1.1 200 OK\r\n\
-         Server: test-accept\r\n\
-         Content-Encoding: gzip\r\n\
-         Content-Length: {}\r\n\
-         \r\n",
-        &gzipped_content.len()
-    )
-    .into_bytes();
+    let mut response = format!("\
+            HTTP/1.1 200 OK\r\n\
+            Server: test-accept\r\n\
+            Content-Encoding: gzip\r\n\
+            Content-Length: {}\r\n\
+            \r\n", &gzipped_content.len())
+        .into_bytes();
     response.extend(&gzipped_content);
 
     let server = server! {
@@ -130,10 +130,7 @@ fn test_accept_header_is_not_changed_if_set() {
 
     let res = client
         .get(&format!("http://{}/accept", server.addr()))
-        .header(
-            reqwest::header::ACCEPT,
-            reqwest::header::HeaderValue::from_static("application/json"),
-        )
+        .header(reqwest::header::ACCEPT, reqwest::header::HeaderValue::from_static("application/json"))
         .send()
         .unwrap();
 
@@ -160,12 +157,8 @@ fn test_accept_encoding_header_is_not_changed_if_set() {
     };
     let client = reqwest::Client::new();
 
-    let res = client
-        .get(&format!("http://{}/accept-encoding", server.addr()))
-        .header(
-            reqwest::header::ACCEPT_ENCODING,
-            reqwest::header::HeaderValue::from_static("identity"),
-        )
+    let res = client.get(&format!("http://{}/accept-encoding", server.addr()))
+        .header(reqwest::header::ACCEPT_ENCODING, reqwest::header::HeaderValue::from_static("identity"))
         .send()
         .unwrap();
 

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -1,3 +1,6 @@
+extern crate env_logger;
+extern crate reqwest;
+
 #[macro_use]
 mod support;
 
@@ -5,17 +8,15 @@ mod support;
 fn text_part() {
     let _ = env_logger::try_init();
 
-    let form = reqwest::multipart::Form::new().text("foo", "bar");
+    let form = reqwest::multipart::Form::new()
+        .text("foo", "bar");
 
-    let expected_body = format!(
-        "\
-         --{0}\r\n\
-         Content-Disposition: form-data; name=\"foo\"\r\n\r\n\
-         bar\r\n\
-         --{0}--\r\n\
-         ",
-        form.boundary()
-    );
+    let expected_body = format!("\
+        --{0}\r\n\
+        Content-Disposition: form-data; name=\"foo\"\r\n\r\n\
+        bar\r\n\
+        --{0}--\r\n\
+    ", form.boundary());
 
     let server = server! {
         request: format!("\
@@ -54,22 +55,17 @@ fn file() {
     let _ = env_logger::try_init();
 
     let form = reqwest::multipart::Form::new()
-        .file("foo", "Cargo.lock")
-        .unwrap();
+        .file("foo", "Cargo.lock").unwrap();
 
     let fcontents = std::fs::read_to_string("Cargo.lock").unwrap();
 
-    let expected_body = format!(
-        "\
-         --{0}\r\n\
-         Content-Disposition: form-data; name=\"foo\"; filename=\"Cargo.lock\"\r\n\
-         Content-Type: application/octet-stream\r\n\r\n\
-         {1}\r\n\
-         --{0}--\r\n\
-         ",
-        form.boundary(),
-        fcontents
-    );
+    let expected_body = format!("\
+        --{0}\r\n\
+        Content-Disposition: form-data; name=\"foo\"; filename=\"Cargo.lock\"\r\n\
+        Content-Type: application/octet-stream\r\n\r\n\
+        {1}\r\n\
+        --{0}--\r\n\
+    ", form.boundary(), fcontents);
 
     let server = server! {
         request: format!("\

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,3 +1,5 @@
+extern crate reqwest;
+
 #[macro_use]
 mod support;
 
@@ -35,10 +37,7 @@ fn http_proxy() {
 
     assert_eq!(res.url().as_str(), url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(
-        res.headers().get(reqwest::header::SERVER).unwrap(),
-        &"proxied"
-    );
+    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
 }
 
 #[test]
@@ -67,8 +66,8 @@ fn http_proxy_basic_auth() {
     let res = reqwest::Client::builder()
         .proxy(
             reqwest::Proxy::http(&proxy)
-                .unwrap()
-                .basic_auth("Aladdin", "open sesame"),
+            .unwrap()
+            .basic_auth("Aladdin", "open sesame")
         )
         .build()
         .unwrap()
@@ -78,10 +77,7 @@ fn http_proxy_basic_auth() {
 
     assert_eq!(res.url().as_str(), url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(
-        res.headers().get(reqwest::header::SERVER).unwrap(),
-        &"proxied"
-    );
+    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
 }
 
 #[test]
@@ -108,7 +104,9 @@ fn http_proxy_basic_auth_parsed() {
 
     let url = "http://hyper.rs/prox";
     let res = reqwest::Client::builder()
-        .proxy(reqwest::Proxy::http(&proxy).unwrap())
+        .proxy(
+            reqwest::Proxy::http(&proxy).unwrap()
+        )
         .build()
         .unwrap()
         .get(url)
@@ -117,10 +115,7 @@ fn http_proxy_basic_auth_parsed() {
 
     assert_eq!(res.url().as_str(), url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(
-        res.headers().get(reqwest::header::SERVER).unwrap(),
-        &"proxied"
-    );
+    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
 }
 
 #[test]
@@ -146,7 +141,9 @@ fn test_no_proxy() {
 
     // set up proxy and use no_proxy to clear up client builder proxies.
     let res = reqwest::Client::builder()
-        .proxy(reqwest::Proxy::http(&proxy).unwrap())
+        .proxy(
+            reqwest::Proxy::http(&proxy).unwrap()
+        )
         .no_proxy()
         .build()
         .unwrap()
@@ -192,14 +189,11 @@ fn test_using_system_proxy() {
 
     assert_eq!(res.url().as_str(), url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(
-        res.headers().get(reqwest::header::SERVER).unwrap(),
-        &"proxied"
-    );
+    assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"proxied");
 
     // reset user setting.
     match system_proxy {
         Err(_) => env::remove_var("http_proxy"),
-        Ok(proxy) => env::set_var("http_proxy", proxy),
+        Ok(proxy) => env::set_var("http_proxy", proxy)
     }
 }

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -2,9 +2,9 @@
 
 use std::io::{Read, Write};
 use std::net;
+use std::time::Duration;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
 
 pub struct Server {
     addr: net::SocketAddr,
@@ -19,8 +19,9 @@ impl Server {
 
 impl Drop for Server {
     fn drop(&mut self) {
-        if !thread::panicking() {
-            self.panic_rx
+        if !::std::thread::panicking() {
+            self
+                .panic_rx
                 .recv_timeout(Duration::from_secs(3))
                 .expect("test server should not panic");
         }
@@ -46,10 +47,7 @@ pub fn spawn(txns: Vec<Txn>) -> Server {
     let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     let (panic_tx, panic_rx) = mpsc::channel();
-    let tname = format!(
-        "test({})-support-server",
-        thread::current().name().unwrap_or("<unknown>")
-    );
+    let tname = format!("test({})-support-server", thread::current().name().unwrap_or("<unknown>"));
     thread::Builder::new().name(tname).spawn(move || {
         'txns: for txn in txns {
             let mut expected = txn.request;
@@ -151,7 +149,10 @@ pub fn spawn(txns: Vec<Txn>) -> Server {
         let _ = panic_tx.send(());
     }).expect("server thread spawn");
 
-    Server { addr, panic_rx }
+    Server {
+        addr,
+        panic_rx,
+    }
 }
 
 fn replace_expected_vars(bytes: &mut Vec<u8>, host: &[u8], ua: &[u8]) {
@@ -209,15 +210,16 @@ macro_rules! __internal__txn {
     )
 }
 
+
 #[macro_export]
 macro_rules! __internal__prop {
-    (request: $val:expr) => {
+    (request: $val:expr) => (
         From::from(&$val[..])
-    };
-    (response: $val:expr) => {
+    );
+    (response: $val:expr) => (
         From::from(&$val[..])
-    };
-    ($field:ident: $val:expr) => {
+    );
+    ($field:ident: $val:expr) => (
         From::from($val)
-    };
+    )
 }

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,3 +1,6 @@
+extern crate env_logger;
+extern crate reqwest;
+
 #[macro_use]
 mod support;
 
@@ -35,7 +38,10 @@ fn timeout_closes_connection() {
     };
 
     let url = format!("http://{}/closes", server.addr());
-    let err = client.get(&url).send().unwrap_err();
+    let err = client
+        .get(&url)
+        .send()
+        .unwrap_err();
 
     assert_eq!(err.get_ref().unwrap().to_string(), "timed out");
     assert_eq!(err.url().map(|u| u.as_str()), Some(url.as_str()));
@@ -86,6 +92,7 @@ fn write_timeout_large_body() {
     assert_eq!(err.get_ref().unwrap().to_string(), "timed out");
     assert_eq!(err.url().map(|u| u.as_str()), Some(url.as_str()));
 }
+
 
 #[test]
 fn test_response_timeout() {
@@ -151,10 +158,7 @@ fn test_read_timeout() {
 
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
-    assert_eq!(
-        res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(),
-        &"5"
-    );
+    assert_eq!(res.headers().get(reqwest::header::CONTENT_LENGTH).unwrap(), &"5");
 
     let mut buf = [0; 1024];
     let err = res.read(&mut buf).unwrap_err();


### PR DESCRIPTION
The async/await branch was started before the formatting, and the conflict is enormous. So, we can revert on master, and then merge in async/await, and then format afterwards.