### PR TITLE
Expose url::ParseError as UrlParseError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,9 @@ pub use http::Method;
 pub use http::{StatusCode, Version};
 pub use url::Url;
 
+/// UrlParseError is the error type returned from various Url parsing functions.
+pub type UrlParseError = url::ParseError;
+
 // universal mods
 #[macro_use]
 mod error;


### PR DESCRIPTION
This allows various Url parsing functions to be used in combination with
custom errors that need to know the type of the error returned.

I have taken the liberty to rename `ParseError` to `UrlParseError` to make it less ambiguous.