### PR TITLE
Document socks proxy in lib.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@
 //! i.e. `let proxy = reqwest::Proxy::http("https://secure.example")?;`
 //! or disabled by calling `ClientBuilder::no_proxy()`.
 //!
-//! `socks` feature is required if you have configured sock proxy like this:
+//! `socks` feature is required if you have configured socks proxy like this:
 //!
 //! ```bash
 //! export https_proxy=socks5://127.0.0.1:1086

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,12 @@
 //! i.e. `let proxy = reqwest::Proxy::http("https://secure.example")?;`
 //! or disabled by calling `ClientBuilder::no_proxy()`.
 //!
+//! `socks` feature is required if you have configured sock proxy like this:
+//!
+//! ```bash
+//! export https_proxy=socks5://127.0.0.1:1086
+//! ```
+//!
 //! ## TLS
 //!
 //! By default, a `Client` will make use of system-native transport layer


### PR DESCRIPTION
Fixes: #790 
socks feature is mentioned in [Proxy struct](https://docs.rs/reqwest/0.10.1/reqwest/struct.Proxy.html).  

But I think it can be mentioned in lib doc, which can be more clear.