### PR TITLE
add "Unpin" to impl Trait return of Response method "bytes_stream"

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -308,7 +308,7 @@ impl Response {
     ///
     /// This requires the optional `stream` feature to be enabled.
     #[cfg(feature = "stream")]
-    pub fn bytes_stream(self) -> impl futures_core::Stream<Item = crate::Result<Bytes>> {
+    pub fn bytes_stream(self) -> impl futures_core::Stream<Item = crate::Result<Bytes>> + Unpin {
         self.body
     }
 


### PR DESCRIPTION
Including the "Unpin" trait in this return would make it easier for users to wrap it into their own stream, instead of needing to Box::pin it.