### PR TITLE
support url with authority

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -147,6 +147,7 @@ impl Error {
             Kind::UrlEncoded(ref e) => Some(e),
             Kind::Json(ref e) => Some(e),
             Kind::UrlBadScheme |
+            Kind::UrlCannotBeBaseOrNoHost |
             Kind::TooManyRedirects |
             Kind::RedirectLoop |
             Kind::Status(_) |
@@ -257,6 +258,9 @@ impl fmt::Display for Error {
             Kind::Mime(ref e) => fmt::Display::fmt(e, f),
             Kind::Url(ref e) => fmt::Display::fmt(e, f),
             Kind::UrlBadScheme => f.write_str("URL scheme is not allowed"),
+            Kind::UrlCannotBeBaseOrNoHost => {
+                f.write_str("URL is cannot-be-a-base or does not have a host")
+            },
             #[cfg(all(feature = "default-tls", feature = "rustls-tls"))]
             Kind::TlsIncompatible => f.write_str("Incompatible TLS identity type"),
             #[cfg(feature = "default-tls")]
@@ -296,6 +300,7 @@ impl StdError for Error {
             Kind::Mime(ref e) => e.description(),
             Kind::Url(ref e) => e.description(),
             Kind::UrlBadScheme => "URL scheme is not allowed",
+            Kind::UrlCannotBeBaseOrNoHost => "URL is cannot-be-a-base or does not have a host",
             #[cfg(all(feature = "default-tls", feature = "rustls-tls"))]
             Kind::TlsIncompatible => "Incompatible TLS identity type",
             #[cfg(feature = "default-tls")]
@@ -343,6 +348,7 @@ impl StdError for Error {
             Kind::UrlEncoded(ref e) => e.cause(),
             Kind::Json(ref e) => e.cause(),
             Kind::UrlBadScheme |
+            Kind::UrlCannotBeBaseOrNoHost |
             Kind::TooManyRedirects |
             Kind::RedirectLoop |
             Kind::Status(_) |
@@ -369,6 +375,7 @@ impl StdError for Error {
             Kind::UrlEncoded(ref e) => e.source(),
             Kind::Json(ref e) => e.source(),
             Kind::UrlBadScheme |
+            Kind::UrlCannotBeBaseOrNoHost |
             Kind::TooManyRedirects |
             Kind::RedirectLoop |
             Kind::Status(_) |
@@ -385,6 +392,7 @@ pub(crate) enum Kind {
     Mime(::mime::FromStrError),
     Url(::url::ParseError),
     UrlBadScheme,
+    UrlCannotBeBaseOrNoHost,
     #[cfg(all(feature = "default-tls", feature = "rustls-tls"))]
     TlsIncompatible,
     #[cfg(feature = "default-tls")]
@@ -587,6 +595,10 @@ pub(crate) fn status_code(url: Url, status: StatusCode) -> Error {
 
 pub(crate) fn url_bad_scheme(url: Url) -> Error {
     Error::new(Kind::UrlBadScheme, Some(url))
+}
+
+pub(crate) fn url_cannot_be_base_or_no_host(url: Url) -> Error {
+    Error::new(Kind::UrlCannotBeBaseOrNoHost, Some(url))
 }
 
 #[cfg(feature = "trust-dns")]

--- a/src/request.rs
+++ b/src/request.rs
@@ -119,9 +119,33 @@ impl Request {
 
 impl RequestBuilder {
     pub(crate) fn new(client: Client, request: ::Result<Request>) -> RequestBuilder {
-        RequestBuilder {
-            client,
-            request,
+        let mut builder = RequestBuilder { client, request };
+        let authority = if let Ok(ref mut req) = builder.request {
+            if req.url().has_authority() {
+                let url = req.url().clone();
+                    let username = url.username().to_owned();
+                    let password = url.password().map(ToOwned::to_owned);
+                if !username.is_empty() || password.is_some() {
+                    if req.url_mut().set_username("").is_err()
+                        || req.url_mut().set_password(None).is_err()
+                    {
+                        Err(::error::url_cannot_be_base_or_no_host(url))
+                    } else {
+                        Ok(Some((username, password)))
+                    }
+                } else {
+                    Ok(None)
+                }
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        };
+        if let Ok(Some((username, password))) = authority {
+            builder.basic_auth(username, password)
+        } else {
+            builder
         }
     }
 


### PR DESCRIPTION
For #715.

With this PR, the output of the example in #715 will be:
```
RequestBuilder {
    client: Client,
    request: Ok(
        Request {
            method: POST,
            url: "http://localhost:12345/",
            headers: {
                "authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
                "content-type": "application/json",
            },
        },
    ),
}
```

I checked the logs of nginx, this request was same as the request which sent by `curl/7.65.0` with same url and same content.

- If the modification in this PR was acceptable, I can pull another PR to the master branch.