### PR TITLE
Implement `Response::json` for `wasm32` target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ __internal_proxy_sys_no_cache = []
 http = "0.2"
 url = "2.1"
 bytes = "0.5"
+serde = "1.0"
+## json
+serde_json = { version = "1.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 base64 = "0.11"
@@ -82,7 +85,6 @@ pin-project-lite = "0.1.1"
 
 # TODO: candidates for optional features
 
-serde = "1.0"
 serde_urlencoded = "0.6.1"
 
 # Optional deps...
@@ -105,8 +107,6 @@ cookie_store = { version = "0.10", optional = true }
 ## gzip
 async-compression = { version = "0.2.0", default-features = false, features = ["gzip", "stream"], optional = true }
 
-## json
-serde_json = { version = "1.0", optional = true }
 
 ## socks
 tokio-socks = { version = "0.2", optional = true }

--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -5,6 +5,9 @@ use js_sys::Uint8Array;
 use http::{HeaderMap, StatusCode};
 use url::Url;
 
+#[cfg(feature = "json")]
+use serde::de::DeserializeOwned;
+
 /// A Response to a submitted `Request`.
 pub struct Response {
     http: http::Response<web_sys::Response>,
@@ -56,8 +59,13 @@ impl Response {
     }
     */
 
-    // pub async fn json()
+    /// Try to deserialize the response body as JSON.
+    #[cfg(feature = "json")]
+    pub async fn json<T: DeserializeOwned>(self) -> crate::Result<T> {
+        let full = self.bytes().await?;
 
+        serde_json::from_slice(&full).map_err(crate::error::decode)
+    }
 
     /// Get the response text.
     pub async fn text(self) -> crate::Result<String> {


### PR DESCRIPTION
I am not sure if there is any specific reason why, but I noticed this was missing.