### PR TITLE
Implement Default for Client, ClientBuilder, and Form

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -63,6 +63,12 @@ pub struct ClientBuilder {
     timeout: Timeout,
 }
 
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ClientBuilder {
     /// Constructs a new `ClientBuilder`.
     ///
@@ -452,6 +458,12 @@ impl ClientBuilder {
     {
         self.inner = func(self.inner);
         self
+    }
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -58,6 +58,12 @@ pub struct Part {
     value: Body,
 }
 
+impl Default for Form {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Form {
     /// Creates a new Form without any content.
     pub fn new() -> Form {


### PR DESCRIPTION
I was kind of confused as to why I couldn't find these, but finally realized that #712 only added ones to the async implementation. This brings Default impls to the blocking implementation as well.