### PR TITLE
actions: Remove --all flag from rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: -- --check
 
   build:
     name: ${{ matrix.name }}


### PR DESCRIPTION
The --all flag of rustfmt may trigger metadata resolution
which maybe slow down formatting in this case.