### PR TITLE
Update documentation to show usage of system proxies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,10 +130,16 @@
 //!
 //! ## Proxies
 //!
-//! A `Client` can be configured to make use of HTTP proxies by adding
-//! [`Proxy`](Proxy)s to a `ClientBuilder`.
+//! ** NOTE ** Proxies are enabled by default
 //!
-//! ** NOTE** System proxies will be used in the next breaking change.
+//! System proxies look in environment varables to set http or https proxies.
+//!
+//! `HTTP_PROXY` or `http_proxy` provide http proxies for http connections while
+//! `HTTPS_PROXY` or `https_proxy` provide https proxies for https connections
+//!
+//! These can be overwritten by adding a [`Proxy`](Proxy) to `ClientBuilder`
+//! i.e. `let proxy = reqwest::Proxy::http("https://secure.example")?;`
+//! or disabled by calling `ClientBuilder::no_proxy()`
 //!
 //! ## TLS
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@
 //!
 //! These can be overwritten by adding a [`Proxy`](Proxy) to `ClientBuilder`
 //! i.e. `let proxy = reqwest::Proxy::http("https://secure.example")?;`
-//! or disabled by calling `ClientBuilder::no_proxy()`
+//! or disabled by calling `ClientBuilder::no_proxy()`.
 //!
 //! ## TLS
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 //!
 //! ** NOTE ** Proxies are enabled by default
 //!
-//! System proxies look in environment varables to set http or https proxies.
+//! System proxies look in environment variables to set http or https proxies.
 //!
 //! `HTTP_PROXY` or `http_proxy` provide http proxies for http connections while
 //! `HTTPS_PROXY` or `https_proxy` provide https proxies for https connections

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 //!
 //! ** NOTE ** Proxies are enabled by default.
 //!
-//! System proxies look in environment variables to set http or https proxies.
+//! System proxies look in environment variables to set HTTP or HTTPS proxies.
 //!
 //! `HTTP_PROXY` or `http_proxy` provide http proxies for http connections while
 //! `HTTPS_PROXY` or `https_proxy` provide https proxies for https connections

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@
 //!
 //! ## Proxies
 //!
-//! ** NOTE ** Proxies are enabled by default
+//! ** NOTE ** Proxies are enabled by default.
 //!
 //! System proxies look in environment variables to set http or https proxies.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@
 //! System proxies look in environment variables to set HTTP or HTTPS proxies.
 //!
 //! `HTTP_PROXY` or `http_proxy` provide http proxies for http connections while
-//! `HTTPS_PROXY` or `https_proxy` provide https proxies for https connections
+//! `HTTPS_PROXY` or `https_proxy` provide HTTPS proxies for HTTPS connections.
 //!
 //! These can be overwritten by adding a [`Proxy`](Proxy) to `ClientBuilder`
 //! i.e. `let proxy = reqwest::Proxy::http("https://secure.example")?;`


### PR DESCRIPTION
Add several lines that explain the usage of proxies in the current
version. Introduce the familiar HTTP(S)_PROXY syntax so often seen
in http(s) clients.

Closes #685