### PR TITLE
Update flate2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ encoding_rs = "0.8"
 futures = "0.1.23"
 http = "0.1.15"
 hyper = "0.12.22"
-flate2 = { version = "^1.0.7", default-features = false, features = ["rust_backend"] }
+flate2 = { version = "^1.0.11", default-features = false, features = ["rust_backend"] }
 log = "0.4"
 mime = "0.3.7"
 mime_guess = "2.0"


### PR DESCRIPTION
This updates flate2 to version 1.0.11 which:

- Updates to a new version of miniz_oxide with [important safety fixes](https://github.com/Frommi/miniz_oxide/pull/47). It is 100% safe code now and [forbids unsafe code](https://github.com/Frommi/miniz_oxide/pull/56).
- Makes calls to miniz_oxide no longer go through the C API layer, which has [soundness issues](https://github.com/Frommi/miniz_oxide/pull/36) in the version currently used by reqwest
- Drops most of the unsafe code from flate2 itself when used with Rust backend

I am aware that crate consumers normally use the latest available versions of dependencies. This change is meant to prohibit use of earlier versions due to soundness issues.