### PR TITLE
Add cargo features to control root certs of the rustls backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           - windows / stable-i686-gnu
           - "feat.: default-tls disabled"
           - "feat.: rustls-tls"
+          - "feat.: rustls-tls-manual-roots"
           - "feat.: native-tls"
           - "feat.: default-tls and rustls-tls"
           - "feat.: cookies"
@@ -103,6 +104,8 @@ jobs:
             features: "--no-default-features"
           - name: "feat.: rustls-tls"
             features: "--no-default-features --features rustls-tls"
+          - name: "feat.: rustls-tls-manual-roots"
+            features: "--no-default-features --features rustls-tls-manual-roots"
           - name: "feat.: native-tls"
             features: "--features native-tls"
           - name: "feat.: default-tls and rustls-tls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ default-tls = ["hyper-tls", "native-tls-crate", "__tls", "tokio-tls"]
 native-tls = ["default-tls"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 
-rustls-tls = ["hyper-rustls", "tokio-rustls", "webpki-roots", "rustls", "__tls"]
+rustls-tls = ["rustls-tls-webpki-roots"]
+rustls-tls-manual-roots = ["__rustls"]
+rustls-tls-webpki-roots = ["webpki-roots", "__rustls"]
 
 blocking = ["futures-util/io", "tokio/rt-threaded", "tokio/rt-core", "tokio/sync"]
 
@@ -57,6 +59,10 @@ socks = ["tokio-socks"]
 
 # Enables common types used for TLS. Useless on its own.
 __tls = []
+
+# Enables common rustls code.
+# Equivalent to rustls-tls-manual-roots but shorter :)
+__rustls = ["hyper-rustls", "tokio-rustls", "rustls", "__tls"]
 
 # When enabled, disable using the cached SYS_PROXIES.
 __internal_proxy_sys_no_cache = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 rustls-tls = ["rustls-tls-webpki-roots"]
 rustls-tls-manual-roots = ["__rustls"]
 rustls-tls-webpki-roots = ["webpki-roots", "__rustls"]
+rustls-tls-native-roots = ["rustls-native-certs", "__rustls"]
 
 blocking = ["futures-util/io", "tokio/rt-threaded", "tokio/rt-core", "tokio/sync"]
 
@@ -104,6 +105,7 @@ hyper-rustls = { version = "0.21", default-features = false, optional = true }
 rustls = { version = "0.18", features = ["dangerous_configuration"], optional = true }
 tokio-rustls = { version = "0.14", optional = true }
 webpki-roots = { version = "0.20", optional = true }
+rustls-native-certs = { version = "0.4", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.14", package = "cookie", optional = true }

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1,6 +1,6 @@
 #[cfg(any(
     feature = "native-tls",
-    feature = "rustls-tls",
+    feature = "__rustls",
 ))]
 use std::any::Any;
 use std::convert::TryInto;
@@ -236,7 +236,7 @@ impl ClientBuilder {
                         config.local_address,
                         config.nodelay)
                 },
