### PR TITLE
Add minimal versions check for nightly CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,13 @@ jobs:
           command: test
           args: --features __internal_proxy_sys_no_cache -- --test-threads=1
 
+      - name: Check minimal versions
+        run: |
+          cargo clean
+          cargo update -Z minimal-versions
+          cargo check
+          cargo check --all-features
+
   minversion:
     name: Minimum version ${{ matrix.rust }}
     needs: [style]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ async-compression = { version = "0.3.7", default-features = false, features = ["
 tokio-util = { version = "0.6.0", default-features = false, features = ["codec", "io"], optional = true }
 
 ## socks
-tokio-socks = { version = "0.5", optional = true }
+tokio-socks = { version = "0.5.1", optional = true }
 
 ## trust-dns
 trust-dns-resolver = { version = "0.20", optional = true }


### PR DESCRIPTION
I bumped `tokio-socks` because 0.5.0 pulls `futures` and that breaks with `-Z minimal-versions` 