### PR TITLE
Make `headers` method on WASM client for compatibility with async_impl

### DIFF
--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -228,7 +228,7 @@ impl RequestBuilder {
     /// ```
     pub fn headers(mut self, headers: crate::header::HeaderMap) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            async_impl::request::replace_headers(req.headers_mut(), headers);
+            crate::util::replace_headers(req.headers_mut(), headers);
         }
         self
     }
@@ -605,7 +605,7 @@ impl<T> TryFrom<HttpRequest<T>> for Request where T:Into<Body> {
         let url = Url::parse(&uri.to_string())
             .map_err(crate::error::builder)?;
         let mut inner = async_impl::Request::new(method, url);
-        async_impl::request::replace_headers(inner.headers_mut(), headers);
+        crate::util::replace_headers(inner.headers_mut(), headers);
         Ok(Request {
             body: Some(body.into()),
             inner,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,7 @@ if_hyper! {
 
 if_wasm! {
     mod wasm;
+    mod util;
 
     pub use self::wasm::{multipart, Body, Client, ClientBuilder, Request, RequestBuilder, Response};
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,7 @@
+use crate::header::HeaderMap;
+
 // xor-shift
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn fast_random() -> u64 {
     use std::cell::Cell;
     use std::collections::hash_map::RandomState;
@@ -32,4 +35,31 @@ pub(crate) fn fast_random() -> u64 {
         rng.set(n);
         n.0.wrapping_mul(0x2545_f491_4f6c_dd1d)
     })
+}
+
+pub(crate) fn replace_headers(dst: &mut HeaderMap, src: HeaderMap) {
+    // IntoIter of HeaderMap yields (Option<HeaderName>, HeaderValue).
+    // The first time a name is yielded, it will be Some(name), and if
+    // there are more values with the same name, the next yield will be
+    // None.
+    //
+    // TODO: a complex exercise would be to optimize this to only
+    // require 1 hash/lookup of the key, but doing something fancy
+    // with header::Entry...
+
+    let mut prev_name = None;
+    for (key, value) in src {
+        match key {
+            Some(key) => {
+                dst.insert(key.clone(), value);
+                prev_name = Some(key);
+            }
+            None => match prev_name {
+                Some(ref key) => {
+                    dst.append(key.clone(), value);
+                }
+                None => unreachable!("HeaderMap::into_iter yielded None first"),
+            },
+        }
+    }
 }

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -224,6 +224,16 @@ impl RequestBuilder {
         self
     }
 
+    /// Add a set of Headers to the existing ones on this Request.
+    ///
+    /// The headers will be merged in to any already set.
+    pub fn headers(mut self, headers: crate::header::HeaderMap) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            crate::util::replace_headers(req.headers_mut(), headers);
+        }
+        self
+    }
+
     /// Disable CORS on fetching the request.
     ///
     /// # WASM


### PR DESCRIPTION
For the same reasons as #989, to reduce the amount of incompatibility with the async_impl module. 

The `replace_headers` method had to be moved since the async_impl module is not compiled while compiling to wasm. This caused the `replace_headers` method to be unavailable. Since `replace_headers` was marked as `pub(crate)` this shouldn't effect the public API.

`fast_random` had to be excluded from the wasm build to prevent dead code warnings in the wasm target.