### PR TITLE
Refine async API

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@
 
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
-    let mut res = reqwest::Client::new()
+    let res = reqwest::Client::new()
         .get("https://hyper.rs")
         .send()
         .await?;

--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use futures::Stream;
 use hyper::body::Payload;
 use std::fmt;
@@ -7,10 +7,13 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::timer::Delay;
 
-/// An asynchronous `Stream`.
+/// An asynchronous request body.
 pub struct Body {
     inner: Inner,
 }
+
+// The `Stream` trait isn't stable, so the impl isn't public.
+pub(crate) struct ImplStream(Body);
 
 enum Inner {
     Reusable(Bytes),
@@ -21,13 +24,6 @@ enum Inner {
 }
 
 impl Body {
-    pub(crate) fn content_length(&self) -> Option<u64> {
-        match self.inner {
-            Inner::Reusable(ref bytes) => Some(bytes.len() as u64),
-            Inner::Hyper { ref body, .. } => body.size_hint().exact(),
-        }
-    }
-
     /// Wrap a futures `Stream` in a box inside `Body`.
     ///
     /// # Example
@@ -56,14 +52,12 @@ impl Body {
         Body::wrap(hyper::body::Body::wrap_stream(stream))
     }
 
-    #[inline]
     pub(crate) fn response(body: hyper::Body, timeout: Option<Delay>) -> Body {
         Body {
             inner: Inner::Hyper { body, timeout },
         }
     }
 
-    #[inline]
     pub(crate) fn wrap(body: hyper::Body) -> Body {
         Body {
             inner: Inner::Hyper {
@@ -73,19 +67,16 @@ impl Body {
         }
     }
 
-    #[inline]
     pub(crate) fn empty() -> Body {
         Body::wrap(hyper::Body::empty())
     }
 
-    #[inline]
     pub(crate) fn reusable(chunk: Bytes) -> Body {
         Body {
             inner: Inner::Reusable(chunk),
         }
     }
 
-    #[inline]
     pub(crate) fn into_hyper(self) -> (Option<Bytes>, hyper::Body) {
         match self.inner {
             Inner::Reusable(chunk) => (Some(chunk.clone()), chunk.into()),
@@ -96,44 +87,15 @@ impl Body {
         }
     }
 
-    fn inner(self: Pin<&mut Self>) -> Pin<&mut Inner> {
-        unsafe { Pin::map_unchecked_mut(self, |x| &mut x.inner) }
+    pub(crate) fn into_stream(self) -> ImplStream {
+        ImplStream(self)
     }
-}
 
-impl Stream for Body {
-    type Item = Result<Chunk, crate::Error>;
-
-    #[inline]
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        let opt_try_chunk = match self.inner().get_mut() {
-            Inner::Hyper {
-                ref mut body,
-                ref mut timeout,
-            } => {
-                if let Some(ref mut timeout) = timeout {
-                    if let Poll::Ready(()) = Pin::new(timeout).poll(cx) {
-                        return Poll::Ready(Some(Err(crate::error::timedout(None))));
-                    }
-                }
-                futures::ready!(Pin::new(body).poll_data(cx)).map(|opt_chunk| {
-                    opt_chunk
-                        .map(|c| Chunk { inner: c })
-                        .map_err(crate::error::from)
-                })
-            }
-            Inner::Reusable(ref mut bytes) => {
-                if bytes.is_empty() {
-                    None
-                } else {
-                    let chunk = Chunk::from_chunk(bytes.clone());
-                    *bytes = Bytes::new();
-                    Some(Ok(chunk))
-                }
-            }
-        };
-
-        Poll::Ready(opt_try_chunk)
+    pub(crate) fn content_length(&self) -> Option<u64> {
+        match self.inner {
+            Inner::Reusable(ref bytes) => Some(bytes.len() as u64),
+            Inner::Hyper { ref body, .. } => body.size_hint().exact(),
+        }
     }
 }
 
@@ -172,126 +134,41 @@ impl From<&'static str> for Body {
     }
 }
 
-/// A chunk of bytes for a `Body`.
-///
-/// A `Chunk` can be treated like `&[u8]`.
-#[derive(Default)]
-pub struct Chunk {
-    inner: hyper::Chunk,
-}
-
-impl Chunk {
-    #[inline]
-    pub(crate) fn from_chunk(chunk: Bytes) -> Chunk {
-        Chunk {
-            inner: hyper::Chunk::from(chunk),
-        }
-    }
-}
-
-impl Buf for Chunk {
-    fn bytes(&self) -> &[u8] {
-        self.inner.bytes()
-    }
-
-    fn remaining(&self) -> usize {
-        self.inner.remaining()
-    }
-
-    fn advance(&mut self, n: usize) {
-        self.inner.advance(n);
-    }
-}
-
-impl AsRef<[u8]> for Chunk {
-    #[inline]
-    fn as_ref(&self) -> &[u8] {
-        &*self
-    }
-}
-
-impl std::ops::Deref for Chunk {
-    type Target = [u8];
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.inner.as_ref()
-    }
-}
-
-impl Extend<u8> for Chunk {
-    fn extend<T>(&mut self, iter: T)
-    where
-        T: IntoIterator<Item = u8>,
-    {
-        self.inner.extend(iter)
-    }
-}
-
-impl IntoIterator for Chunk {
-    type Item = u8;
-    //XXX: exposing type from hyper!
-    type IntoIter = <hyper::Chunk as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
-    }
-}
-
-impl From<Vec<u8>> for Chunk {
-    fn from(v: Vec<u8>) -> Chunk {
-        Chunk { inner: v.into() }
-    }
-}
-
-impl From<&'static [u8]> for Chunk {
-    fn from(slice: &'static [u8]) -> Chunk {
-        Chunk {
-            inner: slice.into(),
-        }
-    }
-}
-
-impl From<String> for Chunk {
-    fn from(s: String) -> Chunk {
-        Chunk { inner: s.into() }
-    }
-}
-
-impl From<&'static str> for Chunk {
-    fn from(slice: &'static str) -> Chunk {
-        Chunk {
-            inner: slice.into(),
-        }
-    }
-}
-
-impl From<Bytes> for Chunk {
-    fn from(bytes: Bytes) -> Chunk {
-        Chunk {
-            inner: bytes.into(),
-        }
-    }
-}
-
-impl From<Chunk> for Bytes {
-    fn from(chunk: Chunk) -> Bytes {
-        chunk.inner.into()
-    }
-}
-
-impl From<Chunk> for hyper::Chunk {
-    fn from(val: Chunk) -> hyper::Chunk {
-        val.inner
-    }
-}
-
 impl fmt::Debug for Body {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Body").finish()
     }
 }
 
