### PR TITLE
typo fix in doc comments

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -566,7 +566,7 @@ impl Client {
     ///
     /// # Panic
     ///
-    /// This method panics if TLS backend cannot initialized, or the resolver
+    /// This method panics if TLS backend cannot be initialized, or the resolver
     /// cannot load the system configuration.
     ///
     /// Use `Client::builder()` if you wish to handle the failure as an `Error`


### PR DESCRIPTION
Typo fix change:

This method panics if TLS backend cannot initialized
=> This method panics if TLS backend cannot **`be`** initialized


Just a minor typo fix.. Thank you for reviewing this PR :+1: 