### PR TITLE
Add charset() method to Response

### DIFF
--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -300,6 +300,16 @@ impl Response {
         })
     }
 
+    /// Return the encoding declared in the `Content-Type` header, if any.
+    ///
+    /// This can be used with a library such as [`encoding_rs`] to perform
+    /// manual decoding if `text` and `text_with_charset` are too restrictive.
+    ///
+    /// [`encoding_rs`]: https://docs.rs/encoding_rs
+    pub fn charset(&self) -> Option<String> {
+        self.inner.charset()
+    }
+
     /// Copy the response body into a writer.
     ///
     /// This function internally uses [`std::io::copy`] and hence will continuously read data from


### PR DESCRIPTION
This moves the logic in `text_with_charset()` into its own public method.

My use case is a streaming decode of the response using `encoding_rs_io`. For now I [copy/pasted](https://github.com/blyxxyz/ht/blob/6829be32cf5a2b6994afea4c529f5f8e8cd4407e/src/printer.rs#L293) from `text_with_charset()` but that's a little ugly.