### PR TITLE
Disable test_blocking_inside_a_runtime without cfg(debug_assertions)

### DIFF
--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -274,6 +274,7 @@ fn test_appended_headers_not_overwritten() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
 }
 
+#[cfg_attr(not(debug_assertions), ignore)]
 #[test]
 #[should_panic]
 fn test_blocking_inside_a_runtime() {


### PR DESCRIPTION
As by default, when executing tests with -C opt-level=n where "n"
is greater than 0, debug assertions are disabled, which removes the
panic!() this test is expecting.

With this tweak, tests no longer fail with any choice of -C opt-level,
and additionally, tests still execute correctly if these tests are
compiled with:

  -C opt-level=3 -C debug-assertions=yes

Closes: https://github.com/seanmonstar/reqwest/issues/831