### PR TITLE
Implement a custom dns provider for Client

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -22,6 +22,8 @@ use pin_project_lite::pin_project;
 
 #[cfg(feature = "trust-dns")]
 use crate::dns::TrustDnsResolver;
+#[cfg(feature = "trust-dns")]
+use crate::dns::DnsProvider;
 use crate::proxy::{Proxy, ProxyScheme};
 use crate::error::BoxError;
 #[cfg(feature = "default-tls")]
@@ -42,8 +44,8 @@ impl HttpConnector {
     }
 
     #[cfg(feature = "trust-dns")]
-    pub(crate) fn new_trust_dns() -> crate::Result<HttpConnector> {
-        TrustDnsResolver::new()
+    pub(crate) fn new_trust_dns(dns_provider: Option<DnsProvider>) -> crate::Result<HttpConnector> {
+        TrustDnsResolver::new(dns_provider)
             .map(hyper::client::HttpConnector::new_with_resolver)
             .map(Self::TrustDns)
             .map_err(crate::error::builder)

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,12 +1,14 @@
 use std::future::Future;
+use std::io;
+use std::net::IpAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{self, Poll};
-use std::io;
 
 use hyper::client::connect::dns as hyper_dns;
 use hyper::service::Service;
 use tokio::sync::Mutex;
+use trust_dns_resolver::config::NameServerConfigGroup;
 use trust_dns_resolver::{
     config::{ResolverConfig, ResolverOpts},
     lookup_ip::LookupIpIntoIter,
@@ -18,12 +20,14 @@ use crate::error::BoxError;
 type SharedResolver = Arc<AsyncResolver<TokioConnection, TokioConnectionProvider>>;
 
 lazy_static! {
-    static ref SYSTEM_CONF: io::Result<(ResolverConfig, ResolverOpts)> = system_conf::read_system_conf().map_err(io::Error::from);
+    static ref SYSTEM_CONF: io::Result<(ResolverConfig, ResolverOpts)> =
+        system_conf::read_system_conf().map_err(io::Error::from);
 }
 
 #[derive(Clone)]
 pub(crate) struct TrustDnsResolver {
     state: Arc<Mutex<State>>,
+    dns_provider: Option<DnsProvider>,
 }
 
 enum State {
@@ -31,8 +35,21 @@ enum State {
     Ready(SharedResolver),
 }
 
+/// Use to override your system's DNS provider
+#[derive(Clone, Debug)]
+pub enum DnsProvider {
+    /// Use google's DNS
+    Google,
+    /// Use cloudflare's DNS
+    Cloudflare,
+    /// Use quad9's DNS
+    Quad9,
+    /// Custom DNS IPs
+    Custom(Vec<IpAddr>),
+}
+
 impl TrustDnsResolver {
-    pub(crate) fn new() -> io::Result<Self> {
+    pub(crate) fn new(dns_provider: Option<DnsProvider>) -> io::Result<Self> {
         SYSTEM_CONF.as_ref().map_err(|e| {
             io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e))
         })?;
@@ -42,6 +59,7 @@ impl TrustDnsResolver {
         // resolver.
         Ok(TrustDnsResolver {
             state: Arc::new(Mutex::new(State::Init)),
+            dns_provider,
         })
     }
 }
@@ -57,15 +75,17 @@ impl Service<hyper_dns::Name> for TrustDnsResolver {
 
     fn call(&mut self, name: hyper_dns::Name) -> Self::Future {
         let resolver = self.clone();
+        let dns_provider = self.dns_provider.clone();
         Box::pin(async move {
             let mut lock = resolver.state.lock().await;
 
             let resolver = match &*lock {
                 State::Init => {
-                    let resolver = new_resolver(tokio::runtime::Handle::current()).await?;
+                    let resolver =
+                        new_resolver(tokio::runtime::Handle::current(), dns_provider).await?;
                     *lock = State::Ready(resolver.clone());
                     resolver
-                },
+                }
                 State::Ready(resolver) => resolver.clone(),
             };
 
@@ -81,11 +101,26 @@ impl Service<hyper_dns::Name> for TrustDnsResolver {
 
 /// Takes a `Handle` argument as an indicator that it must be called from
 /// within the context of a Tokio runtime.
-async fn new_resolver(handle: tokio::runtime::Handle) -> Result<SharedResolver, BoxError> {
-    let (config, opts) = SYSTEM_CONF
+async fn new_resolver(
+    handle: tokio::runtime::Handle,
+    dns_provider: Option<DnsProvider>,
+) -> Result<SharedResolver, BoxError> {
+    let (mut config, opts) = SYSTEM_CONF
         .as_ref()
         .expect("can't construct TrustDnsResolver if SYSTEM_CONF is error")
         .clone();
+    if let Some(dns_servers) = dns_provider {
+        config = match dns_servers {
+            DnsProvider::Cloudflare => ResolverConfig::cloudflare(),
+            DnsProvider::Google => ResolverConfig::google(),
+            DnsProvider::Quad9 => ResolverConfig::quad9(),
+            DnsProvider::Custom(addrs) => ResolverConfig::from_parts(
+                config.domain().cloned(),
+                config.search().to_vec(),
+                NameServerConfigGroup::from_ips_clear(&addrs, 54),
+            ),
+        }
+    }
     let resolver = AsyncResolver::new(config, opts, handle).await?;
     Ok(Arc::new(resolver))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,8 @@ if_hyper! {
     pub mod cookie;
     #[cfg(feature = "trust-dns")]
     mod dns;
+    #[cfg(feature = "trust-dns")]
+    pub use crate::dns::DnsProvider;
     mod proxy;
     pub mod redirect;
     #[cfg(feature = "__tls")]


### PR DESCRIPTION
Hey there, I just started this to solve a problem that I had because I wanted to use a custom DNS server for some calls and I think the way I did is a bit off.
Let me know if you think this is something useful and I can do the right changes to make it look better.
One thing that I didn't commit yet is a value for the enum `DnsProvider` which is `Custom(Vec<IpAddr>)`