-impl fmt::Debug for Chunk {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.inner, f)
+// ===== impl ImplStream =====
+
+impl Stream for ImplStream {
+    type Item = Result<Bytes, crate::Error>;
+
+    #[inline]
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let opt_try_chunk = match self.0.inner {
+            Inner::Hyper {
+                ref mut body,
+                ref mut timeout,
+            } => {
+                if let Some(ref mut timeout) = timeout {
+                    if let Poll::Ready(()) = Pin::new(timeout).poll(cx) {
+                        return Poll::Ready(Some(Err(crate::error::timedout(None))));
+                    }
+                }
+                futures::ready!(Pin::new(body).poll_data(cx))
+                    .map(|opt_chunk| opt_chunk.map(Into::into).map_err(crate::error::from))
+            }
+            Inner::Reusable(ref mut bytes) => {
+                if bytes.is_empty() {
+                    None
+                } else {
+                    Some(Ok(std::mem::replace(bytes, Bytes::new())))
+                }
+            }
+        };
+
+        Poll::Ready(opt_try_chunk)
     }
 }

--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -1,6 +1,6 @@
-pub use self::body::{Body, Chunk};
+pub use self::body::Body;
 pub use self::client::{Client, ClientBuilder};
-pub use self::decoder::Decoder;
+pub(crate) use self::decoder::Decoder;
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::{Response, ResponseBuilderExt};
 

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -203,8 +203,7 @@ impl Response {
     /// or it cannot be properly deserialized to target type `T`. For more
     /// details please see [`serde_json::from_reader`].
     /// [`serde_json::from_reader`]: https://docs.serde.rs/serde_json/fn.from_reader.html
-    #[inline]
-    pub fn json<T: DeserializeOwned>(&mut self) -> crate::Result<T> {
+    pub fn json<T: DeserializeOwned>(self) -> crate::Result<T> {
         wait::timeout(self.inner.json(), self.timeout).map_err(|e| match e {
             wait::Waited::TimedOut => crate::error::timedout(None),
             wait::Waited::Executor(e) => crate::error::from(e),
@@ -228,12 +227,7 @@ impl Response {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// # Note
-    ///
-    /// This consumes the body. Trying to read more, or use of `response.json()`
-    /// will return empty values.
-    pub fn text(&mut self) -> crate::Result<String> {
+    pub fn text(self) -> crate::Result<String> {
         self.text_with_charset("utf-8")
     }
 
@@ -256,12 +250,7 @@ impl Response {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// # Note
-    ///
-    /// This consumes the body. Trying to read more, or use of `response.json()`
-    /// will return empty values.
-    pub fn text_with_charset(&mut self, default_encoding: &str) -> crate::Result<String> {
+    pub fn text_with_charset(self, default_encoding: &str) -> crate::Result<String> {
         wait::timeout(self.inner.text_with_charset(default_encoding), self.timeout).map_err(|e| {
             match e {
                 wait::Waited::TimedOut => crate::error::timedout(None),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,8 +187,8 @@ pub use hyper::{StatusCode, Version};
 pub use url::ParseError as UrlError;
 pub use url::Url;
 
-pub use self::r#async::{
-    multipart, Body, Client, ClientBuilder, Decoder, Request, RequestBuilder, Response,
+pub use self::async_impl::{
+    multipart, Body, Client, ClientBuilder, Request, RequestBuilder, Response,
 };
 //pub use self::body::Body;
 //pub use self::client::{Client, ClientBuilder};
@@ -223,7 +223,7 @@ mod tls;
 #[deprecated(note = "types moved to top of crate")]
 pub mod r#async {
     pub use crate::async_impl::{
-        multipart, Body, Chunk, Client, ClientBuilder, Decoder, Request, RequestBuilder, Response,
+        multipart, Body, Client, ClientBuilder, Request, RequestBuilder, Response,
     };
 }
 

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -22,7 +22,7 @@ fn test_response_text() {
     };
 
     let url = format!("http://{}/text", server.addr());
-    let mut res = reqwest::blocking::get(&url).unwrap();
+    let res = reqwest::blocking::get(&url).unwrap();
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
@@ -57,7 +57,7 @@ fn test_response_non_utf_8_text() {
     };
 
     let url = format!("http://{}/text", server.addr());
-    let mut res = reqwest::blocking::get(&url).unwrap();
+    let res = reqwest::blocking::get(&url).unwrap();
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
@@ -92,7 +92,7 @@ fn test_response_json() {
     };
 
     let url = format!("http://{}/json", server.addr());
-    let mut res = reqwest::blocking::get(&url).unwrap();
+    let res = reqwest::blocking::get(&url).unwrap();
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
@@ -126,7 +126,7 @@ fn test_response_copy_to() {
     };
 
     let url = format!("http://{}/1", server.addr());
-    let mut res = reqwest::blocking::get(&url).unwrap();
+    let res = reqwest::blocking::get(&url).unwrap();
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.headers().get(reqwest::header::SERVER).unwrap(), &"test");
@@ -158,7 +158,7 @@ fn test_get() {
     };
 
     let url = format!("http://{}/1", server.addr());
-    let mut res = reqwest::blocking::get(&url).unwrap();
+    let res = reqwest::blocking::get(&url).unwrap();
 
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
@@ -194,7 +194,7 @@ fn test_post() {
     };
 
     let url = format!("http://{}/2", server.addr());
-    let mut res = reqwest::blocking::Client::new()
+    let res = reqwest::blocking::Client::new()
         .post(&url)
         .body("Hello")
         .send()

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -142,7 +142,7 @@ fn test_read_timeout() {
     };
 
     let url = format!("http://{}/read-timeout", server.addr());
-    let mut res = reqwest::blocking::Client::builder()
+    let res = reqwest::blocking::Client::builder()
         .timeout(Duration::from_millis(500))
         .build()
         .unwrap()


### PR DESCRIPTION
- Converted `Response::text` and `Response::json` to `async fn`
- Added `Response::bytes` async fn as a counterpat to `text`.
- Added `Response::chunk` async fn to stream chunks of the response body.
- Added `From<Response> for Body` to allow piping a response as a request body.
- Removed `Decoder` from public API
- Removed body accessor methods from `Response`
- Removed `Chunk` type, replaced with `bytes::Bytes`.
- Removed public `impl Stream for Body`.