### PR TITLE
Reject non-http, non-https URLs.

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -35,6 +35,7 @@ use super::Body;
 use crate::connect::{Connector, HttpConnector};
 #[cfg(feature = "cookies")]
 use crate::cookie;
+use crate::error;
 use crate::into_url::{expect_uri, try_uri};
 use crate::redirect::{self, remove_sensitive_headers};
 #[cfg(feature = "__tls")]
@@ -995,6 +996,9 @@ impl Client {
 
     pub(super) fn execute_request(&self, req: Request) -> Pending {
         let (method, url, mut headers, body, timeout) = req.pieces();
+        if url.scheme() != "http" && url.scheme() != "https" {
+            return Pending::new_err(error::url_bad_scheme(url));
+        }
 
         // insert default headers in the request headers
         // without overwriting already appended headers.
@@ -1494,5 +1498,21 @@ fn add_cookie_header(headers: &mut HeaderMap, cookie_store: &cookie::CookieStore
             crate::header::COOKIE,
             HeaderValue::from_bytes(header.as_bytes()).unwrap(),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn execute_request_rejects_invald_urls() {
+        let url = url::Url::parse("hxxps://www.rust-lang.org/").unwrap();
+        let result = crate::get(url.clone()).await;
+
+        let expected = crate::error::url_bad_scheme(url);
+
+        assert_eq!(result.is_err(), true);
+        let actual = result.unwrap_err();
+        assert_eq!(actual.inner.kind, expected.inner.kind);
+        assert_eq!(actual.inner.url, expected.inner.url);
     }
 }

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -222,7 +222,7 @@ impl ClientBuilder {
                 },
                 #[cfg(feature = "native-tls")]
                 TlsBackend::BuiltNativeTls(conn) => {
-                        Connector::from_built_default_tls(
+                    Connector::from_built_default_tls(
                         http,
                         conn,
                         proxies.clone(),
@@ -232,7 +232,7 @@ impl ClientBuilder {
                 },
                 #[cfg(feature = "rustls-tls")]
                 TlsBackend::BuiltRustls(conn) => {
-                        Connector::new_rustls_tls(
+                    Connector::new_rustls_tls(
                         http,
                         conn,
                         proxies.clone(),

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -219,25 +219,25 @@ impl ClientBuilder {
                         config.local_address,
                         config.nodelay,
                     )?
-                }
+                },
                 #[cfg(feature = "native-tls")]
                 TlsBackend::BuiltNativeTls(conn) => {
-                    Connector::from_built_default_tls(
-                    http,
-                    conn,
-                    proxies.clone(),
-                    user_agent(&config.headers),
-                    config.local_address,
+                        Connector::from_built_default_tls(
+                        http,
+                        conn,
+                        proxies.clone(),
+                        user_agent(&config.headers),
+                        config.local_address,
                         config.nodelay)
                 },
                 #[cfg(feature = "rustls-tls")]
                 TlsBackend::BuiltRustls(conn) => {
-                    Connector::new_rustls_tls(
-                    http,
-                    conn,
-                    proxies.clone(),
-                    user_agent(&config.headers),
-                    config.local_address,
+                        Connector::new_rustls_tls(
+                        http,
+                        conn,
+                        proxies.clone(),
+                        user_agent(&config.headers),
+                        config.local_address,
                         config.nodelay)
                 },
                 #[cfg(feature = "rustls-tls")]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1,4 +1,7 @@
-#[cfg(any(feature = "native-tls", feature = "rustls-tls",))]
+#[cfg(any(
+    feature = "native-tls",
+    feature = "rustls-tls",
+))]
 use std::any::Any;
 use std::convert::TryInto;
 use std::net::IpAddr;
@@ -207,6 +210,7 @@ impl ClientBuilder {
                         }
                     }
 
+
                     Connector::new_default_tls(
                         http,
                         tls,
@@ -217,23 +221,25 @@ impl ClientBuilder {
                     )?
                 }
                 #[cfg(feature = "native-tls")]
-                TlsBackend::BuiltNativeTls(conn) => Connector::from_built_default_tls(
+                TlsBackend::BuiltNativeTls(conn) => {
+                    Connector::from_built_default_tls(
                     http,
                     conn,
                     proxies.clone(),
                     user_agent(&config.headers),
                     config.local_address,
-                    config.nodelay,
-                ),
+                        config.nodelay)
+                },
                 #[cfg(feature = "rustls-tls")]
-                TlsBackend::BuiltRustls(conn) => Connector::new_rustls_tls(
+                TlsBackend::BuiltRustls(conn) => {
+                    Connector::new_rustls_tls(
                     http,
                     conn,
                     proxies.clone(),
                     user_agent(&config.headers),
                     config.local_address,
-                    config.nodelay,
-                ),
+                        config.nodelay)
+                },
                 #[cfg(feature = "rustls-tls")]
                 TlsBackend::Rustls => {
                     use crate::tls::NoVerifier;
@@ -268,13 +274,16 @@ impl ClientBuilder {
                         config.local_address,
                         config.nodelay,
                     )
-                }
-                #[cfg(any(feature = "native-tls", feature = "rustls-tls",))]
+                },
+                #[cfg(any(
+                    feature = "native-tls",
+                    feature = "rustls-tls",
+                ))]
                 TlsBackend::UnknownPreconfigured => {
                     return Err(crate::error::builder(
-                        "Unknown TLS backend passed to `use_preconfigured_tls`",
+                        "Unknown TLS backend passed to `use_preconfigured_tls`"
                     ));
-                }
+                },
             }
 
             #[cfg(not(feature = "__tls"))]
