### PR TITLE
rustfmt all

### DIFF
--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -185,11 +185,7 @@ impl Decoder {
     /// how to decode the content body of the request.
     ///
     /// Uses the correct variant by inspecting the Content-Encoding header.
-    pub(super) fn detect(
-        _headers: &mut HeaderMap,
-        body: Body,
-        _accepts: Accepts,
-    ) -> Decoder {
+    pub(super) fn detect(_headers: &mut HeaderMap, body: Body, _accepts: Accepts) -> Decoder {
         #[cfg(feature = "gzip")]
         {
             if _accepts.gzip && Decoder::detect_gzip(_headers) {

--- a/src/blocking/body.rs
+++ b/src/blocking/body.rs
@@ -92,7 +92,7 @@ impl Body {
     /// Converts streamed requests to their buffered equivalent and
     /// returns a reference to the buffer. If the request is already
     /// buffered, this has no effect.
-    /// 
+    ///
     /// Be aware that for large requests this method is expensive
     /// and may cause your program to run out of memory.
     pub fn buffer(&mut self) -> Result<&[u8], crate::Error> {
@@ -103,11 +103,10 @@ impl Body {
                 } else {
                     Vec::new()
                 };
-                io::copy(reader, &mut bytes)
-                    .map_err(crate::error::builder)?;
+                io::copy(reader, &mut bytes).map_err(crate::error::builder)?;
                 self.kind = Kind::Bytes(bytes.into());
                 self.buffer()
-            },
+            }
             Kind::Bytes(ref bytes) => Ok(bytes.as_ref()),
         }
     }
@@ -290,14 +289,14 @@ async fn send_future(sender: Sender) -> Result<(), crate::Error> {
                 buf.reserve(8192);
                 // zero out the reserved memory
                 unsafe {
-                    let uninit = mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(buf.bytes_mut());
+                    let uninit =
+                        mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(buf.bytes_mut());
                     ptr::write_bytes(uninit.as_mut_ptr(), 0, uninit.len());
                 }
             }
 
-            let bytes = unsafe {
-                mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(buf.bytes_mut())
-            };
+            let bytes =
+                unsafe { mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(buf.bytes_mut()) };
             match body.read(bytes) {
                 Ok(0) => {
                     // The buffer was empty and nothing's left to

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1,7 +1,4 @@
-#[cfg(any(
-    feature = "native-tls",
-    feature = "__rustls",
-))]
+#[cfg(any(feature = "native-tls", feature = "__rustls",))]
 use std::any::Any;
 use std::convert::TryInto;
 use std::fmt;
@@ -18,7 +15,7 @@ use tokio::sync::{mpsc, oneshot};
 use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::wait;
-use crate::{async_impl, header, IntoUrl, Method, Proxy, redirect};
+use crate::{async_impl, header, redirect, IntoUrl, Method, Proxy};
 #[cfg(feature = "__tls")]
 use crate::{Certificate, Identity};
 
@@ -96,9 +93,7 @@ impl ClientBuilder {
         ClientHandle::new(self).map(|handle| Client { inner: handle })
     }
 
-
     // Higher-level options
-
 
     /// Sets the `User-Agent` header to be used by this client.
     ///
@@ -223,7 +218,9 @@ impl ClientBuilder {
     ///
     /// This requires the optional `brotli` feature to be enabled
     #[cfg(feature = "brotli")]
-    pub fn brotli(self, enable: bool) -> ClientBuilder { self.with_inner(|inner| inner.brotli(enable)) }
+    pub fn brotli(self, enable: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.brotli(enable))
+    }
 
     /// Disable auto response body gzip decompression.
     ///
@@ -239,7 +236,9 @@ impl ClientBuilder {
     /// This method exists even if the optional `brotli` feature is not enabled.
     /// This can be used to ensure a `Client` doesn't use brotli decompression
     /// even if another dependency were to enable the optional `brotli` feature.
-    pub fn no_brotli(self) -> ClientBuilder { self.with_inner(|inner| inner.no_brotli()) }
+    pub fn no_brotli(self) -> ClientBuilder {
+        self.with_inner(|inner| inner.no_brotli())
+    }
 
     // Redirect options
 
@@ -413,8 +412,8 @@ impl ClientBuilder {
     ///
     /// If `None`, the option will not be set.
     pub fn tcp_keepalive<D>(self, val: D) -> ClientBuilder
-        where
-            D: Into<Option<Duration>>,
+    where
+        D: Into<Option<Duration>>,
     {
         self.with_inner(move |inner| inner.tcp_keepalive(val))
     }
@@ -542,10 +541,7 @@ impl ClientBuilder {
     ///
     /// This requires one of the optional features `native-tls` or
     /// `rustls-tls(-...)` to be enabled.
-    #[cfg(any(
-        feature = "native-tls",
-        feature = "__rustls",
-    ))]
+    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
     pub fn use_preconfigured_tls(self, tls: impl Any) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))
     }
