### PR TITLE
Make execute method on WASM client for compatibility with async_impl

### DIFF
--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -92,6 +92,25 @@ impl Client {
         RequestBuilder::new(self.clone(), req)
     }
 
+    /// Executes a `Request`.
+    ///
+    /// A `Request` can be built manually with `Request::new()` or obtained
+    /// from a RequestBuilder with `RequestBuilder::build()`.
+    ///
+    /// You should prefer to use the `RequestBuilder` and
+    /// `RequestBuilder::send()`.
+    ///
+    /// # Errors
+    ///
+    /// This method fails if there was an error while sending request,
+    /// redirect loop was detected or redirect limit was exhausted.
+    pub fn execute(
+        &self,
+        request: Request,
+    ) -> impl Future<Output = Result<Response, crate::Error>> {
+        self.execute_request(request)
+    }
+
     pub(super) fn execute_request(
         &self,
         req: Request,


### PR DESCRIPTION
The async_impl of reqwest has a `execute` impl on Client which is used to execute a request and return a Result Future. When building a async crate to wasm this method is missing, requiring forking and rewriting the crate.

I'm not aware of any reason why this method should be missing, but if there was a good reason for leaving the `execute` method please say so. The same if you require any changes!