### PR TITLE
Trust dns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           - "feat.: stream"
           - "feat.: socks/default-tls"
           - "feat.: socks/rustls-tls"
-          # - "feat.: trust-dns"
+          - "feat.: trust-dns"
 
         include:
           - name: linux / stable
@@ -123,8 +123,8 @@ jobs:
             features: "--features socks"
           - name: "feat.: socks/rustls-tls"
             features: "--features socks,rustls-tls"
-          # - name: "feat.: trust-dns"
-          #   features: "--features trust-dns"
+          - name: "feat.: trust-dns"
+            features: "--features trust-dns"
 
     steps:
       - name: Checkout

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -221,7 +221,7 @@ impl ClientBuilder {
                         proxies.clone(),
                         user_agent(&config.headers),
                         config.local_address,
-                        config.nodelay)?
+                        config.nodelay)
                 },
                 #[cfg(feature = "rustls-tls")]
                 TlsBackend::BuiltRustls(conn) => {
@@ -231,7 +231,7 @@ impl ClientBuilder {
                         proxies.clone(),
                         user_agent(&config.headers),
                         config.local_address,
-                        config.nodelay)?
+                        config.nodelay)
                 },
                 #[cfg(feature = "rustls-tls")]
                 TlsBackend::Rustls => {
@@ -266,7 +266,7 @@ impl ClientBuilder {
                         user_agent(&config.headers),
                         config.local_address,
                         config.nodelay,
-                    )?
+                    )
                 },
                 #[cfg(any(
                     feature = "native-tls",
@@ -280,7 +280,7 @@ impl ClientBuilder {
             }
 
             #[cfg(not(feature = "__tls"))]
-            Connector::new(http, proxies.clone(), config.local_address, config.nodelay)?
+            Connector::new(http, proxies.clone(), config.local_address, config.nodelay)
         };
 
         connector.set_timeout(config.connect_timeout);

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -481,6 +481,27 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))
     }
 
+    /// Enables the [trust-dns](trust_dns_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
+    ///
+    /// If the `trust-dns` feature is turned on, the default option is enabled.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `trust-dns` feature to be enabled
+    #[cfg(feature = "trust-dns")]
+    pub fn trust_dns(self, enable: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.trust_dns(enable))
+    }
+
+    /// Disables the trust-dns async resolver.
+    ///
+    /// This method exists even if the optional `trust-dns` feature is not enabled.
+    /// This can be used to ensure a `Client` doesn't use the trust-dns async resolver
+    /// even if another dependency were to enable the optional `trust-dns` feature.
+    pub fn no_trust_dns(self) -> ClientBuilder {
+        self.with_inner(|inner| inner.no_trust_dns())
+    }
+
     // private
 
     fn with_inner<F>(mut self, func: F) -> ClientBuilder

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -137,18 +137,18 @@ impl Connector {
         proxies: Arc<Vec<Proxy>>,
         local_addr: T,
         nodelay: bool,
-    ) -> crate::Result<Connector>
+    ) -> Connector
     where
         T: Into<Option<IpAddr>>,
     {
         http.set_local_address(local_addr.into());
         http.set_nodelay(nodelay);
-        Ok(Connector {
+        Connector {
             inner: Inner::Http(http),
             verbose: verbose::OFF,
             proxies,
             timeout: None,
-        })
+        }
     }
 
     #[cfg(feature = "default-tls")]
@@ -164,14 +164,14 @@ impl Connector {
         T: Into<Option<IpAddr>>,
     {
         let tls = tls.build().map_err(crate::error::builder)?;
-        Self::from_built_default_tls(
+        Ok(Self::from_built_default_tls(
             http,
             tls,
             proxies,
             user_agent,
             local_addr,
             nodelay,
-        )
+        ))
     }
 
     #[cfg(feature = "default-tls")]
@@ -181,21 +181,21 @@ impl Connector {
         proxies: Arc<Vec<Proxy>>,
         user_agent: Option<HeaderValue>,
         local_addr: T,
-        nodelay: bool) -> crate::Result<Connector>
+        nodelay: bool) -> Connector
         where
             T: Into<Option<IpAddr>>,
     {
         http.set_local_address(local_addr.into());
         http.enforce_http(false);
 
-        Ok(Connector {
+        Connector {
             inner: Inner::DefaultTls(http, tls),
             proxies,
             verbose: verbose::OFF,
             timeout: None,
             nodelay,
             user_agent,
-        })
+        }
     }
 
     #[cfg(feature = "rustls-tls")]
@@ -206,7 +206,7 @@ impl Connector {
         user_agent: Option<HeaderValue>,
         local_addr: T,
         nodelay: bool,
-    ) -> crate::Result<Connector>
+    ) -> Connector
     where
         T: Into<Option<IpAddr>>,
     {
@@ -222,7 +222,7 @@ impl Connector {
             (Arc::new(tls), Arc::new(tls_proxy))
         };
 
-        Ok(Connector {
+        Connector {
             inner: Inner::RustlsTls {
                 http,
                 tls,
@@ -233,7 +233,7 @@ impl Connector {
             timeout: None,
             nodelay,
             user_agent,
-        })
+        }
     }
 
     pub(crate) fn set_timeout(&mut self, timeout: Option<Duration>) {

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -18,7 +18,7 @@ use crate::error::BoxError;
 type SharedResolver = Arc<AsyncResolver<TokioConnection, TokioConnectionProvider>>;
 
 lazy_static! {
-    static ref SYSTEM_CONF: io::Result<(ResolverConfig, ResolverOpts)> = system_conf::read_system_conf();
+    static ref SYSTEM_CONF: io::Result<(ResolverConfig, ResolverOpts)> = system_conf::read_system_conf().map_err(io::Error::from);
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This does two things:
- Enable the `trust-dns` feature in CI and fixes the build.
- Adds the ability to disable `trust-dns` in the `ClientBuilder` even if the feature is enabled.