### PR TITLE
Enable "system" proxies by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,4 +102,4 @@ env:
     - RUST_BACKTRACE=1
 script:
   - cargo build $FEATURES
-  - cargo test -v $FEATURES -- --test-threads=1
+  - cargo test -v $FEATURES --features __internal_proxy_sys_no_cache -- --test-threads=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,12 @@ json = ["serde_json"]
 
 unstable-stream = []
 
+# Internal (PRIVATE!) features used to aid testing.
+# Don't rely on these whatsoever. They may disappear at anytime.
+
+# When enabled, disable using the cached SYS_PROXIES.
+__internal_proxy_sys_no_cache = []
+
 [dependencies]
 http = "0.1.15"
 url = "2.1"
@@ -49,6 +55,7 @@ futures-core-preview = { version = "=0.3.0-alpha.19" }
 futures-util-preview = { version = "=0.3.0-alpha.19" }
 http-body = "=0.2.0-alpha.3"
 hyper = { version = "=0.13.0-alpha.4", default-features = false, features = ["tcp"] }
+lazy_static = "1.4"
 log = "0.4"
 mime = "0.3.7"
 mime_guess = "2.0"
@@ -150,4 +157,3 @@ required-features = ["cookies"]
 name = "gzip"
 path = "tests/gzip.rs"
 required-features = ["gzip"]
-

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -193,18 +193,25 @@ impl ClientBuilder {
     // Proxy options
 
     /// Add a `Proxy` to the list of proxies the `Client` will use.
+    ///
+    /// # Note
+    ///
+    /// Adding a proxy will disable the automatic usage of the "system" proxy.
     pub fn proxy(self, proxy: Proxy) -> ClientBuilder {
         self.with_inner(move |inner| inner.proxy(proxy))
     }
 
-    /// Disable proxy setting.
+    /// Clear all `Proxies`, so `Client` will use no proxy anymore.
+    ///
+    /// This also disables the automatic usage of the "system" proxy.
     pub fn no_proxy(self) -> ClientBuilder {
         self.with_inner(move |inner| inner.no_proxy())
     }
 
-    /// Enable system proxy setting.
+    #[doc(hidden)]
+    #[deprecated(note = "the system proxy is used automatically")]
     pub fn use_sys_proxy(self) -> ClientBuilder {
-        self.with_inner(move |inner| inner.use_sys_proxy())
+        self
     }
 
     // Timeout options

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,9 @@ if_hyper! {
     #[macro_use]
     extern crate doc_comment;
 
+    #[macro_use]
+    extern crate lazy_static;
+
     #[cfg(test)]
     doctest!("../README.md");
 


### PR DESCRIPTION
If no proxies are configured for a client, the environment (system) will
be inspected automatically to set up proxies.

Configuring a `Proxy` on a client or calling `no_proxy` will disable the
use of the automatic system proxy.

Closes #403