### PR TITLE
Updated documentation in examples

### DIFF
--- a/examples/form.rs
+++ b/examples/form.rs
@@ -1,5 +1,8 @@
 // Short example of a POST request with form data.
 //
+// This is using the `tokio` runtime. You'll need the following dependency:
+//
+// `tokio = { version = "1", features = ["full"] }`
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() {

--- a/examples/json_dynamic.rs
+++ b/examples/json_dynamic.rs
@@ -6,7 +6,7 @@
 
 // This is using the `tokio` runtime. You'll need the following dependency:
 //
-// `tokio = { version = "0.2", features = ["macros"] }`
+// `tokio = { version = "1", features = ["full"] }`
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
     let echo_json: serde_json::Value = reqwest::Client::new()

--- a/examples/json_typed.rs
+++ b/examples/json_typed.rs
@@ -18,7 +18,7 @@ struct Post {
 
 // This is using the `tokio` runtime. You'll need the following dependency:
 //
-// `tokio = { version = "0.2", features = ["macros"] }`
+// `tokio = { version = "1", features = ["full"] }`
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
     let new_post = Post {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@
 
 // This is using the `tokio` runtime. You'll need the following dependency:
 //
-// `tokio = { version = "0.2", features = ["macros"] }`
+// `tokio = { version = "1", features = ["full"] }`
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {

--- a/examples/tor_socks.rs
+++ b/examples/tor_socks.rs
@@ -2,7 +2,7 @@
 
 // This is using the `tokio` runtime. You'll need the following dependency:
 //
-// `tokio = { version = "0.2", features = ["macros"] }`
+// `tokio = { version = "1", features = ["full"] }`
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
     // Make sure you are running tor and this is your socks port


### PR DESCRIPTION
Documentation in examples recommends using `tokio 0.2` as dependency, while README.md recomends `tokio 1`.
I've updated comments in examples according to readme.