### PR TITLE
Support saving/loading the cooke store as JSON

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -59,7 +59,7 @@ use crate::{IntoUrl, Method, Proxy, StatusCode, Url};
 /// [`Rc`]: std::rc::Rc
 #[derive(Clone)]
 pub struct Client {
-    inner: Arc<ClientRef>,
+    pub(crate) inner: Arc<ClientRef>,
 }
 
 /// A `ClientBuilder` can be used to create a `Client` with  custom configuration.
@@ -1113,6 +1113,33 @@ impl Client {
     }
 }
 
+#[cfg(feature = "cookies")]
+impl Client {
+    /// Save the internal cookies as JSON
+    ///
+    /// Using `persistent` will only save cookies marked as persistent,
+    /// this should probably be `true` to respect the cookie.
+    ///
+    /// Using `expired` will save expired cookies,
+    /// this should probably be `false` to respect the cookie.
+    ///
+    /// # Errors
+    /// This method fails when the underlying writer encouters an error.
+    #[cfg(feature = "json")]
+    pub fn save_cookies_json<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        persistent: bool,
+        expired: bool,
+    ) -> Option<Result<(), std::io::Error>> {
+        self.inner.cookie_store.as_ref().map(|cs| {
+            cs.read()
+                .unwrap_or_else(|e| e.into_inner())
+                .save_json(writer, persistent, expired)
+        })
+    }
+}
+
 impl fmt::Debug for Client {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = f.debug_struct("Client");
@@ -1202,10 +1229,10 @@ impl Config {
     }
 }
 
-struct ClientRef {
+pub(crate) struct ClientRef {
     accepts: Accepts,
     #[cfg(feature = "cookies")]
-    cookie_store: Option<RwLock<cookie::CookieStore>>,
+    pub(crate) cookie_store: Option<RwLock<cookie::CookieStore>>,
     headers: HeaderMap,
     hyper: HyperClient,
     redirect_policy: redirect::Policy,

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -676,6 +676,33 @@ impl fmt::Debug for Client {
     }
 }
 
+#[cfg(feature = "cookies")]
+impl Client {
+    /// Save the internal cookies as JSON
+    ///
+    /// Using `persistent` will only save cookies marked as persistent,
+    /// this should probably be `true` to respect the cookie.
+    ///
+    /// Using `expired` will save expired cookies,
+    /// this should probably be `false` to respect the cookie.
+    ///
+    /// # Errors
+    /// This method fails when the underlying writer encouters an error.
+    #[cfg(feature = "json")]
+    pub fn save_cookies_json<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        persistent: bool,
+        expired: bool,
+    ) -> Option<Result<(), std::io::Error>> {
+        self.inner.cookie_store.as_ref().map(|cs| {
+            cs.read()
+                .unwrap_or_else(|e| e.into_inner())
+                .save_json(writer, persistent, expired)
+        })
+    }
+}
+
 impl fmt::Debug for ClientBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.inner.fmt(f)
@@ -694,6 +721,8 @@ type ThreadSender = mpsc::UnboundedSender<(async_impl::Request, OneshotResponse)
 struct InnerClientHandle {
     tx: Option<ThreadSender>,
     thread: Option<thread::JoinHandle<()>>,
+    #[cfg(feature = "cookies")] // this field is required only to get access to the cookies for now
+    inner: Arc<async_impl::client::ClientRef>,
 }
 
 impl Drop for InnerClientHandle {
@@ -717,6 +746,11 @@ impl ClientHandle {
         let builder = builder.inner;
         let (tx, rx) = mpsc::unbounded_channel::<(async_impl::Request, OneshotResponse)>();
         let (spawn_tx, spawn_rx) = oneshot::channel::<crate::Result<()>>();
+
+        let client = builder.build()?;
+        #[cfg(feature = "cookies")]
+        let inner = Arc::clone(&client.inner);
+
         let handle = thread::Builder::new()
             .name("reqwest-internal-sync-runtime".into())
             .spawn(move || {
@@ -732,15 +766,6 @@ impl ClientHandle {
                 };
 
                 let f = async move {
-                    let client = match builder.build() {
-                        Err(e) => {
-                            if let Err(e) = spawn_tx.send(Err(e)) {
-                                error!("Failed to communicate client creation failure: {:?}", e);
-                            }
-                            return;
-                        }
-                        Ok(v) => v,
-                    };
                     if let Err(e) = spawn_tx.send(Ok(())) {
                         error!("Failed to communicate successful startup: {:?}", e);
                         return;
@@ -774,6 +799,8 @@ impl ClientHandle {
         let inner_handle = Arc::new(InnerClientHandle {
             tx: Some(tx),
             thread: Some(handle),
+            #[cfg(feature = "cookies")]
+            inner,
         });
 
         Ok(ClientHandle {

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -185,6 +185,22 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.cookie_store(enable))
     }
 
+    /// Load cookies from JSON
+    ///
+    /// Cookies received in responses will be preserved and included in
+    /// additional requests. The cookie store will be initialized from
+    /// the provided JSON object.
+    ///
+    /// By default, no cookie store is used.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional features `cookies` and `json` to be enabled.
+    #[cfg(all(feature = "cookies", feature = "json"))]
+    pub fn load_cookies_json<R: std::io::BufRead>(mut self, reader: R) -> ClientBuilder {
+        self.with_inner(|inner| inner.load_cookies_json(reader))
+    }
+
     /// Enable auto gzip decompression by checking the `Content-Encoding` response header.
     ///
     /// If auto gzip decompresson is turned on:


### PR DESCRIPTION
_This is inspired by some of the code & discussion from https://github.com/seanmonstar/reqwest/pull/1009_

**I'm looking for feedback, I don't think this is ready as-is.**

# API Changes
- Add a `save_cookies_json` to the `Client`
- Add a `load_cookies_json` to the `ClientBuilder`

This sort-of exposes the json format as part of the API. Changes to `cookie_store` could result in old JSON files being unreadable. Given that this would just be an error, and not an API breakage, I'm not sure if that's a concern.

# Questions
#### 1) Do we make `reqwest::cookie::CookieStore` pub?
  - This would make building simpler, because the caller would be responsible for instantiation & error handling.
  - Unfortunately the underlying `cookie_store::CookieStore` does **not** support `.clone()`. Do we care that `load_cookies_json` would be done on a `CookieStore`, but `save_cookies_json` would be done directly on a `Client`?
#### 2) Error handling?
  - The `cookie_store` crate raises either `Box<dyn Error>` or its own `CookieError` enum. This PR managed to dodge the issue by having `save_cookies_json` create an `io::Error`, and `load_cookies_json` used the `Kind::Builder` enum.
  - Are we okay with this strategy? Should we add `Kind::Cookie`? Other ideas?
#### 3) Arguments for `save_cookies_json`
 -  Right now there are two bool flags for `persistent` and `expired`. I think the "right" thing is to only save persistent non-expired cookies, but there are reasons to want more options:
    - for debugging purposes, you might want _all_ cookies
    - for my personal usecase, I need to save the non-persistent cookies to be used later, so I would guess there are many similar APIs where cookies are not tagged properly
