### PR TITLE
Add configuration for trust-dns-resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,12 @@ brotli = ["async-compression", "async-compression/brotli"]
 json = ["serde_json"]
 
 trust-dns = ["trust-dns-resolver"]
+trust-dns-over-tls = []
+trust-dns-over-openssl = ["trust-dns-resolver/dns-over-openssl","trust-dns-over-tls"]
+trust-dns-over-native-tls = ["trust-dns-resolver/dns-over-native-tls","trust-dns-over-tls"]
+trust-dns-over-rustls = ["trust-dns-resolver/dns-over-rustls","trust-dns-over-tls"]
+trust-dns-over-https = []
+trust-dns-over-https-rustls = ["trust-dns-resolver/dns-over-https-rustls","trust-dns-over-https"]
 
 stream = []
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{self, Poll};
 use std::io;
+use std::net::IpAddr;
 
 use hyper::client::connect::dns as hyper_dns;
 use hyper::service::Service;
@@ -26,13 +27,65 @@ pub(crate) struct TrustDnsResolver {
     state: Arc<Mutex<State>>,
 }
 
+#[derive(Debug)]
+pub(crate) struct TrustDnsConfig {
+    pub(crate) ips: Vec<IpAddr>,
+    pub(crate) port: u16,
+    pub(crate) transport: DnsTransport,
+    pub(crate) domain: Option<String>,
+    pub(crate) search_domains: Vec<String>,
+}
+
+/// Transport protocol for DNS
+#[derive(Debug)]
+pub(crate) enum DnsTransport {
+    /// This will create UDP and TCP connections, using the same port.
+    /// Queries and responses are sent unencrypted.
+    UdpAndTcp,
+    #[cfg(feature = "trust-dns-over-tls")]
+    /// DNS over TLS.
+    ///
+    /// This requires `trust-dns-over-openssl` or `trust-dns-over-native-tls`
+    /// or `trust-dns-over-rustls` feature.
+    Tls {
+        /// Simple public key infrastructure (SPKI) name.
+        tls_dns_name: String,
+    },
+    #[cfg(feature = "trust-dns-over-https")]
+    /// DNS over HTTPS.
+    ///
+    /// This requires `trust-dns-over-https-rustls` feature.
+    Https {
+        /// Simple public key infrastructure (SPKI) name.
+        tls_dns_name: String,
+    },
+}
+
+#[derive(Debug)]
+pub (crate) struct TrustDnsError {
+    pub(crate) error: BoxError
+}
+
 enum State {
-    Init,
+    Init(Option<ResolverConfig>),
     Ready(SharedResolver),
 }
 
+impl TrustDnsConfig {
+    pub(crate) fn new() -> Self {
+        TrustDnsConfig {
+            ips: vec![],
+            port: 53,
+            transport: DnsTransport::UdpAndTcp,
+            domain: None,
+            search_domains: vec![],
+        }
+    }
+}
+
+
 impl TrustDnsResolver {
-    pub(crate) fn new() -> io::Result<Self> {
+    pub(crate) fn new(config: Option<ResolverConfig>) -> io::Result<Self> {
         SYSTEM_CONF.as_ref().map_err(|e| {
             io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e))
         })?;
@@ -41,7 +94,7 @@ impl TrustDnsResolver {
         // Tokio Runtime, so we must delay the actual construction of the
         // resolver.
         Ok(TrustDnsResolver {
-            state: Arc::new(Mutex::new(State::Init)),
+            state: Arc::new(Mutex::new(State::Init(config))),
         })
     }
 }
@@ -61,8 +114,9 @@ impl Service<hyper_dns::Name> for TrustDnsResolver {
             let mut lock = resolver.state.lock().await;
 
             let resolver = match &*lock {
-                State::Init => {
-                    let resolver = new_resolver(tokio::runtime::Handle::current()).await?;
+                State::Init(config) => {
+                    let resolver =
+                        new_resolver(tokio::runtime::Handle::current(), config.clone()).await?;
                     *lock = State::Ready(resolver.clone());
                     resolver
                 },
@@ -81,11 +135,14 @@ impl Service<hyper_dns::Name> for TrustDnsResolver {
 
 /// Takes a `Handle` argument as an indicator that it must be called from
 /// within the context of a Tokio runtime.
-async fn new_resolver(handle: tokio::runtime::Handle) -> Result<SharedResolver, BoxError> {
-    let (config, opts) = SYSTEM_CONF
+async fn new_resolver(
+    handle: tokio::runtime::Handle,
+    config: Option<ResolverConfig>,
+) -> Result<SharedResolver, BoxError> {
+    let (config_system, opts) = SYSTEM_CONF
         .as_ref()
         .expect("can't construct TrustDnsResolver if SYSTEM_CONF is error")
         .clone();
-    let resolver = AsyncResolver::new(config, opts, handle).await?;
+    let resolver = AsyncResolver::new(config.unwrap_or(config_system), opts, handle).await?;
     Ok(Arc::new(resolver))
 }


### PR DESCRIPTION
Currently, `trust-dns-resolver` is initialized with the system DNS configuration (`/etc/resolv.conf` on Unix OSes or registry on Windows) and there's no API to change the resolver configuration (#881).

This adds `ClientBuilder::trust_dns_config()` method that sets `trust_dns_resolver::config::ResolverConfig` and `trust_dns_resolver::config::ResolverOpts`.