### PR TITLE
chore(deps): bump wasm-bindgen-futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,9 +108,9 @@ winreg = "0.6"
 # wasm
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.25"
-wasm-bindgen = "0.2.48"
-wasm-bindgen-futures = { version = "0.3", features = ["futures_0_3"] }
+js-sys = "0.3.28"
+wasm-bindgen = "0.2.51"
+wasm-bindgen-futures = "0.4.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -15,7 +15,7 @@ async fn promise<T>(promise: js_sys::Promise) -> Result<T, crate::error::BoxErro
 where
     T: JsCast,
 {
-    use wasm_bindgen_futures::futures_0_3::JsFuture;
+    use wasm_bindgen_futures::JsFuture;
 
     let js_val = JsFuture::from(promise)
         .await


### PR DESCRIPTION
This removes futures v0.1.29 .