### PR TITLE
Support Deflate decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           - "feat.: blocking"
           - "feat.: gzip"
           - "feat.: brotli"
+          - "feat.: deflate"
           - "feat.: json"
           - "feat.: multipart"
           - "feat.: stream"
@@ -89,21 +90,21 @@ jobs:
           - name: windows / stable-x86_64-msvc
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            features: "--features blocking,gzip,brotli,json,multipart"
+            features: "--features blocking,gzip,brotli,deflate,json,multipart"
           - name: windows / stable-i686-msvc
             os: windows-latest
             target: i686-pc-windows-msvc
-            features: "--features blocking,gzip,brotli,json,multipart"
+            features: "--features blocking,gzip,brotli,deflate,json,multipart"
           - name: windows / stable-x86_64-gnu
             os: windows-latest
             rust: stable-x86_64-pc-windows-gnu
             target: x86_64-pc-windows-gnu
-            features: "--features blocking,gzip,brotli,json,multipart"
+            features: "--features blocking,gzip,brotli,deflate,json,multipart"
           - name: windows / stable-i686-gnu
             os: windows-latest
             rust: stable-i686-pc-windows-gnu
             target: i686-pc-windows-gnu
-            features: "--features blocking,gzip,brotli,json,multipart"
+            features: "--features blocking,gzip,brotli,deflate,json,multipart"
 
           - name: "feat.: default-tls disabled"
             features: "--no-default-features"
@@ -123,6 +124,8 @@ jobs:
             features: "--features gzip"
           - name: "feat.: brotli"
             features: "--features brotli"
+          - name: "feat.: deflate"
+            features: "--features deflate"
           - name: "feat.: json"
             features: "--features json"
           - name: "feat.: multipart"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ gzip = ["async-compression", "async-compression/gzip", "tokio-util"]
 
 brotli = ["async-compression", "async-compression/brotli", "tokio-util"]
 
+deflate = ["async-compression", "async-compression/deflate", "tokio-util"]
+
 json = ["serde_json"]
 
 multipart = ["mime_guess"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,11 @@ path = "tests/brotli.rs"
 required-features = ["brotli"]
 
 [[test]]
+name = "deflate"
+path = "tests/deflate.rs"
+required-features = ["deflate"]
+
+[[test]]
 name = "multipart"
 path = "tests/multipart.rs"
 required-features = ["multipart"]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -536,6 +536,29 @@ impl ClientBuilder {
         self
     }
 
+    /// Enable auto deflate decompression by checking the `Content-Encoding` response header.
+    ///
+    /// If auto deflate decompression is turned on:
+    ///
+    /// - When sending a request and if the request's headers do not already contain
+    ///   an `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to `deflate`.
+    ///   The request body is **not** automatically compressed.
+    /// - When receiving a response, if it's headers contain a `Content-Encoding` value that
+    ///   equals to `deflate`, both values `Content-Encoding` and `Content-Length` are removed from the
+    ///   headers' set. The response body is automatically decompressed.
+    ///
+    /// If the `deflate` feature is turned on, the default option is enabled.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `deflate` feature to be enabled
+    #[cfg(feature = "deflate")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
+    pub fn deflate(mut self, enable: bool) -> ClientBuilder {
+        self.config.accepts.deflate = enable;
+        self
+    }
+
     /// Disable auto response body gzip decompression.
     ///
     /// This method exists even if the optional `gzip` feature is not enabled.
@@ -565,6 +588,23 @@ impl ClientBuilder {
         }
 
         #[cfg(not(feature = "brotli"))]
+        {
+            self
+        }
+    }
+
+    /// Disable auto response body deflate decompression.
+    ///
+    /// This method exists even if the optional `deflate` feature is not enabled.
+    /// This can be used to ensure a `Client` doesn't use deflate decompression
+    /// even if another dependency were to enable the optional `deflate` feature.
+    pub fn no_deflate(self) -> ClientBuilder {
+        #[cfg(feature = "deflate")]
+        {
+            self.deflate(false)
+        }
+
+        #[cfg(not(feature = "deflate"))]
         {
             self
         }

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -183,13 +183,13 @@ impl Decoder {
         use http::header::{CONTENT_ENCODING, CONTENT_LENGTH, TRANSFER_ENCODING};
         use log::warn;
 
-        let content_encoding_gzip: bool;
+        let content_encoding_brotli: bool;
         let mut is_brotli = {
-            content_encoding_gzip = headers
+            content_encoding_brotli = headers
                 .get_all(CONTENT_ENCODING)
                 .iter()
                 .any(|enc| enc == "br");
-            content_encoding_gzip
+            content_encoding_brotli
                 || headers
                     .get_all(TRANSFER_ENCODING)
                     .iter()

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -257,6 +257,28 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.brotli(enable))
     }
 
+    /// Enable auto deflate decompression by checking the `Content-Encoding` response header.
+    ///
+    /// If auto deflate decompresson is turned on:
+    ///
+    /// - When sending a request and if the request's headers do not already contain
+    ///   an `Accept-Encoding` **and** `Range` values, the `Accept-Encoding` header is set to `deflate`.
+    ///   The request body is **not** automatically compressed.
+    /// - When receiving a response, if it's headers contain a `Content-Encoding` value that
+    ///   equals to `deflate`, both values `Content-Encoding` and `Content-Length` are removed from the
+    ///   headers' set. The response body is automatically decompressed.
+    ///
+    /// If the `deflate` feature is turned on, the default option is enabled.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `deflate` feature to be enabled
+    #[cfg(feature = "deflate")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "deflate")))]
+    pub fn deflate(self, enable: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.deflate(enable))
+    }
+
     /// Disable auto response body gzip decompression.
     ///
     /// This method exists even if the optional `gzip` feature is not enabled.
