### PR TITLE
Add https_only() for ClientBuilder

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -573,6 +573,18 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.no_trust_dns())
     }
 
+    /// Enable only specific methods (HTTP/HTTPS) to be used.
+    /// 
+    /// Defaults to allow methods allowed.
+    /// 
+    /// Use it with [HTTP_MASK] and [HTTPS_MASK].
+    /// 
+    /// [HTTP_MASK]: static.HTTPS_MASK.html
+    /// [HTTPS_MASK]: static.HTTPS_MASK.html
+    pub fn allow_method(self, flag: u8) -> ClientBuilder {
+        self.with_inner(|inner| inner.allow_method(flag))
+    }
+
     // private
 
     fn with_inner<F>(mut self, func: F) -> ClientBuilder

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -573,16 +573,11 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.no_trust_dns())
     }
 
-    /// Enable only specific methods (HTTP/HTTPS) to be used.
+    /// Restrict the Client to be used with HTTPS only requests.
     /// 
-    /// Defaults to allow methods allowed.
-    /// 
-    /// Use it with [HTTP_MASK] and [HTTPS_MASK].
-    /// 
-    /// [HTTP_MASK]: static.HTTPS_MASK.html
-    /// [HTTPS_MASK]: static.HTTPS_MASK.html
-    pub fn allow_method(self, flag: u8) -> ClientBuilder {
-        self.with_inner(|inner| inner.allow_method(flag))
+    /// Defaults to false.
+    pub fn https_only(self, enabled: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.https_only(enabled))
     }
 
     // private

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,8 +318,3 @@ if_wasm! {
 
     pub use self::wasm::{multipart, Body, Client, ClientBuilder, Request, RequestBuilder, Response};
 }
-
-/// Bytes shift mask to define the HTTP methods.
-pub static HTTP_MASK: u8 = 1 << 0;
-/// Bytes shift mask to define the HTTPS methods.
-pub static HTTPS_MASK: u8 = 1 << 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,3 +318,8 @@ if_wasm! {
 
     pub use self::wasm::{multipart, Body, Client, ClientBuilder, Request, RequestBuilder, Response};
 }
+
+/// Bytes shift mask to define the HTTP methods.
+pub static HTTP_MASK: u8 = 1 << 0;
+/// Bytes shift mask to define the HTTPS methods.
+pub static HTTPS_MASK: u8 = 1 << 1;

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -288,3 +288,38 @@ fn test_blocking_inside_a_runtime() {
         let _should_panic = reqwest::blocking::get(&url);
     });
 }
+
+#[test]
+fn test_allowed_methods_blocking() {
+    let resp = reqwest::blocking::Client::builder()
+        .allow_method(reqwest::HTTP_MASK)
+        .build()
+        .expect("client builder")
+        .get("https://google.com")
+        .send();
+
+    assert_eq!(resp.is_err(), true);
+
+    let resp = reqwest::blocking::Client::builder()
+        .allow_method(reqwest::HTTPS_MASK)
+        .build()
+        .expect("client builder")
+        .get("https://google.com")
+        .send();
+
+    assert_eq!(resp.is_err(), false);
+
+    let builder = reqwest::blocking::Client::builder()
+        .allow_method(reqwest::HTTPS_MASK)
+        .allow_method(reqwest::HTTP_MASK)
+        .build()
+        .expect("client builder");
+
+    let resp = builder.get("https://google.com").send();
+
+    assert_eq!(resp.is_err(), false);
+
+    let resp = builder.get("http://google.com").send();
+
+    assert_eq!(resp.is_err(), false);
+}

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -289,37 +289,24 @@ fn test_blocking_inside_a_runtime() {
     });
 }
 
