### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,16 +69,16 @@ jobs:
 
         include:
           - name: linux / stable
-            test-features: "--features __internal_proxy_sys_no_cache"
+            test-features: "--features '__internal_proxy_sys_no_cache,blocking,json'"
           - name: linux / beta
             rust: beta
-            test-features: "--features __internal_proxy_sys_no_cache"
+            test-features: "--features '__internal_proxy_sys_no_cache,blocking,json'"
           # - name: linux / nightly
           #   rust: nightly
-          #   test-features: "--features __internal_proxy_sys_no_cache"
+          #   test-features: "--features '__internal_proxy_sys_no_cache,blocking,json'"
           - name: macOS / stable
             os: macOS-latest
-            test-features: "--features __internal_proxy_sys_no_cache"
+            test-features: "--features '__internal_proxy_sys_no_cache,blocking,json'"
 
           - name: windows / stable-x86_64-msvc
             os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.39.0]
+        rust: [1.40.0]
 
     steps:
       - name: Checkout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,14 +271,14 @@ fn _assert_impls() {
 }
 
 if_hyper! {
-    #[cfg(test)]
+    #[cfg(doctest)]
     #[macro_use]
     extern crate doc_comment;
 
     #[macro_use]
     extern crate lazy_static;
 
-    #[cfg(test)]
+    #[cfg(doctest)]
     doctest!("../README.md");
 
     pub use self::async_impl::{


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.