@@ -273,6 +295,15 @@ impl ClientBuilder {
     /// even if another dependency were to enable the optional `brotli` feature.
     pub fn no_brotli(self) -> ClientBuilder {
         self.with_inner(|inner| inner.no_brotli())
+    }
+
+    /// Disable auto response body deflate decompression.
+    ///
+    /// This method exists even if the optional `deflate` feature is not enabled.
+    /// This can be used to ensure a `Client` doesn't use deflate decompression
+    /// even if another dependency were to enable the optional `deflate` feature.
+    pub fn no_deflate(self) -> ClientBuilder {
+        self.with_inner(|inner| inner.no_deflate())
     }
 
     // Redirect options

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@
 //! - **cookies**: Provides cookie session support.
 //! - **gzip**: Provides response body gzip decompression.
 //! - **brotli**: Provides response body brotli decompression.
+//! - **deflate**: Provides response body deflate decompression.
 //! - **json**: Provides serialization and deserialization for JSON bodies.
 //! - **multipart**: Provides functionality for multipart forms.
 //! - **stream**: Adds support for `futures::Stream`.

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -24,6 +24,12 @@ async fn auto_headers() {
                 .unwrap()
                 .contains("br"));
         }
+        if cfg!(feature = "deflate") {
+            assert!(req.headers()["accept-encoding"]
+                .to_str()
+                .unwrap()
+                .contains("deflate"));
+        }
 
         http::Response::default()
     });

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -1,5 +1,4 @@
 mod support;
-use std::io::Read;
 use support::*;
 
 #[tokio::test]
