### PR TITLE
Expose http1_writev config option to user

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -92,6 +92,7 @@ struct Config {
     #[cfg(feature = "__tls")]
     tls: TlsBackend,
     http2_only: bool,
+    http1_writev: Option<bool>,
     http1_title_case_headers: bool,
     http2_initial_stream_window_size: Option<u32>,
     http2_initial_connection_window_size: Option<u32>,
@@ -142,6 +143,7 @@ impl ClientBuilder {
                 #[cfg(feature = "__tls")]
                 tls: TlsBackend::default(),
                 http2_only: false,
+                http1_writev: None,
                 http1_title_case_headers: false,
                 http2_initial_stream_window_size: None,
                 http2_initial_connection_window_size: None,
@@ -297,6 +299,10 @@ impl ClientBuilder {
         let mut builder = hyper::Client::builder();
         if config.http2_only {
             builder.http2_only(true);
+        }
+
+        if let Some(http1_writev) = config.http1_writev {
+            builder.http1_writev(http1_writev);
         }
 
         if let Some(http2_initial_stream_window_size) = config.http2_initial_stream_window_size {
@@ -629,6 +635,14 @@ impl ClientBuilder {
     /// Enable case sensitive headers.
     pub fn http1_title_case_headers(mut self) -> ClientBuilder {
         self.config.http1_title_case_headers = true;
+        self
+    }
+
+    /// Force hyper to use either queued(if true), or flattened(if false) write strategy
+    /// This may eliminate unnecessary cloning of buffers for some TLS backends
+    /// By default hyper will try to guess which strategy to use
+    pub fn http1_writev(mut self, writev: bool) -> ClientBuilder {
+        self.config.http1_writev = Some(writev);
         self
     }
 


### PR DESCRIPTION
After https://github.com/hyperium/hyper/pull/2285 is merged it will be nice to expose http1_writev option, because without it I experience a lot of large buffer cloning using default tls. Setting http1_writev to true fixes that for default tls, but not for rustls, unfortunately.