### PR TITLE
Replace uuid dependency with tiny internal RNG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ mime_guess = "2.0"
 percent-encoding = "2.1"
 tokio = { version = "=0.2.0-alpha.6", default-features = false, features = ["io", "tcp", "timer"] }
 tokio-executor = "=0.2.0-alpha.6"
-uuid = { version = "0.7", features = ["v4"] }
 time = "0.1.42"
 
 # TODO: candidates for optional features

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -25,7 +25,10 @@ async fn text_part() {
         async move {
             assert_eq!(req.method(), "POST");
             assert_eq!(req.headers()["content-type"], ct);
-            assert_eq!(req.headers()["content-length"], "125");
+            assert_eq!(
+                req.headers()["content-length"],
+                expected_body.len().to_string()
+            );
 
             let mut full: Vec<u8> = Vec::new();
             while let Some(item) = req.body_mut().next().await {


### PR DESCRIPTION
Removes about 10 dependencies, and we don't need a strong RNG just to generate multipart boundaries.