### PR TITLE
Fixed incorrect description of ClientBuilder::gzip

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -261,10 +261,10 @@ impl ClientBuilder {
     /// If auto gzip decompresson is turned on:
     /// - When sending a request and if the request's headers do not already contain
     ///   an `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to `gzip`.
-    ///   The body is **not** automatically inflated.
+    ///   The body is **not** automatically compressed.
     /// - When receiving a response, if it's headers contain a `Content-Encoding` value that
     ///   equals to `gzip`, both values `Content-Encoding` and `Content-Length` are removed from the
-    ///   headers' set. The body is automatically deinflated.
+    ///   headers' set. The body is automatically decompressed.
     ///
     /// Default is enabled.
     pub fn gzip(self, enable: bool) -> ClientBuilder {


### PR DESCRIPTION
"inflate" actually means decompress in the context of DEFLATE. "deflate" reduces the size of something, i.e. compression, and inflate is the opposite, i.e. decompression.