### PR TITLE
blocking: opt-out CPUs auto-detection in debug mode

### DIFF
--- a/src/blocking/wait.rs
+++ b/src/blocking/wait.rs
@@ -68,6 +68,7 @@ fn enter() {
     #[cfg(debug_assertions)]
     {
         tokio::runtime::Builder::new()
+            .core_threads(1)
             .build()
             .expect("build shell runtime")
             .enter(|| {});


### PR DESCRIPTION
This tweaks the tokio runtime checker (only used in debug mode) in
order to use a single thread.
Performing the CPUs auto-detection step on each check adds significant
syscall-tracing noise and runtime latency. This completely skips it.

Ref: https://github.com/tokio-rs/tokio/pull/2238