### PR TITLE
get rid of useless `move ||` when no new thread is created

### DIFF
--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -87,7 +87,7 @@ impl Form {
     where
         T: Into<Cow<'static, str>>,
     {
-        self.with_inner(move |inner| inner.part(name, part))
+        self.with_inner(|inner| inner.part(name, part))
     }
 
     /// Configure this `Form` to percent-encode using the `path-segment` rules.
@@ -233,7 +233,7 @@ impl Part {
 
     // Re-export when mime 0.4 is available, with split MediaType/MediaRange.
     fn mime(self, mime: Mime) -> Part {
-        self.with_inner(move |inner| inner.mime(mime))
+        self.with_inner(|inner| inner.mime(mime))
     }
 
     /// Sets the filename, builder style.
@@ -241,7 +241,7 @@ impl Part {
     where
         T: Into<Cow<'static, str>>,
     {
-        self.with_inner(move |inner| inner.file_name(filename))
+        self.with_inner(|inner| inner.file_name(filename))
     }
 
     fn with_inner<F>(self, func: F) -> Self

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -125,7 +125,7 @@ impl ClientBuilder {
         V: TryInto<HeaderValue>,
         V::Error: Into<http::Error>,
     {
-        self.with_inner(move |inner| inner.user_agent(value))
+        self.with_inner(|inner| inner.user_agent(value))
     }
 
     /// Sets the default headers for every request.
@@ -167,7 +167,7 @@ impl ClientBuilder {
     /// # }
     /// ```
     pub fn default_headers(self, headers: header::HeaderMap) -> ClientBuilder {
-        self.with_inner(move |inner| inner.default_headers(headers))
+        self.with_inner(|inner| inner.default_headers(headers))
     }
 
     /// Enable a persistent cookie store for the client.
@@ -247,7 +247,7 @@ impl ClientBuilder {
     ///
     /// Default will follow redirects up to a maximum of 10.
     pub fn redirect(self, policy: redirect::Policy) -> ClientBuilder {
-        self.with_inner(move |inner| inner.redirect(policy))
+        self.with_inner(|inner| inner.redirect(policy))
     }
 
     /// Enable or disable automatic setting of the `Referer` header.
@@ -265,14 +265,14 @@ impl ClientBuilder {
     ///
     /// Adding a proxy will disable the automatic usage of the "system" proxy.
     pub fn proxy(self, proxy: Proxy) -> ClientBuilder {
-        self.with_inner(move |inner| inner.proxy(proxy))
+        self.with_inner(|inner| inner.proxy(proxy))
     }
 
     /// Clear all `Proxies`, so `Client` will use no proxy anymore.
     ///
     /// This also disables the automatic usage of the "system" proxy.
     pub fn no_proxy(self) -> ClientBuilder {
-        self.with_inner(move |inner| inner.no_proxy())
+        self.with_inner(|inner| inner.no_proxy())
     }
 
     #[doc(hidden)]
@@ -318,7 +318,7 @@ impl ClientBuilder {
     ///
     /// [log]: https://crates.io/crates/log
     pub fn connection_verbose(self, verbose: bool) -> ClientBuilder {
-        self.with_inner(move |inner| inner.connection_verbose(verbose))
+        self.with_inner(|inner| inner.connection_verbose(verbose))
     }
 
     // HTTP options
@@ -337,7 +337,7 @@ impl ClientBuilder {
 
     /// Sets the maximum idle connection per host allowed in the pool.
     pub fn pool_max_idle_per_host(self, max: usize) -> ClientBuilder {
-        self.with_inner(move |inner| inner.pool_max_idle_per_host(max))
+        self.with_inner(|inner| inner.pool_max_idle_per_host(max))
     }
 
     #[doc(hidden)]
@@ -388,7 +388,7 @@ impl ClientBuilder {
     //
     // TODO(v0.11.x): Remove trailing underscore.
     pub fn tcp_nodelay_(self, enabled: bool) -> ClientBuilder {
-        self.with_inner(move |inner| inner.tcp_nodelay_(enabled))
+        self.with_inner(|inner| inner.tcp_nodelay_(enabled))
     }
 
     /// Bind to a local IP Address.
@@ -406,7 +406,7 @@ impl ClientBuilder {
     where
         T: Into<Option<IpAddr>>,
     {
-        self.with_inner(move |inner| inner.local_address(addr))
+        self.with_inner(|inner| inner.local_address(addr))
     }
 
     /// Set that all sockets have `SO_KEEPALIVE` set with the supplied duration.
@@ -418,7 +418,7 @@ impl ClientBuilder {
         where
             D: Into<Option<Duration>>,
     {
-        self.with_inner(move |inner| inner.tcp_keepalive(val))
+        self.with_inner(|inner| inner.tcp_keepalive(val))
     }
 
     // TLS options
@@ -456,13 +456,13 @@ impl ClientBuilder {
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
     pub fn add_root_certificate(self, cert: Certificate) -> ClientBuilder {
-        self.with_inner(move |inner| inner.add_root_certificate(cert))
+        self.with_inner(|inner| inner.add_root_certificate(cert))
     }
 
     /// Sets the identity to be used for client certificate authentication.
     #[cfg(feature = "__tls")]
     pub fn identity(self, identity: Identity) -> ClientBuilder {
-        self.with_inner(move |inner| inner.identity(identity))
+        self.with_inner(|inner| inner.identity(identity))
     }
 
     /// Controls the use of hostname verification.
@@ -510,7 +510,7 @@ impl ClientBuilder {
     /// This requires the optional `native-tls` feature to be enabled.
     #[cfg(feature = "native-tls")]
     pub fn use_native_tls(self) -> ClientBuilder {
-        self.with_inner(move |inner| inner.use_native_tls())
+        self.with_inner(|inner| inner.use_native_tls())
     }
 
     /// Force using the Rustls TLS backend.
@@ -523,7 +523,7 @@ impl ClientBuilder {
     /// This requires the optional `rustls-tls(-...)` feature to be enabled.
     #[cfg(feature = "__rustls")]
     pub fn use_rustls_tls(self) -> ClientBuilder {
-        self.with_inner(move |inner| inner.use_rustls_tls())
+        self.with_inner(|inner| inner.use_rustls_tls())
     }
 
     /// Use a preconfigured TLS backend.
@@ -549,7 +549,7 @@ impl ClientBuilder {
         feature = "__rustls",
     ))]
     pub fn use_preconfigured_tls(self, tls: impl Any) -> ClientBuilder {
-        self.with_inner(move |inner| inner.use_preconfigured_tls(tls))
+        self.with_inner(|inner| inner.use_preconfigured_tls(tls))
     }
 
     /// Enables the [trust-dns](trust_dns_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
@@ -690,7 +690,7 @@ impl Client {
     ///
     /// This method fails whenever supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
-        let req = url.into_url().map(move |url| Request::new(method, url));
+        let req = url.into_url().map(|url| Request::new(method, url));
         RequestBuilder::new(self.clone(), req)
     }
 

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -125,7 +125,7 @@ impl Form {
     where
         T: Into<Cow<'static, str>>,
     {
-        self.with_inner(move |inner| inner.part(name, part))
+        self.with_inner(|inner| inner.part(name, part))
     }
 
     /// Configure this `Form` to percent-encode using the `path-segment` rules.
@@ -245,7 +245,7 @@ impl Part {
 
     // Re-export when mime 0.4 is available, with split MediaType/MediaRange.
     fn mime(self, mime: Mime) -> Part {
-        self.with_inner(move |inner| inner.mime(mime))
+        self.with_inner(|inner| inner.mime(mime))
     }
 
     /// Sets the filename, builder style.
@@ -253,7 +253,7 @@ impl Part {
     where
         T: Into<Cow<'static, str>>,
     {
-        self.with_inner(move |inner| inner.file_name(filename))
+        self.with_inner(|inner| inner.file_name(filename))
     }
 
     fn with_inner<F>(self, func: F) -> Self

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -350,7 +350,7 @@ impl Response {
             timeout,
             _thread_handle,
         } = self;
-        inner.error_for_status().map(move |inner| Response {
+        inner.error_for_status().map(|inner| Response {
             inner,
             body,
             timeout,

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -114,7 +114,7 @@ impl Client {
     ///
     /// This method fails whenever supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
-        let req = url.into_url().map(move |url| Request::new(method, url));
+        let req = url.into_url().map(|url| Request::new(method, url));
         RequestBuilder::new(self.clone(), req)
     }
 

--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -77,7 +77,7 @@ impl Form {
     where
         T: Into<Cow<'static, str>>,
     {
-        self.with_inner(move |inner| inner.part(name, part))
+        self.with_inner(|inner| inner.part(name, part))
     }
 
     fn with_inner<F>(self, func: F) -> Self
@@ -162,7 +162,7 @@ impl Part {
 
     // Re-export when mime 0.4 is available, with split MediaType/MediaRange.
     fn mime(self, mime: Mime) -> Part {
-        self.with_inner(move |inner| inner.mime(mime))
+        self.with_inner(|inner| inner.mime(mime))
     }
 
     /// Sets the filename, builder style.
@@ -170,7 +170,7 @@ impl Part {
     where
         T: Into<Cow<'static, str>>,
     {
-        self.with_inner(move |inner| inner.file_name(filename))
+        self.with_inner(|inner| inner.file_name(filename))
     }
 
     fn with_inner<F>(self, func: F) -> Self


### PR DESCRIPTION
There is, afaik, no need to use `move` for all these function. Am I wrong? 