### PR TITLE
Rewrite tests with a hyper server instead of raw TCP

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,44 +1,35 @@
-#[macro_use]
 mod support;
+use support::*;
 
-use std::io::Write;
-use std::time::Duration;
-
-use reqwest::multipart::{Form, Part};
-use reqwest::{Body, Client};
-
-use bytes::Bytes;
+use reqwest::Client;
 
 #[tokio::test]
-async fn gzip_response() {
-    gzip_case(10_000, 4096).await;
-}
+async fn auto_headers() {
+    let server = server::http(move |req| {
+        async move {
+            assert_eq!(req.method(), "GET");
 
-#[tokio::test]
-async fn gzip_single_byte_chunks() {
-    gzip_case(10, 1).await;
+            assert_eq!(req.headers()["accept"], "*/*");
+            assert_eq!(req.headers()["user-agent"], DEFAULT_USER_AGENT);
+            assert_eq!(req.headers()["accept-encoding"], "gzip");
+
+            http::Response::default()
+        }
+    });
+
+    let url = format!("http://{}/1", server.addr());
+    let res = reqwest::get(&url).await.unwrap();
+
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    assert_eq!(res.remote_addr(), Some(server.addr()));
 }
 
 #[tokio::test]
 async fn response_text() {
     let _ = env_logger::try_init();
 
-    let server = server! {
-        request: b"\
-            GET /text HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Content-Length: 5\r\n\
-            \r\n\
-            Hello\
-            "
-    };
+    let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
 
     let client = Client::new();
 
@@ -55,22 +46,7 @@ async fn response_text() {
 async fn response_json() {
     let _ = env_logger::try_init();
 
-    let server = server! {
-        request: b"\
-            GET /json HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Content-Length: 7\r\n\
-            \r\n\
-            \"Hello\"\
-            "
-    };
+    let server = server::http(move |_req| async { http::Response::new("\"Hello\"".into()) });
 
     let client = Client::new();
 
@@ -84,286 +60,28 @@ async fn response_json() {
 }
 
 #[tokio::test]
-async fn multipart() {
-    use futures_util::{future, stream};
-
-    let _ = env_logger::try_init();
-
-    let stream = reqwest::Body::wrap_stream(stream::once(future::ready(Ok::<_, reqwest::Error>(
-        "part1 part2".to_owned(),
-    ))));
-    let part = Part::stream(stream);
-
-    let form = Form::new().text("foo", "bar").part("part_stream", part);
-
-    let expected_body = format!(
-        "\
-         24\r\n\
-         --{0}\r\n\r\n\
-         2E\r\n\
-         Content-Disposition: form-data; name=\"foo\"\r\n\r\n\r\n\
-         3\r\n\
-         bar\r\n\
-         2\r\n\
-         \r\n\r\n\
-         24\r\n\
-         --{0}\r\n\r\n\
-         36\r\n\
-         Content-Disposition: form-data; name=\"part_stream\"\r\n\r\n\r\n\
-         B\r\n\
-         part1 part2\r\n\
-         2\r\n\
-         \r\n\r\n\
-         26\r\n\
-         --{0}--\r\n\r\n\
-         0\r\n\r\n\
-         ",
-        form.boundary()
-    );
-
-    let server = server! {
-        request: format!("\
-            POST /multipart/1 HTTP/1.1\r\n\
-            content-type: multipart/form-data; boundary={}\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            transfer-encoding: chunked\r\n\
-            \r\n\
-            {}\
-            ", form.boundary(), expected_body),
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: multipart\r\n\
-            Content-Length: 0\r\n\
-            \r\n\
-            "
-    };
-
-    let url = format!("http://{}/multipart/1", server.addr());
-
-    let client = Client::new();
-
-    let res = client
-        .post(&url)
-        .multipart(form)
-        .send()
-        .await
-        .expect("Failed to post multipart");
-    assert_eq!(res.url().as_str(), &url);
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
-}
-
-#[tokio::test]
-async fn request_timeout() {
-    let _ = env_logger::try_init();
-
-    let server = server! {
-        request: b"\
-            GET /slow HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Content-Length: 5\r\n\
-            \r\n\
-            Hello\
-            ",
-        read_timeout: Duration::from_secs(2)
-    };
-
-    let client = Client::builder()
-        .timeout(Duration::from_millis(500))
-        .build()
-        .unwrap();
-
-    let url = format!("http://{}/slow", server.addr());
-
-    let res = client.get(&url).send().await;
-
-    let err = res.unwrap_err();
-
-    assert!(err.is_timeout());
-    assert_eq!(err.url().map(|u| u.as_str()), Some(url.as_str()));
-}
-
-#[tokio::test]
-async fn response_timeout() {
-    let _ = env_logger::try_init();
-
-    let server = server! {
-        request: b"\
-            GET /slow HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Content-Length: 5\r\n\
-            \r\n\
-            Hello\
-            ",
-        write_timeout: Duration::from_secs(2)
-    };
-
-    let client = Client::builder()
-        .timeout(Duration::from_millis(500))
-        .build()
-        .unwrap();
-
-    let url = format!("http://{}/slow", server.addr());
-    let res = client.get(&url).send().await.expect("Failed to get");
-    let body = res.text().await;
-
-    let err = body.unwrap_err();
-
-    assert!(err.is_timeout());
-}
-
-async fn gzip_case(response_size: usize, chunk_size: usize) {
-    let content: String = (0..response_size)
-        .into_iter()
-        .map(|i| format!("test {}", i))
-        .collect();
-    let mut encoder = libflate::gzip::Encoder::new(Vec::new()).unwrap();
-    match encoder.write(content.as_bytes()) {
-        Ok(n) => assert!(n > 0, "Failed to write to encoder."),
-        _ => panic!("Failed to gzip encode string."),
-    };
-
-    let gzipped_content = encoder.finish().into_result().unwrap();
-
-    let mut response = format!(
-        "\
-         HTTP/1.1 200 OK\r\n\
-         Server: test-accept\r\n\
-         Content-Encoding: gzip\r\n\
-         Content-Length: {}\r\n\
-         \r\n",
-        &gzipped_content.len()
-    )
-    .into_bytes();
-    response.extend(&gzipped_content);
-
-    let server = server! {
-        request: b"\
-            GET /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        chunk_size: chunk_size,
-        write_timeout: Duration::from_millis(10),
-        response: response
-    };
-
-    let client = Client::new();
-
-    let res = client
-        .get(&format!("http://{}/gzip", server.addr()))
-        .send()
-        .await
-        .expect("response");
-
-    let body = res.text().await.expect("text");
-    assert_eq!(body, content);
-}
-
-#[tokio::test]
-async fn body_stream() {
-    let _ = env_logger::try_init();
-
-    let source = futures_util::stream::iter::<Vec<Result<Bytes, std::io::Error>>>(vec![
-        Ok(Bytes::from_static(b"123")),
-        Ok(Bytes::from_static(b"4567")),
-    ]);
-
-    let expected_body = "3\r\n123\r\n4\r\n4567\r\n0\r\n\r\n";
-
-    let server = server! {
-        request: format!("\
-            POST /post HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            transfer-encoding: chunked\r\n\
-            \r\n\
-            {}\
-            ", expected_body),
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: post\r\n\
-            Content-Length: 7\r\n\
-            \r\n\
-            "
-    };
-
-    let url = format!("http://{}/post", server.addr());
-
-    let client = Client::new();
-
-    let res = client
-        .post(&url)
-        .body(Body::wrap_stream(source))
-        .send()
-        .await
-        .expect("Failed to post");
-
-    assert_eq!(res.url().as_str(), &url);
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
-}
-
-#[tokio::test]
 async fn body_pipe_response() {
     let _ = env_logger::try_init();
 
-    let server = server! {
-        request: b"\
-            GET /get HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: pipe\r\n\
-            Content-Length: 7\r\n\
-            \r\n\
-            pipe me\
-            ";
+    let server = server::http(move |mut req| {
+        async move {
+            if req.uri() == "/get" {
+                http::Response::new("pipe me".into())
+            } else {
+                assert_eq!(req.uri(), "/pipe");
+                assert_eq!(req.headers()["transfer-encoding"], "chunked");
 
-        request: b"\
-            POST /pipe HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            transfer-encoding: chunked\r\n\
-            \r\n\
-            7\r\n\
-            pipe me\r\n\
-            0\r\n\r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: pipe\r\n\
-            Content-Length: 0\r\n\
-            \r\n\
-            "
-    };
+                let mut full: Vec<u8> = Vec::new();
+                while let Some(item) = req.body_mut().next().await {
+                    full.extend(&*item.unwrap());
+                }
+
+                assert_eq!(full, b"pipe me");
+
+                http::Response::default()
+            }
+        }
+    });
 
     let client = Client::new();
 

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -1,13 +1,101 @@
-#[macro_use]
 mod support;
+use support::*;
 
 use std::io::Write;
-use std::time::Duration;
 
 #[tokio::test]
-async fn test_gzip_response() {
-    let content: String = (0..50).into_iter().map(|i| format!("test {}", i)).collect();
-    let chunk_size = content.len() / 3;
+async fn gzip_response() {
+    gzip_case(10_000, 4096).await;
+}
+
+#[tokio::test]
+async fn gzip_single_byte_chunks() {
+    gzip_case(10, 1).await;
+}
+
+#[tokio::test]
+async fn test_gzip_empty_body() {
+    let server = server::http(move |req| {
+        async move {
+            assert_eq!(req.method(), "HEAD");
+
+            http::Response::builder()
+                .header("content-encoding", "gzip")
+                .header("content-length", 100)
+                .body(Default::default())
+                .unwrap()
+        }
+    });
+
+    let client = reqwest::Client::new();
+    let res = client
+        .head(&format!("http://{}/gzip", server.addr()))
+        .send()
+        .await
+        .unwrap();
+
+    let body = res.text().await.unwrap();
+
+    assert_eq!(body, "");
+}
+
+#[tokio::test]
+async fn test_accept_header_is_not_changed_if_set() {
+    let server = server::http(move |req| {
+        async move {
+            assert_eq!(req.headers()["accept"], "application/json");
+            assert_eq!(req.headers()["accept-encoding"], "gzip");
+            http::Response::default()
+        }
+    });
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(&format!("http://{}/accept", server.addr()))
+        .header(
+            reqwest::header::ACCEPT,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_accept_encoding_header_is_not_changed_if_set() {
+    let server = server::http(move |req| {
+        async move {
+            assert_eq!(req.headers()["accept"], "*/*");
+            assert_eq!(req.headers()["accept-encoding"], "identity");
+            http::Response::default()
+        }
+    });
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(&format!("http://{}/accept-encoding", server.addr()))
+        .header(
+            reqwest::header::ACCEPT_ENCODING,
+            reqwest::header::HeaderValue::from_static("identity"),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+}
+
+async fn gzip_case(response_size: usize, chunk_size: usize) {
+    use futures_util::stream::StreamExt;
+
+    let content: String = (0..response_size)
+        .into_iter()
+        .map(|i| format!("test {}", i))
+        .collect();
     let mut encoder = libflate::gzip::Encoder::new(Vec::new()).unwrap();
     match encoder.write(content.as_bytes()) {
         Ok(n) => assert!(n > 0, "Failed to write to encoder."),
@@ -28,147 +116,38 @@ async fn test_gzip_response() {
     .into_bytes();
     response.extend(&gzipped_content);
 
-    let server = server! {
-        request: b"\
-            GET /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        chunk_size: chunk_size,
-        write_timeout: Duration::from_millis(10),
-        response: response
-    };
-    let url = format!("http://{}/gzip", server.addr());
-    let res = reqwest::get(&url).await.unwrap();
+    let server = server::http(move |req| {
+        assert_eq!(req.headers()["accept-encoding"], "gzip");
 
-    let body = res.text().await.unwrap();
+        let gzipped = gzipped_content.clone();
+        async move {
+            let len = gzipped.len();
+            let stream = futures_util::stream::unfold((gzipped, 0), move |(gzipped, pos)| {
+                async move {
+                    let chunk = gzipped.chunks(chunk_size).nth(pos)?.to_vec();
 
+                    Some((chunk, (gzipped, pos + 1)))
+                }
+            });
+
+            let body = hyper::Body::wrap_stream(stream.map(Ok::<_, std::convert::Infallible>));
+
+            http::Response::builder()
+                .header("content-encoding", "gzip")
+                .header("content-length", len)
+                .body(body)
+                .unwrap()
+        }
+    });
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(&format!("http://{}/gzip", server.addr()))
+        .send()
+        .await
+        .expect("response");
+
+    let body = res.text().await.expect("text");
     assert_eq!(body, content);
-}
-
-#[tokio::test]
-async fn test_gzip_empty_body() {
-    let server = server! {
-        request: b"\
-            HEAD /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: test-accept\r\n\
-            Content-Encoding: gzip\r\n\
-            Content-Length: 100\r\n\
-            \r\n"
-    };
-
-    let client = reqwest::Client::new();
-    let res = client
-        .head(&format!("http://{}/gzip", server.addr()))
-        .send()
-        .await
-        .unwrap();
-
-    let body = res.text().await.unwrap();
-
-    assert_eq!(body, "");
-}
-
-#[tokio::test]
-async fn test_gzip_invalid_body() {
-    let server = server! {
-        request: b"\
-            GET /gzip HTTP/1.1\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: test-accept\r\n\
-            Content-Encoding: gzip\r\n\
-            Content-Length: 100\r\n\
-            \r\n\
-            0"
-    };
-    let url = format!("http://{}/gzip", server.addr());
-    let res = reqwest::get(&url).await.unwrap();
-    // this tests that the request.send() didn't error, but that the error
-    // is in reading the body
-
-    res.text().await.unwrap_err();
-}
-
-#[tokio::test]
-async fn test_accept_header_is_not_changed_if_set() {
-    let server = server! {
-        request: b"\
-            GET /accept HTTP/1.1\r\n\
-            accept: application/json\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept-encoding: gzip\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: test-accept\r\n\
-            Content-Length: 0\r\n\
-            \r\n\
-            "
-    };
-    let client = reqwest::Client::new();
-
-    let res = client
-        .get(&format!("http://{}/accept", server.addr()))
-        .header(
-            reqwest::header::ACCEPT,
-            reqwest::header::HeaderValue::from_static("application/json"),
-        )
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
-}
-
-#[tokio::test]
-async fn test_accept_encoding_header_is_not_changed_if_set() {
-    let server = server! {
-        request: b"\
-            GET /accept-encoding HTTP/1.1\r\n\
-            accept-encoding: identity\r\n\
-            user-agent: $USERAGENT\r\n\
-            accept: */*\r\n\
-            host: $HOST\r\n\
-            \r\n\
-            ",
-        response: b"\
-            HTTP/1.1 200 OK\r\n\
-            Server: test-accept-encoding\r\n\
-            Content-Length: 0\r\n\
-            \r\n\
-            "
-    };
-    let client = reqwest::Client::new();
-
-    let res = client
-        .get(&format!("http://{}/accept-encoding", server.addr()))
-        .header(
-            reqwest::header::ACCEPT_ENCODING,
-            reqwest::header::HeaderValue::from_static("identity"),
-        )
-        .send()
-        .await
-        .unwrap();
-
-    assert_eq!(res.status(), reqwest::StatusCode::OK);
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,2 +1,6 @@
-#[macro_use]
 pub mod server;
+
+// TODO: remove once done converting to new support server?
+#[allow(unused)]
+pub static DEFAULT_USER_AGENT: &'static str =
+    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -1,14 +1,18 @@
-//! A server builder helper for the integration tests.
-
-use std::io::{Read, Write};
+use std::convert::Infallible;
+use std::future::Future;
 use std::net;
-use std::sync::mpsc;
+use std::sync::mpsc as std_mpsc;
 use std::thread;
 use std::time::Duration;
 
+use tokio::sync::oneshot;
+
+pub use http::Response;
+
 pub struct Server {
     addr: net::SocketAddr,
-    panic_rx: mpsc::Receiver<()>,
+    panic_rx: std_mpsc::Receiver<()>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
 }
 
 impl Server {
@@ -19,7 +23,11 @@ impl Server {
 
 impl Drop for Server {
     fn drop(&mut self) {
-        if !thread::panicking() {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+
+        if !::std::thread::panicking() {
             self.panic_rx
                 .recv_timeout(Duration::from_secs(3))
                 .expect("test server should not panic");
@@ -27,197 +35,46 @@ impl Drop for Server {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct Txn {
-    pub request: Vec<u8>,
-    pub response: Vec<u8>,
+pub fn http<F, Fut>(func: F) -> Server
+where
+    F: Fn(http::Request<hyper::Body>) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = http::Response<hyper::Body>> + Send + 'static,
+{
+    let srv = hyper::Server::bind(&([127, 0, 0, 1], 0).into()).serve(
+        hyper::service::make_service_fn(move |_| {
+            let func = func.clone();
+            async move {
+                Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
+                    let fut = func(req);
+                    async move { Ok::<_, Infallible>(fut.await) }
+                }))
+            }
+        }),
+    );
 
-    pub read_timeout: Option<Duration>,
-    pub read_closes: bool,
-    pub response_timeout: Option<Duration>,
-    pub write_timeout: Option<Duration>,
-    pub chunk_size: Option<usize>,
-}
+    let addr = srv.local_addr();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let srv = srv.with_graceful_shutdown(async move {
+        let _ = shutdown_rx.await;
+    });
 
-static DEFAULT_USER_AGENT: &'static str =
-    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
-
-pub fn spawn(txns: Vec<Txn>) -> Server {
-    let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    let (panic_tx, panic_rx) = mpsc::channel();
+    let (panic_tx, panic_rx) = std_mpsc::channel();
     let tname = format!(
         "test({})-support-server",
         thread::current().name().unwrap_or("<unknown>")
     );
-    thread::Builder::new().name(tname).spawn(move || {
-        'txns: for txn in txns {
-            let mut expected = txn.request;
-            let reply = txn.response;
-            let (mut socket, _addr) = listener.accept().unwrap();
+    thread::Builder::new()
+        .name(tname)
+        .spawn(move || {
+            let mut rt = tokio::runtime::current_thread::Runtime::new().expect("rt new");
+            rt.block_on(srv).unwrap();
+            let _ = panic_tx.send(());
+        })
+        .expect("thread spawn");
 
-            socket.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
-
-            replace_expected_vars(&mut expected, addr.to_string().as_ref(), DEFAULT_USER_AGENT.as_ref());
-
-            if let Some(dur) = txn.read_timeout {
-                thread::park_timeout(dur);
-            }
-
-            let mut buf = vec![0; expected.len() + 256];
-
-            let mut n = 0;
-            while n < expected.len() {
-                match socket.read(&mut buf[n..]) {
-                    Ok(0) => {
-                        if !txn.read_closes {
-                            panic!("server unexpected socket closed");
-                        } else {
-                            continue 'txns;
-                        }
-                    },
-                    Ok(nread) => n += nread,
-                    Err(err) => {
-                        println!("server read error: {}", err);
-                        break;
-                    }
-                }
-            }
-
-            if txn.read_closes {
-                socket.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
-                match socket.read(&mut [0; 256]) {
-                    Ok(0) => {
-                        continue 'txns
-                    },
-                    Ok(_) => {
-                        panic!("server read expected EOF, found more bytes");
-                    },
-                    Err(err) => {
-                        panic!("server read expected EOF, got error: {}", err);
-                    }
-                }
-            }
-
-            match (std::str::from_utf8(&expected), std::str::from_utf8(&buf[..n])) {
-                (Ok(expected), Ok(received)) => {
-                    if expected.len() > 300 && std::env::var("REQWEST_TEST_BODY_FULL").is_err() {
-                        assert_eq!(
-                            expected.len(),
-                            received.len(),
-                            "expected len = {}, received len = {}; to skip length check and see exact contents, re-run with REQWEST_TEST_BODY_FULL=1",
-                            expected.len(),
-                            received.len(),
-                        );
-                    }
-                    assert_eq!(expected, received)
-                },
-                _ => {
-                    assert_eq!(
-                        expected.len(),
-                        n,
-                        "expected len = {}, received len = {}",
-                        expected.len(),
-                        n,
-                    );
-                    assert_eq!(expected, &buf[..n])
-                },
-            }
-
-            if let Some(dur) = txn.response_timeout {
-                thread::park_timeout(dur);
-            }
-
-            if let Some(dur) = txn.write_timeout {
-                let headers_end = b"\r\n\r\n";
-                let headers_end = reply.windows(headers_end.len()).position(|w| w == headers_end).unwrap() + 4;
-                socket.write_all(&reply[..headers_end]).unwrap();
-
-                let body = &reply[headers_end..];
-
-                if let Some(chunk_size) = txn.chunk_size {
-                    for content in body.chunks(chunk_size) {
-                        thread::park_timeout(dur);
-                        socket.write_all(&content).unwrap();
-                    }
-                } else {
-                    thread::park_timeout(dur);
-                    socket.write_all(&body).unwrap();
-                }
-            } else {
-                socket.write_all(&reply).unwrap();
-            }
-        }
-        let _ = panic_tx.send(());
-    }).expect("server thread spawn");
-
-    Server { addr, panic_rx }
-}
-
-fn replace_expected_vars(bytes: &mut Vec<u8>, host: &[u8], ua: &[u8]) {
-    // plenty horrible, but these are just tests, and gets the job done
-    let mut index = 0;
-    loop {
-        if index == bytes.len() {
-            return;
-        }
-
-        for b in (&bytes[index..]).iter() {
-            index += 1;
-            if *b == b'$' {
-                break;
-            }
-        }
-
-        let has_host = (&bytes[index..]).starts_with(b"HOST");
-        if has_host {
-            bytes.drain(index - 1..index + 4);
-            for (i, b) in host.iter().enumerate() {
-                bytes.insert(index - 1 + i, *b);
-            }
-        } else {
-            let has_ua = (&bytes[index..]).starts_with(b"USERAGENT");
-            if has_ua {
-                bytes.drain(index - 1..index + 9);
-                for (i, b) in ua.iter().enumerate() {
-                    bytes.insert(index - 1 + i, *b);
-                }
-            }
-        }
+    Server {
+        addr,
+        panic_rx,
+        shutdown_tx: Some(shutdown_tx),
     }
-}
-
-#[macro_export]
-macro_rules! server {
-    ($($($f:ident: $v:expr),+);*) => ({
-        let txns = vec![
-            $(__internal__txn! {
-                $($f: $v,)+
-            }),*
-        ];
-        crate::support::server::spawn(txns)
-    })
-}
-
-#[macro_export]
-macro_rules! __internal__txn {
-    ($($field:ident: $val:expr,)+) => (
-        crate::support::server::Txn {
-            $( $field: __internal__prop!($field: $val), )+
-            .. Default::default()
-        }
-    )
-}
-
-#[macro_export]
-macro_rules! __internal__prop {
-    (request: $val:expr) => {
-        From::from(&$val[..])
-    };
-    (response: $val:expr) => {
-        From::from(&$val[..])
-    };
-    ($field:ident: $val:expr) => {
-        From::from($val)
-    };
 }


### PR DESCRIPTION
This makes the tests much less brittle, by not depending on the exact
order of the HTTP headers, nor always requiring to check for every
single header.