### PR TITLE
remove dependency on rustls-native-certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ native-tls-crate = { version = "0.2", optional = true, package = "native-tls" }
 tokio-tls = { version = "0.3.0", optional = true }
 
 # rustls-tls
-hyper-rustls = { version = "0.20", optional = true }
+hyper-rustls = { version = "0.20", default-features = false, features = ["webpki-tokio"], optional = true }
 rustls = { version = "0.17", features = ["dangerous_configuration"], optional = true }
 tokio-rustls = { version = "0.13", optional = true }
 webpki-roots = { version = "0.18", optional = true }


### PR DESCRIPTION
The latest version of `hyper-tls` introduced the dependency on `rustls-native-certs`. Apart from the fact it is not compiling on some targets, it looks like `reqwest` is using the `webpki` bundle so there is no need for `rustls-native-certs`.