### PR TITLE
Refactor IntoUrl trait

### DIFF
--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -11,10 +11,12 @@ impl IntoUrl for String {}
 impl<'a> IntoUrl for &'a str {}
 impl<'a> IntoUrl for &'a String {}
 
-pub trait IntoUrlSealed: AsRef<str> {
+pub trait IntoUrlSealed {
     // Besides parsing as a valid `Url`, the `Url` must be a valid
     // `http::Uri`, in that it makes sense to use in a network request.
     fn into_url(self) -> crate::Result<Url>;
+
+    fn as_str(&self) -> &str;
 }
 
 impl IntoUrlSealed for Url {
@@ -25,11 +27,19 @@ impl IntoUrlSealed for Url {
             Err(crate::error::url_bad_scheme(self))
         }
     }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 impl<'a> IntoUrlSealed for &'a str {
     fn into_url(self) -> crate::Result<Url> {
         Url::parse(self).map_err(crate::error::builder)?.into_url()
+    }
+
+    fn as_str(&self) -> &str {
+        self
     }
 }
 
@@ -37,11 +47,19 @@ impl<'a> IntoUrlSealed for &'a String {
     fn into_url(self) -> crate::Result<Url> {
         (&**self).into_url()
     }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 impl<'a> IntoUrlSealed for String {
     fn into_url(self) -> crate::Result<Url> {
         (&*self).into_url()
+    }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
     }
 }
 

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -3,21 +3,21 @@ use url::Url;
 /// A trait to try to convert some type into a `Url`.
 ///
 /// This trait is "sealed", such that only types within reqwest can
-/// implement it. The reason is that it will eventually be deprecated
-/// and removed, when `std::convert::TryFrom` is stabilized.
-pub trait IntoUrl: PolyfillTryInto {}
+/// implement it.
+pub trait IntoUrl: IntoUrlSealed {}
 
-impl<T: PolyfillTryInto> IntoUrl for T {}
+impl IntoUrl for Url {}
+impl IntoUrl for String {}
+impl<'a> IntoUrl for &'a str {}
+impl<'a> IntoUrl for &'a String {}
 
-pub trait PolyfillTryInto {
+pub trait IntoUrlSealed: AsRef<str> {
     // Besides parsing as a valid `Url`, the `Url` must be a valid
     // `http::Uri`, in that it makes sense to use in a network request.
     fn into_url(self) -> crate::Result<Url>;
-
-    fn _as_str(&self) -> &str;
 }
 
-impl PolyfillTryInto for Url {
+impl IntoUrlSealed for Url {
     fn into_url(self) -> crate::Result<Url> {
         if self.has_host() {
             Ok(self)
@@ -25,29 +25,23 @@ impl PolyfillTryInto for Url {
             Err(crate::error::url_bad_scheme(self))
         }
     }
-
-    fn _as_str(&self) -> &str {
-        self.as_ref()
-    }
 }
 
-impl<'a> PolyfillTryInto for &'a str {
+impl<'a> IntoUrlSealed for &'a str {
     fn into_url(self) -> crate::Result<Url> {
         Url::parse(self).map_err(crate::error::builder)?.into_url()
     }
-
-    fn _as_str(&self) -> &str {
-        self.as_ref()
-    }
 }
 
-impl<'a> PolyfillTryInto for &'a String {
+impl<'a> IntoUrlSealed for &'a String {
     fn into_url(self) -> crate::Result<Url> {
         (&**self).into_url()
     }
+}
 
-    fn _as_str(&self) -> &str {
-        self.as_ref()
+impl<'a> IntoUrlSealed for String {
+    fn into_url(self) -> crate::Result<Url> {
+        (&*self).into_url()
     }
 }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -111,11 +111,11 @@ pub trait IntoProxyScheme {
 impl<S: IntoUrl> IntoProxyScheme for S {
     fn into_proxy_scheme(self) -> crate::Result<ProxyScheme> {
         // validate the URL
-        let url = match self.as_ref().into_url() {
+        let url = match self.as_str().into_url() {
             Ok(ok) => ok,
             Err(e) => {
                 // the issue could have been caused by a missing scheme, so we try adding http://
-                format!("http://{}", self.as_ref())
+                format!("http://{}", self.as_str())
                     .into_url()
                     .map_err(|_| {
                         // return the original error

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use crate::into_url::{IntoUrl, PolyfillTryInto};
+use crate::into_url::{IntoUrl, IntoUrlSealed};
 use crate::Url;
 use http::{header::HeaderValue, Uri};
 use ipnet::IpNet;
@@ -111,11 +111,11 @@ pub trait IntoProxyScheme {
 impl<S: IntoUrl> IntoProxyScheme for S {
     fn into_proxy_scheme(self) -> crate::Result<ProxyScheme> {
         // validate the URL
-        let url = match self._as_str().into_url() {
+        let url = match self.as_ref().into_url() {
             Ok(ok) => ok,
             Err(e) => {
                 // the issue could have been caused by a missing scheme, so we try adding http://
-                format!("http://{}", self._as_str())
+                format!("http://{}", self.as_ref())
                     .into_url()
                     .map_err(|_| {
                         // return the original error


### PR DESCRIPTION
- Rename `PolyfillTryInto` to `SealedIntoUrl`
- `impl IntoUrl for String`
- Add implementations for `IntoUrl` individually so that they show up in the docs
- ~~Remove `_as_str` method from `SealedIntoUrl` and make `AsRef<str>` a supertrait instead~~