### PR TITLE
Separate default-tls and native-tls features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           - windows / stable-i686-gnu
           - "feat.: default-tls disabled"
           - "feat.: rustls-tls"
+          - "feat.: native-tls"
           - "feat.: default-tls and rustls-tls"
           - "feat.: cookies"
           - "feat.: blocking"
@@ -100,6 +101,8 @@ jobs:
             features: "--no-default-features"
           - name: "feat.: rustls-tls"
             features: "--no-default-features --features rustls-tls"
+          - name: "feat.: native-tls"
+            features: "--features native-tls"
           - name: "feat.: default-tls and rustls-tls"
             features: "--features rustls-tls"
           - name: "feat.: cookies"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,15 @@ all-features = true
 [features]
 default = ["default-tls"]
 
-tls = []
+# Note: this doesn't enable the 'native-tls' feature, which adds specific
+# functionality for it.
+default-tls = ["hyper-tls", "native-tls-crate", "__tls", "tokio-tls"]
 
-default-tls = ["hyper-tls", "native-tls", "tls", "tokio-tls"]
-default-tls-vendored = ["default-tls", "native-tls/vendored"]
+# Enables native-tls specific functionality not available by default.
+native-tls = ["default-tls"]
+native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 
-rustls-tls = ["hyper-rustls", "tokio-rustls", "webpki-roots", "rustls", "tls"]
+rustls-tls = ["hyper-rustls", "tokio-rustls", "webpki-roots", "rustls", "__tls"]
 
 blocking = ["futures-channel", "futures-util/io", "tokio/rt-threaded", "tokio/rt-core"]
 
@@ -39,6 +42,9 @@ stream = []
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at anytime.
+
+# Enables common types used for TLS. Useless on its own.
+__tls = []
 
 # When enabled, disable using the cached SYS_PROXIES.
 __internal_proxy_sys_no_cache = []
@@ -74,7 +80,7 @@ serde_urlencoded = "0.6.1"
 
 ## default-tls
 hyper-tls = { version = "0.4", optional = true }
-native-tls = { version = "0.2", optional = true }
+native-tls-crate = { version = "0.2", optional = true, package = "native-tls" }
 tokio-tls = { version = "0.3.0", optional = true }
 
 # rustls-tls

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -14,7 +14,7 @@ use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::wait;
 use crate::{async_impl, header, IntoUrl, Method, Proxy, redirect};
-#[cfg(feature = "tls")]
+#[cfg(feature = "__tls")]
 use crate::{Certificate, Identity};
 
 /// A `Client` to make Requests with.
@@ -331,45 +331,15 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls` or `rustls-tls` feature to be
-    /// enabled.
-    #[cfg(feature = "tls")]
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
     pub fn add_root_certificate(self, cert: Certificate) -> ClientBuilder {
         self.with_inner(move |inner| inner.add_root_certificate(cert))
     }
 
     /// Sets the identity to be used for client certificate authentication.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use std::fs::File;
-    /// # use std::io::Read;
-    /// # fn build_client() -> Result<(), Box<std::error::Error>> {
-    /// // read a local PKCS12 bundle
-    /// let mut buf = Vec::new();
-    ///
-    /// #[cfg(feature = "default-tls")]
-    /// File::open("my-ident.pfx")?.read_to_end(&mut buf)?;
-    /// #[cfg(feature = "rustls-tls")]
-    /// File::open("my-ident.pem")?.read_to_end(&mut buf)?;
-    ///
-    /// #[cfg(feature = "default-tls")]
-    /// // create an Identity from the PKCS#12 archive
-    /// let pkcs12 = reqwest::Identity::from_pkcs12_der(&buf, "my-privkey-password")?;
-    /// #[cfg(feature = "rustls-tls")]
-    /// // create an Identity from the PEM file
-    /// let pkcs12 = reqwest::Identity::from_pem(&buf)?;
-    ///
-    /// // get a client builder
-    /// let client = reqwest::blocking::Client::builder()
-    ///     .identity(pkcs12)
-    ///     .build()?;
-    /// # drop(client);
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "__tls")]
     pub fn identity(self, identity: Identity) -> ClientBuilder {
         self.with_inner(move |inner| inner.identity(identity))
     }
@@ -384,7 +354,11 @@ impl ClientBuilder {
     /// hostname verification is not used, any valid certificate for any
     /// site will be trusted for use from any other. This introduces a
     /// significant vulnerability to man-in-the-middle attacks.
-    #[cfg(feature = "default-tls")]
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `native-tls` feature to be enabled.
+    #[cfg(feature = "native-tls")]
     pub fn danger_accept_invalid_hostnames(self, accept_invalid_hostname: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.danger_accept_invalid_hostnames(accept_invalid_hostname))
     }
@@ -400,7 +374,7 @@ impl ClientBuilder {
     /// will be trusted for use. This includes expired certificates. This
     /// introduces significant vulnerabilities, and should only be used
     /// as a last resort.
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "__tls")]
     pub fn danger_accept_invalid_certs(self, accept_invalid_certs: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.danger_accept_invalid_certs(accept_invalid_certs))
     }
@@ -412,10 +386,10 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls` feature to be enabled.
-    #[cfg(feature = "default-tls")]
-    pub fn use_default_tls(self) -> ClientBuilder {
-        self.with_inner(move |inner| inner.use_default_tls())
+    /// This requires the optional `native-tls` feature to be enabled.
+    #[cfg(feature = "native-tls")]
+    pub fn use_native_tls(self) -> ClientBuilder {
+        self.with_inner(move |inner| inner.use_native_tls())
     }
 
     /// Force using the Rustls TLS backend.

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -3,9 +3,9 @@ use http::uri::{Scheme, Authority};
 use http::Uri;
 use hyper::client::connect::{Connected, Connection};
 use tokio::io::{AsyncRead, AsyncWrite};
-#[cfg(feature = "default-tls")]
-use native_tls::{TlsConnector, TlsConnectorBuilder};
-#[cfg(feature = "tls")]
+#[cfg(feature = "native-tls-crate")]
+use native_tls_crate::{TlsConnector, TlsConnectorBuilder};
+#[cfg(feature = "__tls")]
 use http::header::HeaderValue;
 use bytes::{Buf, BufMut};
 
@@ -38,15 +38,15 @@ pub(crate) struct Connector {
     inner: Inner,
     proxies: Arc<Vec<Proxy>>,
     timeout: Option<Duration>,
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "__tls")]
     nodelay: bool,
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "__tls")]
     user_agent: HeaderValue,
 }
 
 #[derive(Clone)]
 enum Inner {
-    #[cfg(not(feature = "tls"))]
+    #[cfg(not(feature = "__tls"))]
     Http(HttpConnector),
     #[cfg(feature = "default-tls")]
     DefaultTls(HttpConnector, TlsConnector),
@@ -59,7 +59,7 @@ enum Inner {
 }
 
 impl Connector {
-    #[cfg(not(feature = "tls"))]
+    #[cfg(not(feature = "__tls"))]
     pub(crate) fn new<T>(
         proxies: Arc<Vec<Proxy>>,
         local_addr: T,
@@ -199,7 +199,7 @@ impl Connector {
                     Ok((Box::new(io) as Conn, connected))
                 }
             }
-            #[cfg(not(feature = "tls"))]
+            #[cfg(not(feature = "__tls"))]
             Inner::Http(_) => socks::connect(proxy, dst, dns),
         }
     }