@@ -572,7 +568,7 @@ impl ClientBuilder {
     }
 
     /// Restrict the Client to be used with HTTPS only requests.
-    /// 
+    ///
     /// Defaults to false.
     pub fn https_only(self, enabled: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.https_only(enabled))
@@ -741,7 +737,8 @@ struct InnerClientHandle {
 
 impl Drop for InnerClientHandle {
     fn drop(&mut self) {
-        let id = self.thread
+        let id = self
+            .thread
             .as_ref()
             .map(|h| h.thread().id())
             .expect("thread not dropped yet");
@@ -764,7 +761,12 @@ impl ClientHandle {
             .name("reqwest-internal-sync-runtime".into())
             .spawn(move || {
                 use tokio::runtime;
-                let mut rt = match runtime::Builder::new().basic_scheduler().enable_all().build().map_err(crate::error::builder) {
+                let mut rt = match runtime::Builder::new()
+                    .basic_scheduler()
+                    .enable_all()
+                    .build()
+                    .map_err(crate::error::builder)
+                {
                     Err(e) => {
                         if let Err(e) = spawn_tx.send(Err(e)) {
                             error!("Failed to communicate runtime creation failure: {:?}", e);
@@ -846,9 +848,7 @@ impl ClientHandle {
                 };
                 wait::timeout(f, timeout)
             } else {
-                let f = async move {
-                    rx.await.map_err(|_canceled| event_loop_panicked())
-                };
+                let f = async move { rx.await.map_err(|_canceled| event_loop_panicked()) };
                 wait::timeout(f, timeout)
             };
 

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -392,8 +392,7 @@ mod tests {
             .part("key3", Part::text("value3").file_name("filename"));
         form.inner.boundary = "boundary".to_string();
         let length = form.compute_length();
-        let expected =
-            "--boundary\r\n\
+        let expected = "--boundary\r\n\
              Content-Disposition: form-data; name=\"reader1\"\r\n\r\n\
              \r\n\
              --boundary\r\n\
@@ -429,8 +428,7 @@ mod tests {
             .part("key3", Part::text("value3").file_name("filename"));
         form.inner.boundary = "boundary".to_string();
         let length = form.compute_length();
-        let expected =
-            "--boundary\r\n\
+        let expected = "--boundary\r\n\
              Content-Disposition: form-data; name=\"key1\"\r\n\r\n\
              value1\r\n\
              --boundary\r\n\

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -1,9 +1,9 @@
-use std::fmt;
 use std::convert::TryFrom;
+use std::fmt;
 use std::time::Duration;
 
 use base64::encode;
-use http::{Request as HttpRequest, request::Parts};
+use http::{request::Parts, Request as HttpRequest};
 use serde::Serialize;
 #[cfg(feature = "json")]
 use serde_json;
@@ -594,7 +594,10 @@ impl RequestBuilder {
     }
 }
 
-impl<T> TryFrom<HttpRequest<T>> for Request where T:Into<Body> {
+impl<T> TryFrom<HttpRequest<T>> for Request
+where
+    T: Into<Body>,
+{
     type Error = crate::Error;
 
     fn try_from(req: HttpRequest<T>) -> crate::Result<Self> {
@@ -605,8 +608,7 @@ impl<T> TryFrom<HttpRequest<T>> for Request where T:Into<Body> {
             headers,
             ..
         } = parts;
-        let url = Url::parse(&uri.to_string())
-            .map_err(crate::error::builder)?;
+        let url = Url::parse(&uri.to_string()).map_err(crate::error::builder)?;
         let mut inner = async_impl::Request::new(method, url);
         crate::util::replace_headers(inner.headers_mut(), headers);
         Ok(Request {
@@ -633,8 +635,8 @@ fn fmt_request_fields<'a, 'b>(
 
 #[cfg(test)]
 mod tests {
-    use super::{HttpRequest, Request};
     use super::super::{body, Client};
+    use super::{HttpRequest, Request};
     use crate::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE, HOST};
     use crate::Method;
     use serde::Serialize;
@@ -955,18 +957,19 @@ mod tests {
         let client = Client::new();
         let some_url = "https://Aladdin:open sesame@localhost/";
 
-        let req = client
-            .get(some_url)
-            .build()
-            .expect("request build");
+        let req = client.get(some_url).build().expect("request build");
 
         assert_eq!(req.url().as_str(), "https://localhost/");
-        assert_eq!(req.headers()["authorization"], "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        assert_eq!(
+            req.headers()["authorization"],
+            "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+        );
     }
 
     #[test]
     fn convert_from_http_request() {
-        let http_request = HttpRequest::builder().method("GET")
+        let http_request = HttpRequest::builder()
+            .method("GET")
             .uri("http://localhost/")
             .header("User-Agent", "my-awesome-agent/1.0")
             .body("test test test")
@@ -993,7 +996,10 @@ mod tests {
             .expect("request build");
 
         assert_eq!(req.url().as_str(), "https://localhost/");
-        assert_eq!(req.headers()["authorization"], "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        assert_eq!(
+            req.headers()["authorization"],
+            "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+        );
         assert_eq!(req.headers()["authorization"].is_sensitive(), true);
     }
 

--- a/src/blocking/wait.rs
+++ b/src/blocking/wait.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use tokio::time::Instant;
 
-
 pub(crate) fn timeout<F, I, E>(fut: F, timeout: Option<Duration>) -> Result<I, Waited<E>>
 where
     F: Future<Output = Result<I, E>>,
@@ -40,7 +39,11 @@ where
                 return Err(Waited::TimedOut(crate::error::TimedOut));
             }
 
-            log::trace!("({:?}) park timeout {:?}", thread::current().id(), deadline - now);
+            log::trace!(
+                "({:?}) park timeout {:?}",
+                thread::current().id(),
+                deadline - now
+            );
             thread::park_timeout(deadline - now);
         } else {
             log::trace!("({:?}) park without timeout", thread::current().id());

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -64,9 +64,10 @@ impl<'a> Cookie<'a> {
 
     /// Get the Max-Age information.
     pub fn max_age(&self) -> Option<std::time::Duration> {
-        self.0
-            .max_age()
-            .map(|d| d.try_into().expect("time::Duration into std::time::Duration"))
+        self.0.max_age().map(|d| {
+            d.try_into()
+                .expect("time::Duration into std::time::Duration")
+        })
     }
 
     /// The cookie expiration time.

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,8 +1,8 @@
 use std::future::Future;
+use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{self, Poll};
-use std::io;
 
 use hyper::client::connect::dns as hyper_dns;
 use hyper::service::Service;
@@ -18,7 +18,8 @@ use crate::error::BoxError;
 type SharedResolver = Arc<AsyncResolver<TokioConnection, TokioConnectionProvider>>;
 
 lazy_static! {
-    static ref SYSTEM_CONF: io::Result<(ResolverConfig, ResolverOpts)> = system_conf::read_system_conf().map_err(io::Error::from);
+    static ref SYSTEM_CONF: io::Result<(ResolverConfig, ResolverOpts)> =
+        system_conf::read_system_conf().map_err(io::Error::from);
 }
 
 #[derive(Clone)]
@@ -65,7 +66,7 @@ impl Service<hyper_dns::Name> for TrustDnsResolver {
                     let resolver = new_resolver(tokio::runtime::Handle::current()).await?;
                     *lock = State::Ready(resolver.clone());
                     resolver
-                },
+                }
                 State::Ready(resolver) => resolver.clone(),
             };
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -842,8 +842,7 @@ fn extract_type_prefix(address: &str) -> Option<&str> {
     if let Some(indice) = address.find("://") {
         if indice == 0 {
             None
-        }
-        else {
+        } else {
             let prefix = &address[..indice];
             let contains_banned = prefix.contains(|c| c == ':' || c == '/');
 
@@ -853,8 +852,7 @@ fn extract_type_prefix(address: &str) -> Option<&str> {
                 None
             }
         }
-    }
-    else {
+    } else {
         None
     }
 }
@@ -1033,9 +1031,16 @@ mod tests {
         // set valid proxy
         let valid_proxies = get_sys_proxies(Some((1, String::from("http://127.0.0.1/"))));
         let valid_proxies_no_schema = get_sys_proxies(Some((1, String::from("127.0.0.1"))));
-        let valid_proxies_explicit_https = get_sys_proxies(Some((1, String::from("https://127.0.0.1/"))));
-        let multiple_proxies = get_sys_proxies(Some((1, String::from("http=127.0.0.1:8888;https=127.0.0.2:8888"))));
-        let multiple_proxies_explicit_schema = get_sys_proxies(Some((1, String::from("http=http://127.0.0.1:8888;https=https://127.0.0.2:8888"))));
+        let valid_proxies_explicit_https =
+            get_sys_proxies(Some((1, String::from("https://127.0.0.1/"))));
+        let multiple_proxies = get_sys_proxies(Some((
+            1,
+            String::from("http=127.0.0.1:8888;https=127.0.0.2:8888"),
+        )));
+        let multiple_proxies_explicit_schema = get_sys_proxies(Some((
+            1,
+            String::from("http=http://127.0.0.1:8888;https=https://127.0.0.2:8888"),
+        )));
 
         // reset user setting when guards drop
         drop(_g1);

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -267,7 +267,6 @@ fn test_redirect_policy_limit() {
         .map(|i| Url::parse(&format!("http://a.b/c/{}", i)).unwrap())
         .collect::<Vec<_>>();
 
-
     match policy.check(StatusCode::FOUND, &next, &previous) {
         ActionKind::Follow => (),
         other => panic!("unexpected {:?}", other),
@@ -298,7 +297,7 @@ fn test_redirect_policy_custom() {
     }
 
     let next = Url::parse("http://foo/baz").unwrap();
-     match policy.check(StatusCode::FOUND, &next, &[]) {
+    match policy.check(StatusCode::FOUND, &next, &[]) {
         ActionKind::Stop => (),
         other => panic!("unexpected {:?}", other),
     }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -22,10 +22,7 @@ enum Cert {
 
 /// Represents a private key and X509 cert as a client certificate.
 pub struct Identity {
-    #[cfg_attr(
-        not(any(feature = "native-tls", feature = "__rustls")),
-        allow(unused)
-    )]
+    #[cfg_attr(not(any(feature = "native-tls", feature = "__rustls")), allow(unused))]
     inner: ClientCert,
 }
 
@@ -159,7 +156,8 @@ impl Identity {
     pub fn from_pkcs12_der(der: &[u8], password: &str) -> crate::Result<Identity> {
         Ok(Identity {
             inner: ClientCert::Pkcs12(
-                native_tls_crate::Identity::from_pkcs12(der, password).map_err(crate::error::builder)?,
+                native_tls_crate::Identity::from_pkcs12(der, password)
+                    .map_err(crate::error::builder)?,
             ),
         })
     }
@@ -245,7 +243,8 @@ impl Identity {
     pub(crate) fn add_to_rustls(self, tls: &mut rustls::ClientConfig) -> crate::Result<()> {
         match self.inner {
             ClientCert::Pem { key, certs } => {
-                tls.set_single_client_cert(certs, key).map_err(|e| crate::error::builder(e))?;
+                tls.set_single_client_cert(certs, key)
+                    .map_err(|e| crate::error::builder(e))?;
                 Ok(())
             }
             #[cfg(feature = "native-tls")]
@@ -275,10 +274,7 @@ pub(crate) enum TlsBackend {
     Rustls,
     #[cfg(feature = "__rustls")]
     BuiltRustls(rustls::ClientConfig),
-    #[cfg(any(
-        feature = "native-tls",
-        feature = "__rustls",
-    ))]
+    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
     UnknownPreconfigured,
 }
 
@@ -293,10 +289,7 @@ impl fmt::Debug for TlsBackend {
             TlsBackend::Rustls => write!(f, "Rustls"),
             #[cfg(feature = "__rustls")]
             TlsBackend::BuiltRustls(_) => write!(f, "BuiltRustls"),
-            #[cfg(any(
-                feature = "native-tls",
-                feature = "__rustls",
-            ))]
+            #[cfg(any(feature = "native-tls", feature = "__rustls",))]
             TlsBackend::UnknownPreconfigured => write!(f, "UnknownPreconfigured"),
         }
     }

--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -1,8 +1,8 @@
 use super::multipart::Form;
 /// dox
 use bytes::Bytes;
-use std::fmt;
 use js_sys::Uint8Array;
+use std::fmt;
 use wasm_bindgen::JsValue;
 
 /// The body of a `Request`.

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -2,16 +2,15 @@ use wasm_bindgen::JsCast;
 
 mod body;
 mod client;
-mod request;
-mod response;
 /// TODO
 pub mod multipart;
+mod request;
+mod response;
 
 pub use self::body::Body;
 pub use self::client::{Client, ClientBuilder};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::Response;
-
 
 async fn promise<T>(promise: js_sys::Promise) -> Result<T, crate::error::BoxError>
 where
@@ -19,13 +18,9 @@ where
 {
     use wasm_bindgen_futures::JsFuture;
 
-    let js_val = JsFuture::from(promise)
-        .await
-        .map_err(crate::error::wasm)?;
+    let js_val = JsFuture::from(promise).await.map_err(crate::error::wasm)?;
 
     js_val
         .dyn_into::<T>()
-        .map_err(|_js_val| {
-            "promise resolved to unexpected type".into()
-        })
+        .map_err(|_js_val| "promise resolved to unexpected type".into())
 }

--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -90,7 +90,6 @@ impl Form {
     }
 
     pub(crate) fn to_form_data(&self) -> crate::Result<FormData> {
-
         let form = FormData::new()
             .map_err(crate::error::wasm)
             .map_err(crate::error::builder)?;

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -2,11 +2,11 @@ use std::convert::TryFrom;
 use std::fmt;
 
 use http::{request::Parts, Method, Request as HttpRequest};
-use url::Url;
+use serde::Serialize;
 #[cfg(feature = "json")]
 use serde_json;
-use serde::Serialize;
 use serde_urlencoded;
+use url::Url;
 
 use super::{Body, Client, Response};
 use crate::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
@@ -180,7 +180,6 @@ impl RequestBuilder {
         let header_value = format!("Bearer {}", token);
         self.header(crate::header::AUTHORIZATION, header_value)
     }
-
 
     /// Set the request body.
     pub fn body<T: Into<Body>>(mut self, body: T) -> RequestBuilder {

--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
 use bytes::Bytes;
-use js_sys::Uint8Array;
 use http::{HeaderMap, StatusCode};
+use js_sys::Uint8Array;
 use url::Url;
 
 #[cfg(feature = "json")]
@@ -17,10 +17,7 @@ pub struct Response {
 }
 
 impl Response {
-    pub(super) fn new(
-        res: http::Response<web_sys::Response>,
-        url: Url,
-    ) -> Response {
+    pub(super) fn new(res: http::Response<web_sys::Response>, url: Url) -> Response {
         Response {
             http: res,
             url: Box::new(url),
@@ -85,7 +82,10 @@ impl Response {
 
     /// Get the response text.
     pub async fn text(self) -> crate::Result<String> {
-        let p = self.http.body().text()
+        let p = self
+            .http
+            .body()
+            .text()
             .map_err(crate::error::wasm)
             .map_err(crate::error::decode)?;
         let js_val = super::promise::<wasm_bindgen::JsValue>(p)
@@ -100,7 +100,10 @@ impl Response {
 
     /// Get the response as bytes
     pub async fn bytes(self) -> crate::Result<Bytes> {
-        let p = self.http.body().array_buffer()
+        let p = self
+            .http
+            .body()
+            .array_buffer()
             .map_err(crate::error::wasm)
             .map_err(crate::error::decode)?;
 


### PR DESCRIPTION
Since many development environments automatically format the code - any
minor edits in the file lead to a change in the entire file. Therefore
it's easier to format all files at once.
