### PR TITLE
Add a use_built_in_root_certificates option for Client

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -727,7 +727,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Controls the use of built-in system certificates during certificate validation.
+    /// Controls the use of built-in/preloaded certificates during certificate validation.
     ///
     /// Defaults to `true` -- built-in system certs will be used.
     ///

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -94,7 +94,7 @@ struct Config {
     #[cfg(feature = "__tls")]
     root_certs: Vec<Certificate>,
     #[cfg(feature = "__tls")]
-    use_built_in_root_certificates: bool,
+    tls_built_in_root_certs: bool,
     #[cfg(feature = "__tls")]
     tls: TlsBackend,
     http2_only: bool,
@@ -148,7 +148,7 @@ impl ClientBuilder {
                 #[cfg(feature = "__tls")]
                 root_certs: Vec::new(),
                 #[cfg(feature = "__tls")]
-                use_built_in_root_certificates: true,
+                tls_built_in_root_certs: true,
                 #[cfg(feature = "__tls")]
                 identity: None,
                 #[cfg(feature = "__tls")]
@@ -213,7 +213,7 @@ impl ClientBuilder {
 
                     tls.danger_accept_invalid_certs(!config.certs_verification);
 
-                    tls.disable_built_in_roots(!config.use_built_in_root_certificates);
+                    tls.disable_built_in_roots(!config.tls_built_in_root_certs);
 
                     for cert in config.root_certs {
                         cert.add_to_native_tls(&mut tls);
@@ -267,12 +267,12 @@ impl ClientBuilder {
                         tls.set_protocols(&["h2".into(), "http/1.1".into()]);
                     }
                     #[cfg(feature = "rustls-tls-webpki-roots")]
-                    if config.use_built_in_root_certificates {
+                    if config.tls_built_in_root_certs {
                     tls.root_store
                         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
                     }
                     #[cfg(feature = "rustls-tls-native-roots")]
-                    if config.use_built_in_root_certificates {
+                    if config.tls_built_in_root_certs {
                         let roots_slice = NATIVE_ROOTS.as_ref().unwrap().roots.as_slice();
                         tls.root_store.roots.extend_from_slice(roots_slice);
                     }
@@ -736,11 +736,11 @@ impl ClientBuilder {
     /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
-    pub fn use_built_in_root_certificates(
+    pub fn tls_built_in_root_certs(
         mut self,
-        use_built_in_root_certificates: bool,
+        tls_built_in_root_certs: bool,
     ) -> ClientBuilder {
-        self.config.use_built_in_root_certificates = use_built_in_root_certificates;
+        self.config.tls_built_in_root_certs = tls_built_in_root_certs;
         self
     }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -94,6 +94,8 @@ struct Config {
     #[cfg(feature = "__tls")]
     root_certs: Vec<Certificate>,
     #[cfg(feature = "__tls")]
+    use_built_in_root_certificates: bool,
+    #[cfg(feature = "__tls")]
     tls: TlsBackend,
     http2_only: bool,
     http1_title_case_headers: bool,
@@ -145,6 +147,8 @@ impl ClientBuilder {
                 timeout: None,
                 #[cfg(feature = "__tls")]
                 root_certs: Vec::new(),
+                #[cfg(feature = "__tls")]
+                use_built_in_root_certificates: true,
                 #[cfg(feature = "__tls")]
                 identity: None,
                 #[cfg(feature = "__tls")]
@@ -209,6 +213,8 @@ impl ClientBuilder {
 
                     tls.danger_accept_invalid_certs(!config.certs_verification);
 
+                    tls.disable_built_in_roots(!config.use_built_in_root_certificates);
+
                     for cert in config.root_certs {
                         cert.add_to_native_tls(&mut tls);
                     }
@@ -261,10 +267,12 @@ impl ClientBuilder {
                         tls.set_protocols(&["h2".into(), "http/1.1".into()]);
                     }
                     #[cfg(feature = "rustls-tls-webpki-roots")]
+                    if config.use_built_in_root_certificates {
                     tls.root_store
                         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+                    }
                     #[cfg(feature = "rustls-tls-native-roots")]
-                    {
+                    if config.use_built_in_root_certificates {
                         let roots_slice = NATIVE_ROOTS.as_ref().unwrap().roots.as_slice();
                         tls.root_store.roots.extend_from_slice(roots_slice);
                     }
@@ -716,6 +724,23 @@ impl ClientBuilder {
     #[cfg(feature = "__tls")]
     pub fn add_root_certificate(mut self, cert: Certificate) -> ClientBuilder {
         self.config.root_certs.push(cert);
+        self
+    }
+
+    /// Controls the use of built-in system certificates during certificate validation.
+    ///
+    /// Defaults to `true` -- built-in system certs will be used.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
+    pub fn use_built_in_root_certificates(
+        mut self,
+        use_built_in_root_certificates: bool,
+    ) -> ClientBuilder {
+        self.config.use_built_in_root_certificates = use_built_in_root_certificates;
         self
     }
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -442,11 +442,11 @@ impl ClientBuilder {
     /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
     /// feature to be enabled.
     #[cfg(feature = "__tls")]
-    pub fn use_built_in_root_certificates(
+    pub fn tls_built_in_root_certs(
         self,
-        use_built_in_root_certificates: bool,
+        tls_built_in_root_certs: bool,
     ) -> ClientBuilder {
-        self.with_inner(move |inner| inner.use_built_in_root_certificates(use_built_in_root_certificates))
+        self.with_inner(move |inner| inner.tls_built_in_root_certs(tls_built_in_root_certs))
     }
 
     /// Sets the identity to be used for client certificate authentication.

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -433,6 +433,22 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.add_root_certificate(cert))
     }
 
+    /// Controls the use of built-in system certificates during certificate validation.
+    ///         
+    /// Defaults to `true` -- built-in system certs will be used.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
+    pub fn use_built_in_root_certificates(
+        self,
+        use_built_in_root_certificates: bool,
+    ) -> ClientBuilder {
+        self.with_inner(move |inner| inner.use_built_in_root_certificates(use_built_in_root_certificates))
+    }
+
     /// Sets the identity to be used for client certificate authentication.
     #[cfg(feature = "__tls")]
     pub fn identity(self, identity: Identity) -> ClientBuilder {

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -59,6 +59,21 @@ async fn test_badssl_self_signed() {
     assert!(text.contains("<title>self-signed.badssl.com</title>"));
 }
 
+#[cfg(feature = "__tls")]
+#[tokio::test]
+async fn test_badssl_no_built_in_roots() {
+    let result = reqwest::Client::builder()
+        .use_built_in_root_certificates(false)
+        .no_proxy()
+        .build()
+        .unwrap()
+        .get("https://mozilla-modern.badssl.com/")
+        .send()
+        .await;
+
+    assert!(result.is_err());
+}
+
 #[cfg(feature = "native-tls")]
 #[tokio::test]
 async fn test_badssl_wrong_host() {

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -63,7 +63,7 @@ async fn test_badssl_self_signed() {
 #[tokio::test]
 async fn test_badssl_no_built_in_roots() {
     let result = reqwest::Client::builder()
-        .use_built_in_root_certificates(false)
+        .tls_built_in_root_certs(false)
         .no_proxy()
         .build()
         .unwrap()


### PR DESCRIPTION
Allows not using built-in certificates, but only certificates provided with `add_root_certificate`.