### PR TITLE
Implement `Response::content_length` for `wasm32`

### DIFF
--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -45,6 +45,22 @@ impl Response {
         self.http.headers_mut()
     }
 
+    /// Get the content-length of this response, if known.
+    ///
+    /// Reasons it may not be known:
+    ///
+    /// - The server didn't send a `content-length` header.
+    /// - The response is compressed and automatically decoded (thus changing
+    //   the actual decoded length).
+    pub fn content_length(&self) -> Option<u64> {
+        self.headers()
+            .get(http::header::CONTENT_LENGTH)?
+            .to_str()
+            .ok()?
+            .parse()
+            .ok()
+    }
+
     /// Get the final `Url` of this `Response`.
     #[inline]
     pub fn url(&self) -> &Url {


### PR DESCRIPTION
I tried to implement `Response::content_length` for the Wasm target. Not sure if this is completely correct!

I'd like to also try to get `Response::chunk` working, but [it looks like we'll need to use a `ReadableStream`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Response.html#method.body) and [I don't see how it's meant to be used](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.ReadableStream.html).