### PR TITLE
Support Cloudflare workers runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,9 +129,9 @@ winreg = "0.7"
 # wasm
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.28"
-wasm-bindgen = { version = "0.2.51", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.1"
+js-sys = "0.3.45"
+wasm-bindgen = { version = "0.2.68", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.18"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"
@@ -145,6 +145,7 @@ features = [
     "FormData",
     "Blob",
     "BlobPropertyBag",
+    "ServiceWorkerGlobalScope",
 ]
 
 [[example]]


### PR DESCRIPTION
The attached change enables the reqwest library to work in the cloudflare workers wasm runtime. The fetch api is the same, but you have to retrieve the fetch function from a different globals dict. The environment is detected automatically (using duck typing) so no compile-time switches or features are needed. I tested the code in both browser and on cf workers.

Why:
I had been using cf workers for a few months, and knew from testing that reqwest didn't work, but I assumed that was because cf doesn't allow outgoing tcp connections and it didn't occur to me that reqwest would have a wasm/fetch back-end. I had written an http client library that wrapped reqwest and js-fetch, and effectively had to duplicate lots of boilerplate code from reqwest. I was happy to discover the wasm/fetch support and realized that a small change to reqwest would allow me to throw away that whole http wrapper library and use reqwest as the primary http client interface!

I tried to make the changes as minimal as possible so you can clearly see the difference. I did upgrade the wasm support libraries to early-September versions. Please let me know if there's anything else I can do to make this easy for you to merge!