### PR TITLE
[WASM] Do not compile with non-applicable features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,7 @@ if_wasm! {
     }
     #[cfg(any(feature = "gzip", feature = "brotli"))]
     std::compile_error! {
-        "The gzip and brotli features not not available in the browser, as decoding is handled by default. Refer to the crate documentation WASM Features section."
+        "The gzip and brotli features are not available in the browser, as decoding is handled by default. Refer to the crate documentation WASM Features section."
     }
     #[cfg(any(
         feature = "default-tls",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,7 +331,7 @@ if_wasm! {
     #[cfg(any(
         feature = "default-tls",
         feature = "native-tls",
-        feature = "native-tls-ventored",
+        feature = "native-tls-vendored",
         feature = "rustls-tls"))]
     std::compile_error! {
         "TLS is not configurable in the browser. Refer to the crate documentation WASM Features section."


### PR DESCRIPTION
Add compile errors and some explanations for features which do not make sense for the browser.

This is inspired mainly by a question which was asked in the WASM channel on the rust discord about why there is no blocking client when targetting WASM, but there are also other features that dont make sense. Ones that I can think of immediately gzip, brotli and the TLS ones, but maybe others as well. However, since the default feature set includes TLS config, that means a simple `cargo build --target=wasm32-unkown-unknown` wouldnt build unless you explicitly `--no-default-features`