### PR TITLE
Implement "default" functions of the trait to fix "insecure" mode

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "__rustls")]
-use rustls::{RootCertStore, ServerCertVerified, ServerCertVerifier, TLSError};
+use rustls::{
+    internal::msgs::handshake::DigitallySignedStruct, HandshakeSignatureValid, RootCertStore,
+    ServerCertVerified, ServerCertVerifier, TLSError,
+};
 use std::fmt;
 #[cfg(feature = "__rustls")]
 use tokio_rustls::webpki::DNSNameRef;
@@ -322,6 +325,24 @@ impl ServerCertVerifier for NoVerifier {
         _ocsp_response: &[u8],
     ) -> Result<ServerCertVerified, TLSError> {
         Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TLSError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TLSError> {
+        Ok(HandshakeSignatureValid::assertion())
     }
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -330,7 +330,7 @@ impl ServerCertVerifier for NoVerifier {
     fn verify_tls12_signature(
         &self,
         _message: &[u8],
-        _cert: &Certificate,
+        _cert: &rustls::Certificate,
         _dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, TLSError> {
         Ok(HandshakeSignatureValid::assertion())
@@ -339,7 +339,7 @@ impl ServerCertVerifier for NoVerifier {
     fn verify_tls13_signature(
         &self,
         _message: &[u8],
-        _cert: &Certificate,
+        _cert: &rustls::Certificate,
         _dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, TLSError> {
         Ok(HandshakeSignatureValid::assertion())


### PR DESCRIPTION
Ignoring validation seems broken as some default functions actually do
check. That is fine for the proper TLS validation, but gets in the way
when someone wants to skip TLS validation (e.g. for self-signed
certificates).

This change re-implements these default functions in a way that they
do not check, but return "success" all the time.

Fixes #1210