### PR TITLE
blocking: add tcp_keepalive option

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -409,6 +409,18 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.local_address(addr))
     }
 
+    /// Set that all sockets have `SO_KEEPALIVE` set with the supplied duration.
+    ///
+    /// If `None`, the option will not be set.
+    ///
+    /// Default is 60 seconds.
+    pub fn tcp_keepalive<D>(self, val: D) -> ClientBuilder
+        where
+            D: Into<Option<Duration>>,
+    {
+        self.with_inner(move |inner| inner.tcp_keepalive(val))
+    }
+
     // TLS options
 
     /// Add a custom root certificate.


### PR DESCRIPTION
This fixes bug #1098 by adding the tcp_keepalive option to the Blocking ClientBuilder.