### PR TITLE
Marked sensitive headers as such in docs

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -405,7 +405,12 @@ impl ClientBuilder {
     /// use reqwest::header;
     /// # async fn doc() -> Result<(), reqwest::Error> {
     /// let mut headers = header::HeaderMap::new();
-    /// headers.insert(header::AUTHORIZATION, header::HeaderValue::from_static("secret"));
+    /// headers.insert("X-MY-HEADER", header::HeaderValue::from_static("value"));
+    ///
+    /// // Consider marking security-sensitive headers with `set_sensitive`.
+    /// let mut auth_value = header::HeaderValue::from_static("secret");
+    /// auth_value.set_sensitive(true);
+    /// headers.insert(header::AUTHORIZATION, auth_value);
     ///
     /// // get a client builder
     /// let client = reqwest::Client::builder()
@@ -422,7 +427,7 @@ impl ClientBuilder {
     /// use reqwest::header;
     /// # async fn doc() -> Result<(), reqwest::Error> {
     /// let mut headers = header::HeaderMap::new();
-    /// headers.insert(header::AUTHORIZATION, header::HeaderValue::from_static("secret"));
+    /// headers.insert("X-MY-HEADER", header::HeaderValue::from_static("value"));
     ///
     /// // get a client builder
     /// let client = reqwest::Client::builder()
@@ -430,7 +435,7 @@ impl ClientBuilder {
     ///     .build()?;
     /// let res = client
     ///     .get("https://www.rust-lang.org")
-    ///     .header(header::AUTHORIZATION, "token")
+    ///     .header("X-MY-HEADER", "new_value")
     ///     .send()
     ///     .await?;
     /// # Ok(())

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -136,7 +136,13 @@ impl ClientBuilder {
     /// use reqwest::header;
     /// # fn build_client() -> Result<(), reqwest::Error> {
     /// let mut headers = header::HeaderMap::new();
+    /// headers.insert("X-MY-HEADER", header::HeaderValue::from_static("value"));
     /// headers.insert(header::AUTHORIZATION, header::HeaderValue::from_static("secret"));
+    ///
+    /// // Consider marking security-sensitive headers with `set_sensitive`.
+    /// let mut auth_value = header::HeaderValue::from_static("secret");
+    /// auth_value.set_sensitive(true);
+    /// headers.insert(header::AUTHORIZATION, auth_value);
     ///
     /// // get a client builder
     /// let client = reqwest::blocking::Client::builder()
@@ -153,7 +159,7 @@ impl ClientBuilder {
     /// use reqwest::header;
     /// # fn build_client() -> Result<(), reqwest::Error> {
     /// let mut headers = header::HeaderMap::new();
-    /// headers.insert(header::AUTHORIZATION, header::HeaderValue::from_static("secret"));
+    /// headers.insert("X-MY-HEADER", header::HeaderValue::from_static("value"));
     ///
     /// // get a client builder
     /// let client = reqwest::blocking::Client::builder()
@@ -161,7 +167,7 @@ impl ClientBuilder {
     ///     .build()?;
     /// let res = client
     ///     .get("https://www.rust-lang.org")
-    ///     .header(header::AUTHORIZATION, "token")
+    ///     .header("X-MY-HEADER", "new_value")
     ///     .send()?;
     /// # Ok(())
     /// # }


### PR DESCRIPTION
Fixes #1158 

This changes the documentation in a few places which show how to set headers on a client. The documentation was using the Authorization header as an example, but not marking the header as sensitive. This PR changes the examples, adding a non-Authorization header, as well as marking the Authorization header as sensitive.