### PR TITLE
HTTP2 client request timeout to HTTP2 server

### DIFF
--- a/tests/http2.rs
+++ b/tests/http2.rs
@@ -1,0 +1,46 @@
+mod support;
+use support::*;
+
+#[cfg(feature = "rustls-tls")]
+#[tokio::test]
+async fn http2_client_server_rustls_tls() {
+    extern crate rustls;
+
+    let server = server::http2(move |_req| async { http::Response::new("Hello".into()) });
+
+    let tls = rustls::ClientConfig::new();
+
+    let client = reqwest::Client::builder()
+        .use_preconfigured_tls(tls)
+        .http2_prior_knowledge()
+        .build()
+        .expect("preconfigured rustls tls");
+
+    let res = client
+        .get(&format!("http://{}/text", server.addr()))
+        .send()
+        .await
+        .expect("Failed to get");
+    let text = res.text().await.expect("Failed to get text");
+    assert_eq!("Hello", text);
+}
+
+#[cfg(feature = "native-tls")]
+#[tokio::test]
+async fn http2_client_server_native_tls() {
+    let server = server::http2(move |_req| async { http::Response::new("Hello".into()) });
+
+    let client = reqwest::Client::builder()
+        .http2_prior_knowledge()
+        .danger_accept_invalid_hostnames(true)
+        .build()
+        .expect("preconfigured rustls tls");
+
+    let res = client
+        .get(&format!("http://{}/text", server.addr()))
+        .send()
+        .await
+        .expect("Failed to get");
+    let text = res.text().await.expect("Failed to get text");
+    assert_eq!("Hello", text);
+}

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -36,6 +36,7 @@ impl Drop for Server {
     }
 }
 
+#[allow(dead_code)]
 pub fn http<F, Fut>(func: F) -> Server
 where
     F: Fn(http::Request<hyper::Body>) -> Fut + Clone + Send + 'static,
@@ -60,6 +61,61 @@ where
                     }
                 },
             ))
+        });
+
+        let addr = srv.local_addr();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let srv = srv.with_graceful_shutdown(async move {
+            let _ = shutdown_rx.await;
+        });
+
+        let (panic_tx, panic_rx) = std_mpsc::channel();
+        let tname = format!(
+            "test({})-support-server",
+            thread::current().name().unwrap_or("<unknown>")
+        );
+        thread::Builder::new()
+            .name(tname)
+            .spawn(move || {
+                rt.block_on(srv).unwrap();
+                let _ = panic_tx.send(());
+            })
+            .expect("thread spawn");
+
+        Server {
+            addr,
+            panic_rx,
+            shutdown_tx: Some(shutdown_tx),
+        }
+    })
+    .join()
+    .unwrap()
+}
+
+pub fn http2<F, Fut>(func: F) -> Server
+where
+    F: Fn(http::Request<hyper::Body>) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = http::Response<hyper::Body>> + Send + 'static,
+{
+    //Spawn new runtime in thread to prevent reactor execution context conflict
+    thread::spawn(move || {
+        let mut rt = runtime::Builder::new()
+            .basic_scheduler()
+            .enable_all()
+            .build()
+            .expect("new rt");
+        let srv = rt.block_on(async move {
+            hyper::Server::bind(&([127, 0, 0, 1], 0).into())
+                .http2_only(true)
+                .serve(hyper::service::make_service_fn(move |_| {
+                    let func = func.clone();
+                    async move {
+                        Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
+                            let fut = func(req);
+                            async move { Ok::<_, Infallible>(fut.await) }
+                        }))
+                    }
+                }))
         });
 
         let addr = srv.local_addr();


### PR DESCRIPTION
I get a timeout error when sending GET request with HTTP2 prior knowledge to HTTP2 only server.
Testing the same HTTP2 request with hyper Serve (modified to accept only http2) https://github.com/hyperium/hyper/blob/master/tests/server.rs#L1825 it passes. Seems that Timeout happens somewhere at a lower level, maybe you have suggestions on how to debug the exact point?


error:

```rust
thread 'http2_client_server_native_tls' panicked at 'test server should not panic: Timeout', tests/support/server.rs:32:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test http2_client_server_native_tls ... FAILED
```