### PR TITLE
Prepare v0.10.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.10.0-alpha.2
+
+- Add `Request::try_clone()` method.
+- Add HTTP2 window size configuration to `ClientBuilder`.
+- Add `Body::as_bytes()` method.
+- Add `Response::bytes()` method for WASM target.
+- Add `RequestBuilder::body()` method for WASM target.
+- Change to enable system/environment proxy detection by default.
+- Fix checking `HTTP_PROXY` environment variable if it the environment is from a CGI script.
+- Fix removal of username/password of parsed proxy URL.
+- Fix pinning `async-compression` dependency to last alpha.
+
 # v0.10.0-alpha.1
 
 - Add `std::future::Future` support.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest"
-version = "0.10.0-alpha.1" # remember to update html_root_url
+version = "0.10.0-alpha.2" # remember to update html_root_url
 description = "higher level HTTP client library"
 keywords = ["http", "request", "client"]
 repository = "https://github.com/seanmonstar/reqwest"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/reqwest/0.10.0-alpha.1")]
+#![doc(html_root_url = "https://docs.rs/reqwest/0.10.0-alpha.2")]
 
 //! # reqwest
 //!


### PR DESCRIPTION
- Add `Request::try_clone()` method.
- Add HTTP2 window size configuration to `ClientBuilder`.
- Add `Body::as_bytes()` method.
- Add `Response::bytes()` method for WASM target.
- Add `RequestBuilder::body()` method for WASM target.
- Change to enable system/environment proxy detection by default.
- Fix checking `HTTP_PROXY` environment variable if it the environment is from a CGI script.
- Fix removal of username/password of parsed proxy URL.
- Fix pinning `async-compression` dependency to last alpha.