### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -222,7 +222,7 @@ impl HttpBody for ImplStream {
                 if bytes.is_empty() {
                     None
                 } else {
-                    Some(Ok(std::mem::replace(bytes, Bytes::new()).into()))
+                    Some(Ok(std::mem::replace(bytes, Bytes::new())))
                 }
             }
         };

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1051,7 +1051,7 @@ impl Client {
 
         let timeout = timeout
             .or(self.inner.request_timeout)
-            .map(|dur| tokio::time::delay_for(dur));
+            .map(tokio::time::delay_for);
 
         *req.headers_mut() = headers.clone();
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1021,14 +1021,10 @@ impl Client {
 
         let accept_encoding = self.inner.accepts.as_str();
 
-        if accept_encoding.is_some()
-            && !headers.contains_key(ACCEPT_ENCODING)
-            && !headers.contains_key(RANGE)
-        {
-            headers.insert(
-                ACCEPT_ENCODING,
-                HeaderValue::from_static(accept_encoding.unwrap()),
-            );
+        if let Some(accept_encoding) = accept_encoding {
+            if !headers.contains_key(ACCEPT_ENCODING) && !headers.contains_key(RANGE) {
+                headers.insert(ACCEPT_ENCODING, HeaderValue::from_static(accept_encoding));
+            }
         }
 
         let uri = expect_uri(&url);

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1045,7 +1045,7 @@ impl Client {
 
         let mut req = hyper::Request::builder()
             .method(method.clone())
-            .uri(uri.clone())
+            .uri(uri)
             .body(body.into_stream())
             .expect("valid request parts");
 

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -225,7 +225,7 @@ impl Stream for Decoder {
                 }
                 Poll::Pending => return Poll::Pending,
             },
-            Inner::PlainText(ref mut body) => return Pin::new(body).poll_next(cx),
+            Inner::PlainText(ref mut body) => Pin::new(body).poll_next(cx),
             #[cfg(feature = "gzip")]
             Inner::Gzip(ref mut decoder) => {
                 return match futures_core::ready!(Pin::new(decoder).poll_next(cx)) {
@@ -242,7 +242,7 @@ impl Stream for Decoder {
                     None => Poll::Ready(None),
                 };
             }
-        };
+        }
     }
 }
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -4,12 +4,10 @@ use std::future::Future;
 use std::io::Write;
 use std::time::Duration;
 
-use base64;
 use base64::write::EncoderWriter as Base64Encoder;
 use serde::Serialize;
 #[cfg(feature = "json")]
 use serde_json;
-use serde_urlencoded;
 
 use super::body::Body;
 use super::client::{Client, Pending};

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -5,7 +5,6 @@ use std::net::SocketAddr;
 use bytes::Bytes;
 use encoding_rs::{Encoding, UTF_8};
 use futures_util::stream::StreamExt;
-use http;
 use hyper::client::connect::HttpInfo;
 use hyper::{HeaderMap, StatusCode, Version};
 use mime::Mime;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -706,10 +706,8 @@ fn get_from_environment() -> SystemProxyMap {
     let mut proxies = HashMap::new();
 
     if is_cgi() {
-        if log::log_enabled!(log::Level::Warn) {
-            if env::var_os("HTTP_PROXY").is_some() {
-                log::warn!("HTTP_PROXY environment variable ignored in CGI");
-            }
+        if log::log_enabled!(log::Level::Warn) && env::var_os("HTTP_PROXY").is_some() {
+            log::warn!("HTTP_PROXY environment variable ignored in CGI");
         }
     } else if !insert_from_env(&mut proxies, "http", "HTTP_PROXY") {
         insert_from_env(&mut proxies, "http", "http_proxy");


### PR DESCRIPTION
fix some clippy warnings. There is still a warning like the following that I find it difficult to solve.

```sh
warning: returning the result of a `let` binding from a block
   --> src/proxy.rs:693:5
    |
683 |     let proxies = get_from_environment();
    |     ------------------------------------- unnecessary `let` binding
...
693 |     proxies
    |     ^^^^^^^
    |
    = note: `#[warn(clippy::let_and_return)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return
help: return the expression directly
    |
683 |     
684 | 
685 |     // TODO: move the following #[cfg] to `if expression` when attributes on `if` expressions allowed
686 |     #[cfg(target_os = "windows")]
687 |     {
688 |         if proxies.is_empty() {
  ...

warning: 1 warning emitted
```