### PR TITLE
Pin async-compression to the last alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ cookie_crate = { version = "0.12", package = "cookie", optional = true }
 cookie_store = { version = "0.10", optional = true }
 
 ## gzip
-async-compression = { version = "0.1.0-alpha.5", default-features = false, features = ["gzip", "stream"], optional = true }
+async-compression = { version = "=0.1.0-alpha.7", default-features = false, features = ["gzip", "stream"], optional = true }
 
 ## json
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
async-compression v0.1.0 was released with futures v0.3.0 as dependency