+#[cfg(feature = "default-tls")]
 #[test]
 fn test_allowed_methods_blocking() {
     let resp = reqwest::blocking::Client::builder()
-        .allow_method(reqwest::HTTP_MASK)
+        .https_only(true)
         .build()
         .expect("client builder")
         .get("https://google.com")
+        .send();
+
+    assert_eq!(resp.is_err(), false);
+
+    let resp = reqwest::blocking::Client::builder()
+        .https_only(true)
+        .build()
+        .expect("client builder")
+        .get("http://google.com")
         .send();
 
     assert_eq!(resp.is_err(), true);
-
-    let resp = reqwest::blocking::Client::builder()
-        .allow_method(reqwest::HTTPS_MASK)
-        .build()
-        .expect("client builder")
-        .get("https://google.com")
-        .send();
-
-    assert_eq!(resp.is_err(), false);
-
-    let builder = reqwest::blocking::Client::builder()
-        .allow_method(reqwest::HTTPS_MASK)
-        .allow_method(reqwest::HTTP_MASK)
-        .build()
-        .expect("client builder");
-
-    let resp = builder.get("https://google.com").send();
-
-    assert_eq!(resp.is_err(), false);
-
-    let resp = builder.get("http://google.com").send();
-
-    assert_eq!(resp.is_err(), false);
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -200,39 +200,26 @@ fn use_preconfigured_rustls_default() {
         .expect("preconfigured rustls tls");
 }
 
+#[cfg(feature = "default-tls")]
 #[tokio::test]
 async fn test_allowed_methods() {
     let resp = reqwest::Client::builder()
-        .allow_method(reqwest::HTTP_MASK)
+        .https_only(true)
         .build()
         .expect("client builder")
         .get("https://google.com")
+        .send()
+        .await;
+
+    assert_eq!(resp.is_err(), false);
+
+    let resp = reqwest::Client::builder()
+        .https_only(true)
+        .build()
+        .expect("client builder")
+        .get("http://google.com")
         .send()
         .await;
 
     assert_eq!(resp.is_err(), true);
-
-    let resp = reqwest::Client::builder()
-        .allow_method(reqwest::HTTPS_MASK)
-        .build()
-        .expect("client builder")
-        .get("https://google.com")
-        .send()
-        .await;
-
-    assert_eq!(resp.is_err(), false);
-
-    let builder = reqwest::Client::builder()
-        .allow_method(reqwest::HTTPS_MASK)
-        .allow_method(reqwest::HTTP_MASK)
-        .build()
-        .expect("client builder");
-
-    let resp = builder.get("https://google.com").send().await;
-
-    assert_eq!(resp.is_err(), false);
-
-    let resp = builder.get("http://google.com").send().await;
-
-    assert_eq!(resp.is_err(), false);
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -199,3 +199,40 @@ fn use_preconfigured_rustls_default() {
         .build()
         .expect("preconfigured rustls tls");
 }
+
+#[tokio::test]
+async fn test_allowed_methods() {
+    let resp = reqwest::Client::builder()
+        .allow_method(reqwest::HTTP_MASK)
+        .build()
+        .expect("client builder")
+        .get("https://google.com")
+        .send()
+        .await;
+
+    assert_eq!(resp.is_err(), true);
+
+    let resp = reqwest::Client::builder()
+        .allow_method(reqwest::HTTPS_MASK)
+        .build()
+        .expect("client builder")
+        .get("https://google.com")
+        .send()
+        .await;
+
+    assert_eq!(resp.is_err(), false);
+
+    let builder = reqwest::Client::builder()
+        .allow_method(reqwest::HTTPS_MASK)
+        .allow_method(reqwest::HTTP_MASK)
+        .build()
+        .expect("client builder");
+
+    let resp = builder.get("https://google.com").send().await;
+
+    assert_eq!(resp.is_err(), false);
+
+    let resp = builder.get("http://google.com").send().await;
+
+    assert_eq!(resp.is_err(), false);
+}


### PR DESCRIPTION
This PR fixes #980 by giving the possibility to create a Client that only accepts defined methods.
For now, this is only HTTPS or HTTP but the code is easily extensible for all future methods that `reqwest` will support.

I hope this PR will be well received even if it wasn't something you guys were waiting for ;) 