### PR TITLE
Add `blocking::Response::headers_mut`

### DIFF
--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -122,6 +122,12 @@ impl Response {
         self.inner.headers()
     }
 
+    /// Get a mutable reference to the `Headers` of this `Response`.
+    #[inline]
+    pub fn headers_mut(&mut self) -> &mut HeaderMap {
+        self.inner.headers_mut()
+    }
+
     /// Retrieve the cookies contained in the response.
     ///
     /// Note that invalid 'Set-Cookie' headers will be ignored.


### PR DESCRIPTION
I noticed this method was missing. Not sure if its deliberate or not, but I would like to use it 😊

Let me know if there is changelog I need to update as well. CHANGELOG.md looked like it only contained released stuff.