### PR TITLE
Use ZlibDecoder for decoding deflate responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ gzip = ["async-compression", "async-compression/gzip", "tokio-util"]
 
 brotli = ["async-compression", "async-compression/brotli", "tokio-util"]
 
-deflate = ["async-compression", "async-compression/deflate", "tokio-util"]
+deflate = ["async-compression", "async-compression/zlib", "tokio-util"]
 
 json = ["serde_json"]
 
@@ -197,6 +197,7 @@ path = "examples/form.rs"
 [[example]]
 name = "simple"
 path = "examples/simple.rs"
+required-features = ["deflate"]
 
 [[test]]
 name = "blocking"

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -10,7 +10,7 @@ use async_compression::tokio::bufread::GzipDecoder;
 use async_compression::tokio::bufread::BrotliDecoder;
 
 #[cfg(feature = "deflate")]
-use async_compression::tokio::bufread::DeflateDecoder;
+use async_compression::tokio::bufread::ZlibDecoder;
 
 use bytes::Bytes;
 use futures_core::Stream;
@@ -57,7 +57,7 @@ enum Inner {
 
     /// A `Deflate` decoder will uncompress the deflated response content before returning it.
     #[cfg(feature = "deflate")]
-    Deflate(FramedRead<DeflateDecoder<StreamReader<Peekable<IoStream>, Bytes>>, BytesCodec>),
+    Deflate(FramedRead<ZlibDecoder<StreamReader<Peekable<IoStream>, Bytes>>, BytesCodec>),
 
     /// A decoder that doesn't have a value yet.
     #[cfg(any(feature = "brotli", feature = "gzip", feature = "deflate"))]
@@ -321,7 +321,7 @@ impl Future for Pending {
             )))),
             #[cfg(feature = "deflate")]
             DecoderType::Deflate => Poll::Ready(Ok(Inner::Deflate(FramedRead::new(
-                DeflateDecoder::new(StreamReader::new(_body)),
+                ZlibDecoder::new(StreamReader::new(_body)),
                 BytesCodec::new(),
             )))),
         }

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -92,7 +92,7 @@ async fn deflate_case(response_size: usize, chunk_size: usize) {
         .into_iter()
         .map(|i| format!("test {}", i))
         .collect();
-    let mut encoder = libflate::deflate::Encoder::new(Vec::new());
+    let mut encoder = libflate::zlib::Encoder::new(Vec::new()).unwrap();
     match encoder.write(content.as_bytes()) {
         Ok(n) => assert!(n > 0, "Failed to write to encoder."),
         _ => panic!("Failed to deflate encode string."),


### PR DESCRIPTION
As pointed out by @blankname in https://github.com/seanmonstar/reqwest/pull/1250, section [3.5](https://tools.ietf.org/html/rfc2616#section-3.5) of the Hypertext Transfer Protocol RFC defines deflate as The "zlib" format in combination with the "deflate" compression. Also, see https://stackoverflow.com/a/3932260/5915221.

It would be nice if reqwest could distinguish raw deflate from Zlib wrapped deflate but I think that could be a future enhancement. 