### PR TITLE
Revert returning Error when using blocking API inside an Executor

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -655,9 +655,6 @@ impl ClientHandle {
         let res = match wait::timeout(fut, self.timeout.0) {
             Ok(res) => res,
             Err(wait::Waited::TimedOut) => return Err(::error::timedout(Some(url))),
-            Err(wait::Waited::Executor(err)) => {
-                return Err(::error::from(err).with_url(url))
-            },
             Err(wait::Waited::Inner(err)) => {
                 return Err(err.with_url(url));
             },

--- a/src/response.rs
+++ b/src/response.rs
@@ -205,7 +205,6 @@ impl Response {
         wait::timeout(self.inner.json(), self.timeout).map_err(|e| {
             match e {
                 wait::Waited::TimedOut => ::error::timedout(None),
-                wait::Waited::Executor(e) => ::error::from(e),
                 wait::Waited::Inner(e) => e,
             }
         })
@@ -263,7 +262,6 @@ impl Response {
         wait::timeout(self.inner.text_with_charset(default_encoding), self.timeout).map_err(|e| {
             match e {
                 wait::Waited::TimedOut => ::error::timedout(None),
-                wait::Waited::Executor(e) => ::error::from(e),
                 wait::Waited::Inner(e) => e,
             }
         })
@@ -378,7 +376,6 @@ impl Stream for WaitBody {
             Some(Err(e)) => {
                 let req_err = match e {
                     wait::Waited::TimedOut => ::error::timedout(None),
-                    wait::Waited::Executor(e) => ::error::from(e),
                     wait::Waited::Inner(e) => e,
                 };
 


### PR DESCRIPTION
Log a warning instead.

cc #541