### PR TITLE
docsrs: build wasm32-unknown-unknown docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ autotests = true
 
 [package.metadata.docs.rs]
 all-features = true
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [package.metadata.playground]
 features = [


### PR DESCRIPTION
docs.rs says that [any target supported by rustup can be configured as a rustdoc target](https://docs.rs/about/metadata), so it would probably make sense to start building docs for the `wasm32-unknown-unknown` target, since not all methods are supported when compiling for the web.