### PR TITLE
re-add the "socks" feature (using tokio-socks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
           - "feat.: gzip"
           - "feat.: json"
           - "feat.: stream"
-          # - "feat.: socks"
+          - "feat.: socks/default-tls"
+          - "feat.: socks/rustls-tls"
           # - "feat.: trust-dns"
 
         include:
@@ -115,8 +116,10 @@ jobs:
             features: "--features json"
           - name: "feat.: stream"
             features: "--features stream"
-          # - name: "feat.: socks"
-          #   features: "--features socks"
+          - name: "feat.: socks/default-tls"
+            features: "--features socks"
+          - name: "feat.: socks/rustls-tls"
+            features: "--features socks,rustls-tls"
           # - name: "feat.: trust-dns"
           #   features: "--features trust-dns"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ json = ["serde_json"]
 
 stream = []
 
+socks = ["tokio-socks"]
+
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at anytime.
 
@@ -107,7 +109,7 @@ async-compression = { version = "0.2.0", default-features = false, features = ["
 serde_json = { version = "1.0", optional = true }
 
 ## socks
-#socks = { version = "0.3.2", optional = true }
+tokio-socks = { version = "0.2", optional = true }
 
 ## trust-dns
 #trust-dns-resolver = { version = "0.11", optional = true }
@@ -155,6 +157,11 @@ required-features = ["json"]
 name = "json_typed"
 path = "examples/json_typed.rs"
 required-features = ["json"]
+
+[[example]]
+name = "tor_socks"
+path = "examples/tor_socks.rs"
+required-features = ["socks"]
 
 [[test]]
 name = "blocking"

--- a/examples/tor_socks.rs
+++ b/examples/tor_socks.rs
@@ -1,0 +1,24 @@
+#![deny(warnings)]
+
+// This is using the `tokio` runtime. You'll need the following dependency:
+//
+// `tokio = { version = "0.2", features = ["macros"] }`
+#[tokio::main]
+async fn main() -> Result<(), reqwest::Error> {
+    // Make sure you are running tor and this is your socks port
+    let proxy = reqwest::Proxy::all("socks5://127.0.0.1:9050").expect("tor proxy should be there");
+    let client = reqwest::Client::builder()
+        .proxy(proxy)
+        .build()
+        .expect("should be able to build reqwest client");
+
+    let res = client.get("https://check.torproject.org").send().await?;
+    println!("Status: {}", res.status());
+
+    let text = res.text().await?;
+    let is_tor = text.contains("Congratulations. This browser is configured to use Tor.");
+    println!("Is Tor: {}", is_tor);
+    assert!(is_tor);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@
 //! - **gzip**: Provides response body gzip decompression.
 //! - **json**: Provides serialization and deserialization for JSON bodies.
 //! - **stream**: Adds support for `futures::Stream`.
+//! - **socks**: Provides SOCKS5 proxy support.
 //!
 //!
 //! [hyper]: http://hyper.rs
@@ -180,8 +181,6 @@
 //! [redirect]: crate::redirect
 //! [Proxy]: ./struct.Proxy.html
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
-
-////! - **socks**: Provides SOCKS5 proxy support.
 ////! - **trust-dns**: Enables a trust-dns async resolver instead of default
 ////!   threadpool using `getaddrinfo`.
 


### PR DESCRIPTION
The "socks" feature has been removed for a while now, the optional dependency on the "socks" crate commented out.

The code for actually providing the socks feature was, however, still mostly present, if a bit out of date.

This PR re-adds the socks feature using the tokio-socks (instead of socks) crate.

~~There is still a FIXME in the code I added and it probably won't compile in some of the different "tls" feature settings. If you could provide some guidance, I'd be happy to fix the remaining issues!~~

I added a `tor_socks` example that checks that a request to `check.torproject.org` is routed through Tor when setting the socks proxy.

Things I assume still need to be done:

- [x] make this compile in all tls environments
- [x] have a look at the FIXME
- [x] add tests and/or an example
- [x] optional: extend the CI configuration