### PR TITLE
Add Into<io::Error> for reqwest::Error

### DIFF
--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -385,7 +385,7 @@ impl Response {
         if self.body.is_none() {
             let body = mem::replace(self.inner.body_mut(), async_impl::Decoder::empty());
 
-            let body = body.map_err(crate::error::into_io).into_async_read();
+            let body = body.map_err(|e| e.into()).into_async_read();
 
             self.body = Some(Box::pin(body));
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -135,7 +135,7 @@ impl Error {
 
     #[allow(unused)]
     pub(crate) fn into_io(self) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, self)
+        self.into()
     }
 }
 
@@ -194,6 +194,16 @@ impl fmt::Display for Error {
         }
 
         Ok(())
+    }
+}
+
+impl Into<io::Error> for Error {
+    fn into(self) -> io::Error {
+        if self.is_timeout() {
+            io::Error::new(io::ErrorKind::TimedOut, self)
+        } else {
+            io::Error::new(io::ErrorKind::Other, self)
+        }
     }
 }
 
@@ -261,13 +271,6 @@ if_wasm! {
     pub(crate) fn wasm(js_val: wasm_bindgen::JsValue) -> BoxError {
         format!("{:?}", js_val).into()
     }
-}
-
-// io::Error helpers
-
-#[allow(unused)]
-pub(crate) fn into_io(e: Error) -> io::Error {
-    e.into_io()
 }
 
 #[allow(unused)]


### PR DESCRIPTION
As discussed on discord. I had an initial go at making a more correct conversion. I didn't want to get too into the weeds of converting to the most correct version or changing the code. EDIT: For clarity this makes it easier to get a response body into an AsyncRead via https://docs.rs/tokio/0.2.22/tokio/io/fn.stream_reader.html 