### PR TITLE
wasm: Omit request body if it's empty

### DIFF
--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -44,6 +44,13 @@ impl Body {
             inner: Inner::Multipart(f),
         }
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        match &self.inner {
+            Inner::Bytes(bytes) => bytes.is_empty(),
+            Inner::Multipart(form) => form.is_empty(),
+        }
+    }
 }
 
 impl From<Bytes> for Body {

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -158,7 +158,9 @@ async fn fetch(req: Request) -> crate::Result<Response> {
     }
 
     if let Some(body) = req.body() {
-        init.body(Some(&body.to_js_value()?.as_ref().as_ref()));
+        if !body.is_empty() {
+            init.body(Some(&body.to_js_value()?.as_ref().as_ref()));
+        }
     }
 
     let js_req = web_sys::Request::new_with_str_and_init(req.url().as_str(), &init)

--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -13,6 +13,12 @@ pub struct Form {
     inner: FormParts<Part>,
 }
 
+impl Form {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.fields.is_empty()
+    }
+}
+
 /// A field in a multipart form.
 pub struct Part {
     meta: PartMetadata,


### PR DESCRIPTION
This should allow creating GET and HEAD requests from http::Request.

Issue encountered by @MTRNord in [Daydream](https://github.com/daydream-mx/Daydream), fix not yet tested.
@MTRNord can you verify that this fixes your issue?