@@ -210,7 +210,7 @@ impl Connector {
         is_proxy: bool,
     ) -> Result<Conn, BoxError> {
         match self.inner {
-            #[cfg(not(feature = "tls"))]
+            #[cfg(not(feature = "__tls"))]
             Inner::Http(mut http) => {
                 let io = http.call(dst).await?;
                 Ok(Conn {
@@ -281,7 +281,7 @@ impl Connector {
         };
 
 
-        #[cfg(feature = "tls")]
+        #[cfg(feature = "__tls")]
         let auth = _auth;
 
         match &self.inner {
@@ -352,7 +352,7 @@ impl Connector {
                     });
                 }
             }
-            #[cfg(not(feature = "tls"))]
+            #[cfg(not(feature = "__tls"))]
             Inner::Http(_) => (),
         }
 
@@ -510,7 +510,7 @@ impl AsyncWrite for Conn {
 pub(crate) type Connecting =
     Pin<Box<dyn Future<Output = Result<Conn, BoxError>> + Send>>;
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "__tls")]
 async fn tunnel<T>(
     mut conn: T,
     host: String,
@@ -586,7 +586,7 @@ where
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "__tls")]
 fn tunnel_eof() -> io::Error {
     io::Error::new(
         io::ErrorKind::UnexpectedEof,
@@ -834,7 +834,7 @@ mod socks {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "__tls")]
 #[cfg(test)]
 mod tests {
     use super::tunnel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,9 +159,11 @@
 //! The following are a list of [Cargo features][cargo-features] that can be
 //! enabled or disabled:
 //!
-//! - **default-tls** *(enabled by default)*: Provides TLS support via the
-//!   `native-tls` library to connect over HTTPS.
-//! - **default-tls-vendored**: Enables the `vendored` feature of `native-tls`.
+//! - **default-tls** *(enabled by default)*: Provides TLS support to connect
+//!   over HTTPS.
+//! - **native-tls**: Enables TLS functionality provided by `native-tls`.
+//! - **native-tls-vendored**: Enables the `vendored` feature of `native-tls`.
+//! - **rustls-tls**: Enables TLS functionality provided by `rustls`.
 //! - **blocking**: Provides the [blocking][] client API.
 //! - **cookies**: Provides cookie session support.
 //! - **gzip**: Provides response body gzip decompression.
@@ -179,7 +181,6 @@
 //! [Proxy]: ./struct.Proxy.html
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
-////! - **rustls-tls**: Provides TLS support via the `rustls` library.
 ////! - **socks**: Provides SOCKS5 proxy support.
 ////! - **trust-dns**: Enables a trust-dns async resolver instead of default
 ////!   threadpool using `getaddrinfo`.
@@ -278,7 +279,7 @@ if_hyper! {
         multipart, Body, Client, ClientBuilder, Request, RequestBuilder, Response, ResponseBuilderExt,
     };
     pub use self::proxy::Proxy;
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "__tls")]
     pub use self::tls::{Certificate, Identity};
 
 
@@ -292,7 +293,7 @@ if_hyper! {
     //mod dns;
     mod proxy;
     pub mod redirect;
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "__tls")]
     mod tls;
 }
 

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "tls")]
+#[cfg(feature = "__tls")]
 #[tokio::test]
 async fn test_badssl_modern() {
     let text = reqwest::get("https://mozilla-modern.badssl.com/")
@@ -29,7 +29,7 @@ async fn test_rustls_badssl_modern() {
     assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "__tls")]
 #[tokio::test]
 async fn test_badssl_self_signed() {
     let text = reqwest::Client::builder()
@@ -47,7 +47,7 @@ async fn test_badssl_self_signed() {
     assert!(text.contains("<title>self-signed.badssl.com</title>"));
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 #[tokio::test]
 async fn test_badssl_wrong_host() {
     let text = reqwest::Client::builder()


### PR DESCRIPTION
To allow for the default-tls to change to a different backend by
default, this adds a new `native-tls` optional feature. Any TLS feature
that was only available using native-tls now requires the `native-tls`
feature to be enabled.