### PR TITLE
Question: problems with a default tls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [features]
-default = ["default-tls"]
+default = ["rustls-tls"]
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.


### PR DESCRIPTION
I asked 3 months ago on stackoverflow [How do I specify features for a sub-dependency in Cargo?](https://stackoverflow.com/questions/59994525/how-do-i-specify-features-for-a-sub-dependency-in-cargo), but I still don't have a solution.

I want to use rustls in my application. My app depends on a client API library which depends on reqwest. It also has a dependency on self_update, which has a dependency on reqwest. The only hack I was able to come up with is to add this to my app:

``` toml
"reqwest:0.10.4" = { branch = "rustls", git = "https://github.com/ctaggart/reqwest" }
```

And change it to `default = ["rustls-tls"]` in my fork. Is there an easier way to configure my app to use rustls?

This is a question, not intending to have this merged.