### PR TITLE
Fix Android CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
       - name: Build
         uses: actions-rs/cargo@v1
         with:
+          use-cross: true
           command: build
           # disable default-tls feature since cross-compiling openssl is dragons
           args: --target aarch64-linux-android --no-default-features


### PR DESCRIPTION
Use "cross" to cross-compile reqwest for Android. The job currently
errors out because the default linker doesn't know what to do with
object files generated for Android.