### PR TITLE
Allow conversion from async client builder to blocking one

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -545,6 +545,15 @@ impl ClientBuilder {
     }
 }
 
+impl From<async_impl::ClientBuilder> for ClientBuilder {
+    fn from(builder: async_impl::ClientBuilder) -> Self {
+        Self {
+            inner: builder,
+            timeout: Timeout::default(),
+        }
+    }
+}
+
 impl Default for Client {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
The builders have mostly the same options and the blocking one is just a
wrapper around the async one. The possible conversion makes it easier to
support creating both kinds from configuration file, reducing some code
duplication.

My motivation is updating the spirit-reqwest configurator crate to 0.10 ‒ 0.9 had only one kind of client, now there are two and I'd like to be able to reuse the same code to create them.