### PR TITLE
Fix #899 Tor Socks example

### DIFF
--- a/examples/tor_socks.rs
+++ b/examples/tor_socks.rs
@@ -6,7 +6,7 @@
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
     // Make sure you are running tor and this is your socks port
-    let proxy = reqwest::Proxy::all("socks5://127.0.0.1:9050").expect("tor proxy should be there");
+    let proxy = reqwest::Proxy::all("socks5h://127.0.0.1:9050").expect("tor proxy should be there");
     let client = reqwest::Client::builder()
         .proxy(proxy)
         .build()


### PR DESCRIPTION
The example used DNS but used the non- proxy resolved DNS URL scheme

Fixes #899 