### PR TITLE
Wrong expectation: a parsed Url should always be a valid Uri

### DIFF
--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -61,4 +61,13 @@ mod tests {
             "builder error for url (file:///etc/hosts): URL scheme is not allowed"
         );
     }
+
+    if_hyper! {
+        #[test]
+        fn test_expect_uri_with_corner_case() {
+            let bad_url_string = "https://rust-lang.org\""; // trailing quote
+            let bad_url = bad_url_string.into_url().expect("bad url is a valid url (but not a valid uri)");
+            expect_uri(&bad_url); // boom
+        }
+    }
 }


### PR DESCRIPTION
While trying to reproduce https://github.com/hyperium/hyper/issues/2280, I got a panic from `reqwest::get()`:

> a parsed Url should always be a valid Uri: InvalidUri(InvalidUriChar)

This happens if the url contains a double quote in the hostname (which of course is garbage but should not panic).

Here's a minimal test case to reproduce, I am not sure what a correct bug fix is. 

(Sorry for creating a "do not merge" PR, not sure what the best case to share this code would be otherwise)