### PR TITLE
Update native-tls to v0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ ipnet = "2.3"
 
 ## default-tls
 hyper-tls = { version = "0.5", optional = true }
-native-tls-crate = { version = "0.2", optional = true, package = "native-tls" }
+native-tls-crate = { version = "0.2.7", optional = true, package = "native-tls" }
 tokio-native-tls = { version = "0.3.0", optional = true }
 
 # rustls-tls


### PR DESCRIPTION
Update to v0.2.7 to prevent possible build error (#1181) caused by incompatible native-tls version < v0.2.7