### PR TITLE
Fix typo in documentation

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -572,8 +572,8 @@ impl ClientBuilder {
 
     /// Enables a request timeout.
     ///
-    /// The timeout is applied from the when the request starts connecting
-    /// until the response body has finished.
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished.
     ///
     /// Default is no timeout.
     pub fn timeout(mut self, timeout: Duration) -> ClientBuilder {

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -229,9 +229,9 @@ impl RequestBuilder {
 
     /// Enables a request timeout.
     ///
-    /// The timeout is applied from the when the request starts connecting
-    /// until the response body has finished. It affects only this request
-    /// and overrides the timeout configured using `ClientBuilder::timeout()`.
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished. It affects only this request and overrides
+    /// the timeout configured using `ClientBuilder::timeout()`.
     pub fn timeout(mut self, timeout: Duration) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             *req.timeout_mut() = Some(timeout);

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -329,9 +329,9 @@ impl RequestBuilder {
 
     /// Enables a request timeout.
     ///
-    /// The timeout is applied from the when the request starts connecting
-    /// until the response body has finished. It affects only this request
-    /// and overrides the timeout configured using `ClientBuilder::timeout()`.
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished. It affects only this request and overrides
+    /// the timeout configured using `ClientBuilder::timeout()`.
     pub fn timeout(mut self, timeout: Duration) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             *req.timeout_mut() = Some(timeout);


### PR DESCRIPTION
This fixes a typo with multiple occurrences in the documentation and rewraps the documentation comments at 80 characters.