### PR TITLE
Refactor Redirect API

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -13,7 +13,7 @@ use log::{error, trace};
 use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::wait;
-use crate::{async_impl, header, IntoUrl, Method, Proxy, RedirectPolicy};
+use crate::{async_impl, header, IntoUrl, Method, Proxy, redirect};
 #[cfg(feature = "tls")]
 use crate::{Certificate, Identity};
 
@@ -176,10 +176,10 @@ impl ClientBuilder {
 
     // Redirect options
 
-    /// Set a `RedirectPolicy` for this client.
+    /// Set a `redirect::Policy` for this client.
     ///
     /// Default will follow redirects up to a maximum of 10.
-    pub fn redirect(self, policy: RedirectPolicy) -> ClientBuilder {
+    pub fn redirect(self, policy: redirect::Policy) -> ClientBuilder {
         self.with_inner(move |inner| inner.redirect(policy))
     }
 
@@ -541,7 +541,7 @@ impl Client {
     /// # Errors
     ///
     /// This method fails if there was an error while sending request,
-    /// redirect loop was detected or redirect limit was exhausted.
+    /// or redirect limit was exhausted.
     pub fn execute(&self, request: Request) -> crate::Result<Response> {
         self.inner.execute_request(request)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -212,12 +212,8 @@ pub(crate) fn request<E: Into<BoxError>>(e: E) -> Error {
     Error::new(Kind::Request, Some(e))
 }
 
-pub(crate) fn loop_detected(url: Url) -> Error {
-    Error::new(Kind::Redirect, Some("infinite redirect loop detected")).with_url(url)
-}
-
-pub(crate) fn too_many_redirects(url: Url) -> Error {
-    Error::new(Kind::Redirect, Some("too many redirects")).with_url(url)
+pub(crate) fn redirect<E: Into<BoxError>>(e: E, url: Url) -> Error {
+    Error::new(Kind::Redirect, Some(e)).with_url(url)
 }
 
 pub(crate) fn status_code(url: Url, status: StatusCode) -> Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,9 +119,9 @@
 //!
 //! ## Redirect Policies
 //!
-//! By default, a `Client` will automatically handle HTTP redirects, detecting
-//! loops, and having a maximum redirect chain of 10 hops. To customize this
-//! behavior, a [`RedirectPolicy`][redirect] can used with a `ClientBuilder`.
+//! By default, a `Client` will automatically handle HTTP redirects, having a
+//! maximum redirect chain of 10 hops. To customize this behavior, a
+//! [`redirect::Policy`][redirect] can be used with a `ClientBuilder`.
 //!
 //! ## Cookies
 //!
@@ -175,7 +175,7 @@
 //! [get]: ./fn.get.html
 //! [builder]: ./struct.RequestBuilder.html
 //! [serde]: http://serde.rs
-//! [redirect]: ./struct.RedirectPolicy.html
+//! [redirect]: crate::redirect
 //! [Proxy]: ./struct.Proxy.html
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
@@ -237,7 +237,6 @@ pub use self::into_url::IntoUrl;
 /// - native TLS backend cannot be initialized
 /// - supplied `Url` cannot be parsed
 /// - there was an error while sending request
-/// - redirect loop was detected
 /// - redirect limit was exhausted
 pub async fn get<T: IntoUrl>(url: T) -> crate::Result<Response> {
     Client::builder().build()?.get(url).send().await
@@ -279,7 +278,6 @@ if_hyper! {
         multipart, Body, Client, ClientBuilder, Request, RequestBuilder, Response, ResponseBuilderExt,
     };
     pub use self::proxy::Proxy;
-    pub use self::redirect::{RedirectAction, RedirectAttempt, RedirectPolicy};
     #[cfg(feature = "tls")]
     pub use self::tls::{Certificate, Identity};
 
@@ -293,17 +291,9 @@ if_hyper! {
     //#[cfg(feature = "trust-dns")]
     //mod dns;
     mod proxy;
-    mod redirect;
+    pub mod redirect;
     #[cfg(feature = "tls")]
     mod tls;
-
-    #[doc(hidden)]
-    #[deprecated(note = "types moved to top of crate")]
-    pub mod r#async {
-        pub use crate::async_impl::{
-            multipart, Body, Client, ClientBuilder, Request, RequestBuilder, Response,
-        };
-    }
 }
 
 if_wasm! {

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -173,7 +173,7 @@ async fn cookie_store_expires() {
         }
     });
 
-    let client = reqwest::r#async::Client::builder()
+    let client = reqwest::Client::builder()
         .cookie_store(true)
         .build()
         .unwrap();
@@ -201,7 +201,7 @@ async fn cookie_store_path() {
         }
     });
 
-    let client = reqwest::r#async::Client::builder()
+    let client = reqwest::Client::builder()
         .cookie_store(true)
         .build()
         .unwrap();

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -240,7 +240,7 @@ async fn test_redirect_policy_can_stop_redirects_without_an_error() {
     let url = format!("http://{}/no-redirect", server.addr());
 
     let res = reqwest::Client::builder()
-        .redirect(reqwest::RedirectPolicy::none())
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap()
         .get(&url)


### PR DESCRIPTION
Changed the redirect types to be from the `redirect` module:

- `reqwest::RedirectPolicy` is now `reqwest::redirect::Policy`
- `reqwest::RedirectAttempt` is now `reqwest::redirect::Attempt`
- `reqwest::RedirectAction` is now `reqwest::redirect::Action`

Changed behavior of default policy to no longer check for redirect loops
(loops should still be caught eventually by the maximum limit).

Removed the `too_many_redirects` and `loop_detected` methods from
`Action`.

Added `error` to `Action` that can be passed any error type.

Closes #717