### PR TITLE
impl From<hyper::Body> for Body

### DIFF
--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -161,6 +161,18 @@ impl Body {
     }
 }
 
+impl From<hyper::Body> for Body {
+    #[inline]
+    fn from(body: hyper::Body) -> Body {
+        Self {
+            inner: Inner::Streaming {
+                body: Box::pin(WrapHyper(body)),
+                timeout: None,
+            },
+        }
+    }
+}
+
 impl From<Bytes> for Body {
     #[inline]
     fn from(bytes: Bytes) -> Body {


### PR DESCRIPTION
This implements a conversion from `hyper::Body` to `reqwest::Body`,
which in turn enables converting a `http::Request<hyper::Body>` into
`reqwest::Request` through the existing `TryFrom` implementation.

Fixes #1156.