### PR TITLE
Add connection_verbose setting to log IO events

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -64,6 +64,7 @@ struct Config {
     #[cfg(feature = "__tls")]
     certs_verification: bool,
     connect_timeout: Option<Duration>,
+    connection_verbose: bool,
     max_idle_per_host: usize,
     #[cfg(feature = "__tls")]
     identity: Option<Identity>,
@@ -111,6 +112,7 @@ impl ClientBuilder {
                 #[cfg(feature = "__tls")]
                 certs_verification: true,
                 connect_timeout: None,
+                connection_verbose: false,
                 max_idle_per_host: std::usize::MAX,
                 proxies: Vec::new(),
                 auto_sys_proxy: true,
@@ -234,6 +236,7 @@ impl ClientBuilder {
         };
 
         connector.set_timeout(config.connect_timeout);
+        connector.set_verbose(config.connection_verbose);
 
         let mut builder = hyper::Client::builder();
         if config.http2_only {
@@ -486,6 +489,17 @@ impl ClientBuilder {
     /// a tokio timer enabled.
     pub fn connect_timeout(mut self, timeout: Duration) -> ClientBuilder {
         self.config.connect_timeout = Some(timeout);
+        self
+    }
+
+    /// Set whether connections should emit verbose logs.
+    ///
+    /// Enabling this option will emit [log][] messages at the `TRACE` level
+    /// for read and write operations on connections.
+    ///
+    /// [log]: https://crates.io/crates/log
+    pub fn connection_verbose(mut self, verbose: bool) -> ClientBuilder {
+        self.config.connection_verbose = verbose;
         self
     }
 

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -487,48 +487,14 @@ impl PercentEncoding {
 }
 
 fn gen_boundary() -> String {
+    use crate::util::fast_random as random;
+
     let a = random();
     let b = random();
     let c = random();
     let d = random();
 
     format!("{:016x}-{:016x}-{:016x}-{:016x}", a, b, c, d)
-}
-
-// xor-shift
-fn random() -> u64 {
-    use std::cell::Cell;
-    use std::collections::hash_map::RandomState;
-    use std::hash::{BuildHasher, Hasher};
-    use std::num::Wrapping;
-
-    thread_local! {
-        static RNG: Cell<Wrapping<u64>> = Cell::new(Wrapping(seed()));
-    }
-
-    fn seed() -> u64 {
-        let seed = RandomState::new();
-
-        let mut out = 0;
-        let mut cnt = 0;
-        while out == 0 {
-            cnt += 1;
-            let mut hasher = seed.build_hasher();
-            hasher.write_usize(cnt);
-            out = hasher.finish();
-        }
-        out
-    }
-
-    RNG.with(|rng| {
-        let mut n = rng.get();
-        debug_assert_ne!(n.0, 0);
-        n ^= n >> 12;
-        n ^= n << 25;
-        n ^= n >> 27;
-        rng.set(n);
-        n.0.wrapping_mul(0x2545_f491_4f6c_dd1d)
-    })
 }
 
 #[cfg(test)]

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -273,6 +273,16 @@ impl ClientBuilder {
         }
     }
 
+    /// Set whether connections should emit verbose logs.
+    ///
+    /// Enabling this option will emit [log][] messages at the `TRACE` level
+    /// for read and write operations on connections.
+    ///
+    /// [log]: https://crates.io/crates/log
+    pub fn connection_verbose(self, verbose: bool) -> ClientBuilder {
+        self.with_inner(move |inner| inner.connection_verbose(verbose))
+    }
+
     // HTTP options
 
     /// Sets the maximum idle connection per host allowed in the pool.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,7 @@ if_hyper! {
     pub mod redirect;
     #[cfg(feature = "__tls")]
     mod tls;
+    mod util;
 }
 
 if_wasm! {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,35 @@
+// xor-shift
+pub(crate) fn fast_random() -> u64 {
+    use std::cell::Cell;
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    use std::num::Wrapping;
+
+    thread_local! {
+        static RNG: Cell<Wrapping<u64>> = Cell::new(Wrapping(seed()));
+    }
+
+    fn seed() -> u64 {
+        let seed = RandomState::new();
+
+        let mut out = 0;
+        let mut cnt = 0;
+        while out == 0 {
+            cnt += 1;
+            let mut hasher = seed.build_hasher();
+            hasher.write_usize(cnt);
+            out = hasher.finish();
+        }
+        out
+    }
+
+    RNG.with(|rng| {
+        let mut n = rng.get();
+        debug_assert_ne!(n.0, 0);
+        n ^= n >> 12;
+        n ^= n << 25;
+        n ^= n >> 27;
+        rng.set(n);
+        n.0.wrapping_mul(0x2545_f491_4f6c_dd1d)
+    })
+}


### PR DESCRIPTION
This adds `ClientBuilder::connection_verbose(bool)`, which when enabled, will emit `TRACE` log messages about underlying connections' read and write operations.

This is requires both enabling `connection_verbose(true)` AND enabling a logger, so that it's not possible to accidentally log this information.