### PR TITLE
Add missing `as_bytes` method to wasm `Body` implementation

### DIFF
--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -35,7 +35,6 @@ impl Body {
             Inner::Multipart(_) => None,
         }
     }
-    
     pub(crate) fn to_js_value(&self) -> crate::Result<JsValue> {
         match &self.inner {
             Inner::Bytes(body_bytes) => {


### PR DESCRIPTION
Looks like there is no `as_bytes` method for `Body` type