-                #[cfg(feature = "rustls-tls")]
+                #[cfg(feature = "__rustls")]
                 TlsBackend::BuiltRustls(conn) => {
                     Connector::new_rustls_tls(
                         http,
@@ -246,7 +246,7 @@ impl ClientBuilder {
                         config.local_address,
                         config.nodelay)
                 },
-                #[cfg(feature = "rustls-tls")]
+                #[cfg(feature = "__rustls")]
                 TlsBackend::Rustls => {
                     use crate::tls::NoVerifier;
 
@@ -256,6 +256,7 @@ impl ClientBuilder {
                     } else {
                         tls.set_protocols(&["h2".into(), "http/1.1".into()]);
                     }
+                    #[cfg(feature = "rustls-tls-webpki-roots")]
                     tls.root_store
                         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 
@@ -283,7 +284,7 @@ impl ClientBuilder {
                 },
                 #[cfg(any(
                     feature = "native-tls",
-                    feature = "rustls-tls",
+                    feature = "__rustls",
                 ))]
                 TlsBackend::UnknownPreconfigured => {
                     return Err(crate::error::builder(
@@ -738,7 +739,7 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls`
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn add_root_certificate(mut self, cert: Certificate) -> ClientBuilder {
@@ -750,7 +751,7 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `native-tls` or `rustls-tls` feature to be
+    /// This requires the optional `native-tls` or `rustls-tls(-...)` feature to be
     /// enabled.
     #[cfg(feature = "__tls")]
     pub fn identity(mut self, identity: Identity) -> ClientBuilder {
@@ -795,7 +796,7 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls`
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn danger_accept_invalid_certs(mut self, accept_invalid_certs: bool) -> ClientBuilder {
@@ -824,8 +825,8 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `rustls-tls` feature to be enabled.
-    #[cfg(feature = "rustls-tls")]
+    /// This requires the optional `rustls-tls(-...)` feature to be enabled.
+    #[cfg(feature = "__rustls")]
     pub fn use_rustls_tls(mut self) -> ClientBuilder {
         self.config.tls = TlsBackend::Rustls;
         self
@@ -848,10 +849,10 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// This requires one of the optional features `native-tls` or
-    /// `rustls-tls` to be enabled.
+    /// `rustls-tls(-...)` to be enabled.
     #[cfg(any(
         feature = "native-tls",
-        feature = "rustls-tls",
+        feature = "__rustls",
     ))]
     pub fn use_preconfigured_tls(mut self, tls: impl Any) -> ClientBuilder {
         let mut tls = Some(tls);
@@ -864,7 +865,7 @@ impl ClientBuilder {
                 return self;
             }
         }
-        #[cfg(feature = "rustls-tls")]
+        #[cfg(feature = "__rustls")]
         {
             if let Some(conn) = (&mut tls as &mut dyn Any).downcast_mut::<Option<rustls::ClientConfig>>() {
 
@@ -1212,7 +1213,7 @@ impl Config {
             }
         }
 
-        #[cfg(all(feature = "native-tls-crate", feature = "rustls-tls"))]
+        #[cfg(all(feature = "native-tls-crate", feature = "__rustls"))]
         {
             f.field("tls_backend", &self.tls);
         }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1,6 +1,6 @@
 #[cfg(any(
     feature = "native-tls",
-    feature = "rustls-tls",
+    feature = "__rustls",
 ))]
 use std::any::Any;
 use std::convert::TryInto;