@@ -808,14 +817,15 @@ impl ClientBuilder {
     ///
     /// This requires one of the optional features `native-tls` or
     /// `rustls-tls` to be enabled.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls",))]
+    #[cfg(any(
+        feature = "native-tls",
+        feature = "rustls-tls",
+    ))]
     pub fn use_preconfigured_tls(mut self, tls: impl Any) -> ClientBuilder {
         let mut tls = Some(tls);
         #[cfg(feature = "native-tls")]
         {
-            if let Some(conn) =
-                (&mut tls as &mut dyn Any).downcast_mut::<Option<native_tls_crate::TlsConnector>>()
-            {
+            if let Some(conn) = (&mut tls as &mut dyn Any).downcast_mut::<Option<native_tls_crate::TlsConnector>>() {
                 let tls = conn.take().expect("is definitely Some");
                 let tls = crate::tls::TlsBackend::BuiltNativeTls(tls);
                 self.config.tls = tls;
@@ -824,9 +834,8 @@ impl ClientBuilder {
         }
         #[cfg(feature = "rustls-tls")]
         {
-            if let Some(conn) =
-                (&mut tls as &mut dyn Any).downcast_mut::<Option<rustls::ClientConfig>>()
-            {
+            if let Some(conn) = (&mut tls as &mut dyn Any).downcast_mut::<Option<rustls::ClientConfig>>() {
+
                 let tls = conn.take().expect("is definitely Some");
                 let tls = crate::tls::TlsBackend::BuiltRustls(tls);
                 self.config.tls = tls;

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,15 +10,15 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// The Errors that may occur when processing a `Request`.
 pub struct Error {
-    pub(crate) inner: Box<Inner>,
+    inner: Box<Inner>,
 }
 
 pub(crate) type BoxError = Box<dyn StdError + Send + Sync>;
 
-pub(crate) struct Inner {
-    pub(crate) kind: Kind,
+struct Inner {
+    kind: Kind,
     source: Option<BoxError>,
-    pub(crate) url: Option<Url>,
+    url: Option<Url>,
 }
 
 impl Error {
@@ -193,7 +193,7 @@ impl From<crate::error::Error> for js_sys::Error {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) enum Kind {
     Builder,
     Request,

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,15 +10,15 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// The Errors that may occur when processing a `Request`.
 pub struct Error {
-    inner: Box<Inner>,
+    pub(crate) inner: Box<Inner>,
 }
 
 pub(crate) type BoxError = Box<dyn StdError + Send + Sync>;
 
-struct Inner {
-    kind: Kind,
+pub(crate) struct Inner {
+    pub(crate) kind: Kind,
     source: Option<BoxError>,
-    url: Option<Url>,
+    pub(crate) url: Option<Url>,
 }
 
 impl Error {
@@ -193,7 +193,7 @@ impl From<crate::error::Error> for js_sys::Error {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Kind {
     Builder,
     Request,


### PR DESCRIPTION
Normally hyper is in charge of rejecting non-http URLs, but because
reqwest supports both http and https URLs, it calls enforce_http(false),
disabling hyper's checks.

This adds back a check in reqwest itself, plus a test.

There may still need to be an additional check in connect.rs.

Fixes #919 