### PR TITLE
Bump mime to current version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ http-body = "0.4.0"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
 lazy_static = "1.4"
 log = "0.4"
-mime = "0.3.7"
+mime = "0.3.16"
 percent-encoding = "2.1"
 tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
 pin-project-lite = "0.2.0"


### PR DESCRIPTION
mime v0.3.7 isn't compatible with `-Z minimal_versions`.