@@ -414,7 +414,7 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls`
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn add_root_certificate(self, cert: Certificate) -> ClientBuilder {
@@ -482,8 +482,8 @@ impl ClientBuilder {
     ///
     /// # Optional
     ///
-    /// This requires the optional `rustls-tls` feature to be enabled.
-    #[cfg(feature = "rustls-tls")]
+    /// This requires the optional `rustls-tls(-...)` feature to be enabled.
+    #[cfg(feature = "__rustls")]
     pub fn use_rustls_tls(self) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_rustls_tls())
     }
@@ -505,10 +505,10 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// This requires one of the optional features `native-tls` or
-    /// `rustls-tls` to be enabled.
+    /// `rustls-tls(-...)` to be enabled.
     #[cfg(any(
         feature = "native-tls",
-        feature = "rustls-tls",
+        feature = "__rustls",
     ))]
     pub fn use_preconfigured_tls(self, tls: impl Any) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -26,7 +26,7 @@ use crate::proxy::{Proxy, ProxyScheme};
 use crate::error::BoxError;
 #[cfg(feature = "default-tls")]
 use self::native_tls_conn::NativeTlsConn;
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "__rustls")]
 use self::rustls_tls_conn::RustlsTlsConn;
 
 #[derive(Clone)]
@@ -123,7 +123,7 @@ enum Inner {
     Http(HttpConnector),
     #[cfg(feature = "default-tls")]
     DefaultTls(HttpConnector, TlsConnector),
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "__rustls")]
     RustlsTls {
         http: HttpConnector,
         tls: Arc<rustls::ClientConfig>,
@@ -199,7 +199,7 @@ impl Connector {
         }
     }
 
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "__rustls")]
     pub(crate) fn new_rustls_tls<T>(
         mut http: HttpConnector,
         tls: rustls::ClientConfig,
@@ -282,7 +282,7 @@ impl Connector {
                     });
                 }
             }
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "__rustls")]
             Inner::RustlsTls { tls_proxy, .. } => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     use tokio_rustls::webpki::DNSNameRef;
@@ -357,7 +357,7 @@ impl Connector {
                     is_proxy,
                 })
             }
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, tls, .. } => {
                 let mut http = http.clone();
 
@@ -434,7 +434,7 @@ impl Connector {
                     });
                 }
             }
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "__rustls")]
             Inner::RustlsTls {
                 http,
                 tls,
@@ -480,7 +480,7 @@ impl Connector {
         match &mut self.inner {
             #[cfg(feature = "default-tls")]
             Inner::DefaultTls(http, _tls) => http.set_keepalive(dur),
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive(dur),
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => http.set_keepalive(dur),
@@ -801,7 +801,7 @@ mod native_tls_conn {
     }
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "__rustls")]
 mod rustls_tls_conn {
     use rustls::Session;
     use std::mem::MaybeUninit;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,11 @@
 //! - **native-tls**: Enables TLS functionality provided by `native-tls`.
 //! - **native-tls-vendored**: Enables the `vendored` feature of `native-tls`.
 //! - **rustls-tls**: Enables TLS functionality provided by `rustls`.
+//!   Equivalent to `rustls-tls-webpki-roots`.
+//! - **rustls-tls-manual-roots**: Enables TLS functionality provided by `rustls`,
+//!   without setting any root certificates. Roots have to be specified manually.
+//! - **rustls-tls-webpki-roots**: Enables TLS functionality provided by `rustls`,
+//!   while using root certificates from the `webpki-roots` crate
 //! - **blocking**: Provides the [blocking][] client API.
 //! - **cookies**: Provides cookie session support.
 //! - **gzip**: Provides response body gzip decompression.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,9 @@
 //! - **rustls-tls-manual-roots**: Enables TLS functionality provided by `rustls`,
 //!   without setting any root certificates. Roots have to be specified manually.
 //! - **rustls-tls-webpki-roots**: Enables TLS functionality provided by `rustls`,
-//!   while using root certificates from the `webpki-roots` crate
+//!   while using root certificates from the `webpki-roots` crate.
+//! - **rustls-tls-native-roots**: Enables TLS functionality provided by `rustls`,
+//!   while using root certificates from the `rustls-native-certs` crate.
 //! - **blocking**: Provides the [blocking][] client API.
 //! - **cookies**: Provides cookie session support.
 //! - **gzip**: Provides response body gzip decompression.

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -18,7 +18,10 @@ async fn test_badssl_modern() {
     assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
 }
 
-#[cfg(feature = "rustls-tls-webpki-roots")]
+#[cfg(any(
+    feature = "rustls-tls-webpki-roots",
+    feature = "rustls-tls-native-roots"
+))]
 #[tokio::test]
 async fn test_rustls_badssl_modern() {
     let text = reqwest::Client::builder()

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-#[cfg(feature = "__tls")]
+#[cfg(all(feature = "__tls", not(feature = "rustls-tls-manual-roots")))]
 #[tokio::test]
 async fn test_badssl_modern() {
     let text = reqwest::Client::builder()
@@ -18,7 +18,7 @@ async fn test_badssl_modern() {
     assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "rustls-tls-webpki-roots")]
 #[tokio::test]
 async fn test_rustls_badssl_modern() {
     let text = reqwest::Client::builder()

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -161,7 +161,7 @@ async fn body_pipe_response() {
     assert_eq!(res2.status(), reqwest::StatusCode::OK);
 }
 
-#[cfg(any(feature = "native-tls", feature = "rustls-tls",))]
+#[cfg(any(feature = "native-tls", feature = "__rustls",))]
 #[test]
 fn use_preconfigured_tls_with_bogus_backend() {
     struct DefinitelyNotTls;
@@ -187,7 +187,7 @@ fn use_preconfigured_native_tls_default() {
         .expect("preconfigured default tls");
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "__rustls")]
 #[test]
 fn use_preconfigured_rustls_default() {
     extern crate rustls;


### PR DESCRIPTION
This PR adds three new public cargo features:

* `rustls-tls-webpki-roots`: equivalent to `rustls-tls` and using the `webpki-roots` crate to obtain the root certificates.
* `rustls-tls-native-roots`: using the `rustls-native-certs` crate to obtain root certificates.
* `rustls-tls-manual-roots`: enabling only raw rustls support without setting any root certificates. Users have to set them manually, or unify with a crate that enables one of the builtin root certificate features.

Furthermore a private cargo feature `__rustls` is added that is equivalent with `rustls-tls-manual-roots` but shorter to type :).

Cargo's model allows a combination of features to be enabled, at which point a combination of the root stores is used.

I'm filing this PR because ability to load OS native roots is a blocker for rustup's adoption of rustls (see https://github.com/rust-lang/rustup/pull/2517#issuecomment-709899351). Currently, the public API of reqwest is incompatible with using `rustls-native-certs` from the outside, and even if it were possible to use it, something like `rustls-tls-manual-roots` would be needed to turn off `webpki-roots` loading.