### PR TITLE
Define `CookieStore` as trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rustls-tls-native-roots = ["rustls-native-certs", "__rustls"]
 
 blocking = ["futures-util/io", "tokio/rt-multi-thread", "tokio/sync"]
 
-cookies = ["cookie_crate", "cookie_store", "time"]
+cookies = ["cookie_crate", "time"]
 
 gzip = ["async-compression", "async-compression/gzip", "tokio-util"]
 
@@ -116,7 +116,7 @@ rustls-native-certs = { version = "0.5", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.14", package = "cookie", optional = true }
-cookie_store = { version = "0.12", optional = true }
+
 time = { version = "0.2.11", optional = true }
 
 ## compression

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -1,5 +1,9 @@
+use std::sync::Arc;
+
 mod support;
 use support::*;
+
+use cookie_store::CookieStoreMutex as CookieStore;
 
 #[tokio::test]
 async fn cookie_response_accessor() {
@@ -84,7 +88,7 @@ async fn cookie_store_simple() {
     });
 
     let client = reqwest::Client::builder()
-        .cookie_store(true)
+        .cookie_store(Some(Arc::new(CookieStore::default())))
         .build()
         .unwrap();
 
@@ -117,7 +121,7 @@ async fn cookie_store_overwrite_existing() {
     });
 
     let client = reqwest::Client::builder()
-        .cookie_store(true)
+        .cookie_store(Some(Arc::new(CookieStore::default())))
         .build()
         .unwrap();
 
@@ -142,7 +146,7 @@ async fn cookie_store_max_age() {
     });
 
     let client = reqwest::Client::builder()
-        .cookie_store(true)
+        .cookie_store(Some(Arc::new(CookieStore::default())))
         .build()
         .unwrap();
     let url = format!("http://{}/", server.addr());
@@ -164,7 +168,7 @@ async fn cookie_store_expires() {
     });
 
     let client = reqwest::Client::builder()
-        .cookie_store(true)
+        .cookie_store(Some(Arc::new(CookieStore::default())))
         .build()
         .unwrap();
 
@@ -190,7 +194,7 @@ async fn cookie_store_path() {
     });
 
     let client = reqwest::Client::builder()
-        .cookie_store(true)
+        .cookie_store(Some(Arc::new(CookieStore::default())))
         .build()
         .unwrap();
 


### PR DESCRIPTION
This PR aims to address #1104 by replacing the newtype `reqwest::cookie::CookieStore` with `trait CookieStore` to define a minimal interface for `reqwest` to store and retrieve cookies.

The [cookie-storage branch of the `cookie_store` crate](https://github.com/pfernie/cookie_store/tree/cookie-storage) contains such an implementation.

Not addressed is providing a default implementation of a `CookieStore` within `reqwest`. Since the trait now reduces `reqwest`s external dependencies (`cookie_store` can be removed as a dependency for the `cookies` features), it may make sense to provide that as an alternative feature in `reqwest`. A new feature `default_cookie_store` could re-introduce the `cookie_store` dependency and provide it as the default `CookieStore` implementation.

* This PR still has a breaking API change in the `ClientBuilder`, as the `ClientBuilder::cookie_store` signature changed from accepting a `bool` to a `Option<dyn CookieStore>`. An alternative method (`set_cookie_store`) could be provided, but that would necessitate both multiple configuration options, and providing a default implementation unless the `bool` fn became gated behind the `default_cookie_store` feature as well.
* This PR would allow for the use case of read-only `CookieStore`. Trivially, a user could depend on `cookie_store::CookieStore`, wrap it in a newtype, and impl `reqwest::cookie::CookieStore` on the newtype implementing `store_cookie_headers` as a no-op.

---

Naming: in writing this description, it is somewhat confusing that the `cookie_store::CookieStore` implementation overlaps with the proposed trait `reqwest::cookie::CookieStore`. Documentation may be less confusing for the trait to retain the name `reqwest::cookie::CookieStorage`.