### PR TITLE
Fix doc comment

### DIFF
--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -51,7 +51,7 @@ impl Response {
     ///
     /// - The server didn't send a `content-length` header.
     /// - The response is compressed and automatically decoded (thus changing
-    //   the actual decoded length).
+    ///  the actual decoded length).
     pub fn content_length(&self) -> Option<u64> {
         self.headers()
             .get(http::header::CONTENT_LENGTH)?


### PR DESCRIPTION
`//` was used for the last line of doc comment. This PR replaces `//` with `///`