### PR TITLE
Build a blocking body from bytes::Bytes to allow copy-free chained network calls.

### DIFF
--- a/src/blocking/body.rs
+++ b/src/blocking/body.rs
@@ -203,6 +203,14 @@ impl From<File> for Body {
         }
     }
 }
+impl From<Bytes> for Body {
+    #[inline]
+    fn from(b: Bytes) -> Body {
+        Body {
+            kind: Kind::Bytes(b),
+        }
+    }
+}
 
 impl fmt::Debug for Kind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -310,3 +310,19 @@ fn test_allowed_methods_blocking() {
 
     assert_eq!(resp.is_err(), true);
 }
+
+/// Test that a [`reqwest::blocking::Body`] can be created from [`bytes::Bytes`].
+#[test]
+fn test_body_from_bytes() {
+    let body = "abc";
+    // No external calls are needed. Only the request building is tested.
+    let request = reqwest::blocking::Client::builder()
+        .build()
+        .expect("Could not build the client")
+        .put("https://google.com")
+        .body(bytes::Bytes::from(body))
+        .build()
+        .expect("Invalid body");
+
+    assert_eq!(request.body().unwrap().as_bytes(), Some(body.as_bytes()));
+}


### PR DESCRIPTION
Currently, if I want to use the `reqwest::blocking::Client`, the response can give me a `bytes::Bytes` but afaik there is no easy/cheap way to turn that into an owned contiguous bytes type needed to build a blocking body. As of 0.10.10, a blocking body can be constructed from a file, `&'static [u8]`, `String`, `&'static str`, and  Vec<u8>. 

The async API DOES allow a body to be built from `Bytes` which is extremely convenient for getting bytes from one url and putting them at another url. My application would benefit greatly from minimizing copying bytes in these get-put chains and this trait implementation seems to be a natural way to address what I imagine is not an extremely uncommon use case. This trait implementation in the blocking API IMO makes sense with the design philosophy of the library, makes the blocking API more consistent with the async one, and allows greater composability within and between the clients. 

While this seems like the simplest/minimal change that will effectively address this pattern of guiding bytes from a get response to a put request, other alternatives to this trait implementation include:
1. Having a more direct blocking return type (`blocking::Response.vec()` or something) (I dont want to use `std::String` as an intermediate step)
2. `impl<T: AsRef<[u8]>> From<T> for blocking::Body`
3. Some other way that I dont know of to transform `bytes::Bytes` into a `Vec<u8>` without copying the bytes?
4. Just clone the bytes