### PR TITLE
Introduce `build` method on WASM RequestBuilder for compatibility with async_impl

### DIFF
--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -250,6 +250,12 @@ impl RequestBuilder {
         self
     }
 
+    /// Build a `Request`, which can be inspected, modified and executed with
+    /// `Client::execute()`.
+    pub fn build(self) -> crate::Result<Request> {
+        self.request
+    }
+
     /// Constructs the Request and sends it to the target URL, returning a
     /// future Response.
     ///


### PR DESCRIPTION
For the same reasons as #989 and #991. The wasm target was missing the `build` method that is present in the blocking and async_impl implementations. This PR adds that method to improve compatibility.