@@ -86,13 +85,11 @@ async fn test_accept_encoding_header_is_not_changed_if_set() {
 }
 
 async fn deflate_case(response_size: usize, chunk_size: usize) {
-    use futures_util::stream::StreamExt;
-
     let content: String = (0..response_size)
         .into_iter()
         .map(|i| format!("test {}", i))
         .collect();
-    let mut encoder = libflate::deflate::Encoder::new(Vec::new()).unwrap();
+    let mut encoder = libflate::deflate::Encoder::new(Vec::new());
     match encoder.write(content.as_bytes()) {
         Ok(n) => assert!(n > 0, "Failed to write to encoder."),
         _ => panic!("Failed to deflate encode string."),

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -1,4 +1,5 @@
 mod support;
+use std::io::Write;
 use support::*;
 
 #[tokio::test]
@@ -85,6 +86,8 @@ async fn test_accept_encoding_header_is_not_changed_if_set() {
 }
 
 async fn deflate_case(response_size: usize, chunk_size: usize) {
+    use futures_util::stream::StreamExt;
+
     let content: String = (0..response_size)
         .into_iter()
         .map(|i| format!("test {}", i))

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -1,0 +1,150 @@
+mod support;
+use std::io::Read;
+use support::*;
+
+#[tokio::test]
+async fn deflate_response() {
+    deflate_case(10_000, 4096).await;
+}
+
+#[tokio::test]
+async fn deflate_single_byte_chunks() {
+    deflate_case(10, 1).await;
+}
+
+#[tokio::test]
+async fn test_deflate_empty_body() {
+    let server = server::http(move |req| async move {
+        assert_eq!(req.method(), "HEAD");
+
+        http::Response::builder()
+            .header("content-encoding", "deflate")
+            .header("content-length", 100)
+            .body(Default::default())
+            .unwrap()
+    });
+
+    let client = reqwest::Client::new();
+    let res = client
+        .head(&format!("http://{}/deflate", server.addr()))
+        .send()
+        .await
+        .unwrap();
+
+    let body = res.text().await.unwrap();
+
+    assert_eq!(body, "");
+}
+
+#[tokio::test]
+async fn test_accept_header_is_not_changed_if_set() {
+    let server = server::http(move |req| async move {
+        assert_eq!(req.headers()["accept"], "application/json");
+        assert!(req.headers()["accept-encoding"]
+            .to_str()
+            .unwrap()
+            .contains("deflate"));
+        http::Response::default()
+    });
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(&format!("http://{}/accept", server.addr()))
+        .header(
+            reqwest::header::ACCEPT,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_accept_encoding_header_is_not_changed_if_set() {
+    let server = server::http(move |req| async move {
+        assert_eq!(req.headers()["accept"], "*/*");
+        assert_eq!(req.headers()["accept-encoding"], "identity");
+        http::Response::default()
+    });
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(&format!("http://{}/accept-encoding", server.addr()))
+        .header(
+            reqwest::header::ACCEPT_ENCODING,
+            reqwest::header::HeaderValue::from_static("identity"),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+}
+
+async fn deflate_case(response_size: usize, chunk_size: usize) {
+    use futures_util::stream::StreamExt;
+
+    let content: String = (0..response_size)
+        .into_iter()
+        .map(|i| format!("test {}", i))
+        .collect();
+    let mut encoder = libflate::deflate::Encoder::new(Vec::new()).unwrap();
+    match encoder.write(content.as_bytes()) {
+        Ok(n) => assert!(n > 0, "Failed to write to encoder."),
+        _ => panic!("Failed to gzip encode string."),
+    };
+
+    let gzipped_content = encoder.finish().into_result().unwrap();
+
+    let mut response = format!(
+        "\
+         HTTP/1.1 200 OK\r\n\
+         Server: test-accept\r\n\
+         Content-Encoding: gzip\r\n\
+         Content-Length: {}\r\n\
+         \r\n",
+        &gzipped_content.len()
+    )
+    .into_bytes();
+    response.extend(&gzipped_content);
+
+    let server = server::http(move |req| {
+        assert!(req.headers()["accept-encoding"]
+            .to_str()
+            .unwrap()
+            .contains("gzip"));
+
+        let gzipped = gzipped_content.clone();
+        async move {
+            let len = gzipped.len();
+            let stream =
+                futures_util::stream::unfold((gzipped, 0), move |(gzipped, pos)| async move {
+                    let chunk = gzipped.chunks(chunk_size).nth(pos)?.to_vec();
+
+                    Some((chunk, (gzipped, pos + 1)))
+                });
+
+            let body = hyper::Body::wrap_stream(stream.map(Ok::<_, std::convert::Infallible>));
+
+            http::Response::builder()
+                .header("content-encoding", "gzip")
+                .header("content-length", len)
+                .body(body)
+                .unwrap()
+        }
+    });
+
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(&format!("http://{}/gzip", server.addr()))
+        .send()
+        .await
+        .expect("response");
+
+    let body = res.text().await.expect("text");
+    assert_eq!(body, content);}


### PR DESCRIPTION
Also adds `deflate()` and `no_deflate()` methods.


One thing I should mention is that I was able to confirm that this works with `http://example.org` with the header `accept-encoding: deflate`. The same cannot be said about `httpbin.org/deflate` which fails with `deflate decompression error`.