### PR TITLE
Document how a RequestBuilder gets constructed

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -26,7 +26,9 @@ pub struct Request {
     timeout: Option<Duration>,
 }
 
-/// A builder to construct the properties of a `Request`. To construct a `RequestBuilder`, refer to the `Client` documentation.
+/// A builder to construct the properties of a `Request`.
+///
+/// To construct a `RequestBuilder`, refer to the `Client` documentation.
 #[must_use = "RequestBuilder does nothing until you 'send' it"]
 pub struct RequestBuilder {
     client: Client,

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -26,7 +26,7 @@ pub struct Request {
     timeout: Option<Duration>,
 }
 
-/// A builder to construct the properties of a `Request`.
+/// A builder to construct the properties of a `Request`. To construct a `RequestBuilder`, refer to the `Client` documentation.
 #[must_use = "RequestBuilder does nothing until you 'send' it"]
 pub struct RequestBuilder {
     client: Client,

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -21,7 +21,7 @@ pub struct Request {
     inner: async_impl::Request,
 }
 
-/// A builder to construct the properties of a `Request`.
+/// A builder to construct the properties of a `Request`. To construct a `RequestBuilder`, refer to the `Client` documentation. 
 #[derive(Debug)]
 #[must_use = "RequestBuilder does nothing until you 'send' it"]
 pub struct RequestBuilder {

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -21,7 +21,7 @@ pub struct Request {
     inner: async_impl::Request,
 }
 
-/// A builder to construct the properties of a `Request`. To construct a `RequestBuilder`, refer to the `Client` documentation. 
+/// A builder to construct the properties of a `Request`. To construct a `RequestBuilder`, refer to the `Client` documentation.
 #[derive(Debug)]
 #[must_use = "RequestBuilder does nothing until you 'send' it"]
 pub struct RequestBuilder {

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -21,7 +21,9 @@ pub struct Request {
     inner: async_impl::Request,
 }
 
-/// A builder to construct the properties of a `Request`. To construct a `RequestBuilder`, refer to the `Client` documentation.
+/// A builder to construct the properties of a `Request`.
+///
+/// To construct a `RequestBuilder`, refer to the `Client` documentation.
 #[derive(Debug)]
 #[must_use = "RequestBuilder does nothing until you 'send' it"]
 pub struct RequestBuilder {


### PR DESCRIPTION
Couldn't figure out why there wasn't a `new` method, and then looked through the source and realized you have to go through `Client`.