### PR TITLE
Update list of OpenSSL versions supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 On Linux:
 
-- OpenSSL 1.0.1, 1.0.2, or 1.1.0 with headers (see https://github.com/sfackler/rust-openssl)
+- OpenSSL 1.0.1, 1.0.2, 1.1.0, or 1.1.1 with headers (see https://github.com/sfackler/rust-openssl)
 
 On Windows and macOS:
 


### PR DESCRIPTION
Update Requirements for Linux to include OpenSSL 1.1.1.

sfackler/rust-openssl supports OpenSSL 1.0.1 through 1.1.1, but its docs are out of date.

Closes #889