### PR TITLE
wasm: Add bytes method to wasm Response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,10 @@ __internal_proxy_sys_no_cache = []
 [dependencies]
 http = "0.1.15"
 url = "2.1"
+bytes = "0.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 base64 = "0.11"
-bytes = "0.4"
 encoding_rs = "0.8"
 futures-core-preview = { version = "=0.3.0-alpha.19" }
 futures-util-preview = { version = "=0.3.0-alpha.19" }


### PR DESCRIPTION
The `bytes` method was missing from the `Response` object of the wasm32
compilation target.