### PR TITLE
Remove Client from RequestBuilder

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -27,7 +27,7 @@ use tokio::time::Sleep;
 use log::debug;
 
 use super::decoder::Accepts;
-use super::request::{Request, RequestBuilder};
+use super::request::{Request, DeprecatedRequestBuilder};
 use super::response::Response;
 use super::Body;
 use crate::connect::{Connector, HttpConnector};
@@ -1064,7 +1064,7 @@ impl Client {
     /// # Errors
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
-    pub fn get<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn get<U: IntoUrl>(&self, url: U) -> DeprecatedRequestBuilder {
         self.request(Method::GET, url)
     }
 
@@ -1073,7 +1073,7 @@ impl Client {
     /// # Errors
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
-    pub fn post<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn post<U: IntoUrl>(&self, url: U) -> DeprecatedRequestBuilder {
         self.request(Method::POST, url)
     }
 
@@ -1082,7 +1082,7 @@ impl Client {
     /// # Errors
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
-    pub fn put<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn put<U: IntoUrl>(&self, url: U) -> DeprecatedRequestBuilder {
         self.request(Method::PUT, url)
     }
 
@@ -1091,7 +1091,7 @@ impl Client {
     /// # Errors
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
-    pub fn patch<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn patch<U: IntoUrl>(&self, url: U) -> DeprecatedRequestBuilder {
         self.request(Method::PATCH, url)
     }
 
@@ -1100,7 +1100,7 @@ impl Client {
     /// # Errors
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
-    pub fn delete<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn delete<U: IntoUrl>(&self, url: U) -> DeprecatedRequestBuilder {
         self.request(Method::DELETE, url)
     }
 
@@ -1109,21 +1109,21 @@ impl Client {
     /// # Errors
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
-    pub fn head<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn head<U: IntoUrl>(&self, url: U) -> DeprecatedRequestBuilder {
         self.request(Method::HEAD, url)
     }
 
     /// Start building a `Request` with the `Method` and `Url`.
     ///
-    /// Returns a `RequestBuilder`, which will allow setting headers and
+    /// Returns a `DeprecatedRequestBuilder`, which will allow setting headers and
     /// the request body before sending.
     ///
     /// # Errors
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
-    pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
+    pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> DeprecatedRequestBuilder {
         let req = url.into_url().map(move |url| Request::new(method, url));
-        RequestBuilder::new(self.clone(), req)
+        DeprecatedRequestBuilder::new(self.clone(), req)
     }
 
     /// Executes a `Request`.
@@ -1131,8 +1131,6 @@ impl Client {
     /// A `Request` can be built manually with `Request::new()` or obtained
     /// from a RequestBuilder with `RequestBuilder::build()`.
     ///
-    /// You should prefer to use the `RequestBuilder` and
-    /// `RequestBuilder::send()`.
     ///
     /// # Errors
     ///

--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -1,6 +1,6 @@
 pub use self::body::Body;
 pub use self::client::{Client, ClientBuilder};
-pub use self::request::{Request, RequestBuilder};
+pub use self::request::{Request, RequestBuilder, DeprecatedRequestBuilder};
 pub use self::response::{Response, ResponseBuilderExt};
 
 #[cfg(feature = "blocking")]

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -608,21 +608,10 @@ impl DeprecatedRequestBuilder {
         DeprecatedRequestBuilder {  request_builder: self.request_builder.header(key, value) }
     }
 
-    /// Add a `Header` to this Request with ability to define if header_value is sensitive.
-    fn header_sensitive<K, V>(mut self, key: K, value: V, sensitive: bool) -> DeprecatedRequestBuilder
-    where
-        HeaderName: TryFrom<K>,
-        <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
-        HeaderValue: TryFrom<V>,
-        <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
-    {
-        DeprecatedRequestBuilder {  request_builder: self.request_builder.header_sensitive(key, value, sensitive) }
-    }
-
     /// Add a set of Headers to the existing ones on this Request.
     ///
     /// The headers will be merged in to any already set.
-    pub fn headers(mut self, headers: crate::header::HeaderMap) -> DeprecatedRequestBuilder {
+    pub fn headers(self, headers: crate::header::HeaderMap) -> DeprecatedRequestBuilder {
         DeprecatedRequestBuilder {  request_builder: self.request_builder.headers(headers) }
     }
 
@@ -644,7 +633,7 @@ impl DeprecatedRequestBuilder {
     }
 
     /// Set the request body.
-    pub fn body<T: Into<Body>>(mut self, body: T) -> DeprecatedRequestBuilder {
+    pub fn body<T: Into<Body>>(self, body: T) -> DeprecatedRequestBuilder {
         DeprecatedRequestBuilder {  request_builder: self.request_builder.body(body) }
     }
 
@@ -653,7 +642,7 @@ impl DeprecatedRequestBuilder {
     /// The timeout is applied from when the request starts connecting until the
     /// response body has finished. It affects only this request and overrides
     /// the timeout configured using `ClientBuilder::timeout()`.
-    pub fn timeout(mut self, timeout: Duration) -> DeprecatedRequestBuilder {
+    pub fn timeout(self, timeout: Duration) -> DeprecatedRequestBuilder {
         DeprecatedRequestBuilder {  request_builder: self.request_builder.timeout(timeout) }
     }
 
@@ -700,17 +689,17 @@ impl DeprecatedRequestBuilder {
     /// # Errors
     /// This method will fail if the object you provide cannot be serialized
     /// into a query string.
-    pub fn query<T: Serialize + ?Sized>(mut self, query: &T) -> DeprecatedRequestBuilder {
+    pub fn query<T: Serialize + ?Sized>(self, query: &T) -> DeprecatedRequestBuilder {
         DeprecatedRequestBuilder {  request_builder: self.request_builder.query(query) }
     }
 
     /// Set HTTP version
-    pub fn version(mut self, version: Version) -> DeprecatedRequestBuilder {
+    pub fn version(self, version: Version) -> DeprecatedRequestBuilder {
         DeprecatedRequestBuilder {  request_builder: self.request_builder.version(version) }
     }
 
     /// Send a form body.
-    pub fn form<T: Serialize + ?Sized>(mut self, form: &T) -> DeprecatedRequestBuilder {
+    pub fn form<T: Serialize + ?Sized>(self, form: &T) -> DeprecatedRequestBuilder {
         DeprecatedRequestBuilder {  request_builder: self.request_builder.form(form) }
     }
 
@@ -808,6 +797,12 @@ impl DeprecatedRequestBuilder {
                         request: Ok(req),
                 }
             })
+    }
+}
+
+impl fmt::Debug for DeprecatedRequestBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.request_builder.fmt(f)
     }
 }
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -581,7 +581,7 @@ pub struct DeprecatedRequestBuilder {
 
 impl DeprecatedRequestBuilder {
     pub(super) fn new(client: Client, request: crate::Result<Request>) -> DeprecatedRequestBuilder {
-        let mut builder = DeprecatedRequestBuilder { request_builder : RequestBuilder { client, request } };
+        let mut builder = DeprecatedRequestBuilder { request_builder : RequestBuilder ::new (client, request ) };
 
         let auth = builder
             .request_builder

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -570,6 +570,344 @@ where
     }
 }
 
+/// A builder to construct the properties of a `Request`.
+///
+/// To construct a `RequestBuilder`, refer to the `Client` documentation.
+#[must_use = "RequestBuilder does nothing until you 'send' it"]
+pub struct DeprecatedRequestBuilder {
+    client: Client,
+    request: crate::Result<Request>,
+}
+
+
+impl DeprecatedRequestBuilder {
+    pub(super) fn new(client: Client, request: crate::Result<Request>) -> DeprecatedRequestBuilder {
+        let mut builder = DeprecatedRequestBuilder { client, request };
+
+        let auth = builder
+            .request
+            .as_mut()
+            .ok()
+            .and_then(|req| extract_authority(&mut req.url));
+
+        if let Some((username, password)) = auth {
+            builder.basic_auth(username, password)
+        } else {
+            builder
+        }
+    }
+
+    /// Add a `Header` to this Request.
+    pub fn header<K, V>(self, key: K, value: V) -> DeprecatedRequestBuilder
+    where
+        HeaderName: TryFrom<K>,
+        <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
+        HeaderValue: TryFrom<V>,
+        <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
+    {
+        self.header_sensitive(key, value, false)
+    }
+
+    /// Add a `Header` to this Request with ability to define if header_value is sensitive.
+    fn header_sensitive<K, V>(mut self, key: K, value: V, sensitive: bool) -> DeprecatedRequestBuilder
+    where
+        HeaderName: TryFrom<K>,
+        <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
+        HeaderValue: TryFrom<V>,
+        <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
+    {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
+            match <HeaderName as TryFrom<K>>::try_from(key) {
+                Ok(key) => match <HeaderValue as TryFrom<V>>::try_from(value) {
+                    Ok(mut value) => {
+                        value.set_sensitive(sensitive);
+                        req.headers_mut().append(key, value);
+                    }
+                    Err(e) => error = Some(crate::error::builder(e.into())),
+                },
+                Err(e) => error = Some(crate::error::builder(e.into())),
+            };
+        }
+        if let Some(err) = error {
+            self.request = Err(err);
+        }
+        self
+    }
+
+    /// Add a set of Headers to the existing ones on this Request.
+    ///
+    /// The headers will be merged in to any already set.
+    pub fn headers(mut self, headers: crate::header::HeaderMap) -> DeprecatedRequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            crate::util::replace_headers(req.headers_mut(), headers);
+        }
+        self
+    }
+
+    /// Enable HTTP basic authentication.
+    pub fn basic_auth<U, P>(self, username: U, password: Option<P>) -> DeprecatedRequestBuilder
+    where
+        U: fmt::Display,
+        P: fmt::Display,
+    {
+        let mut header_value = b"Basic ".to_vec();
+        {
+            let mut encoder = Base64Encoder::new(&mut header_value, base64::STANDARD);
+            // The unwraps here are fine because Vec::write* is infallible.
+            write!(encoder, "{}:", username).unwrap();
+            if let Some(password) = password {
+                write!(encoder, "{}", password).unwrap();
+            }
+        }
+
+        self.header_sensitive(crate::header::AUTHORIZATION, header_value, true)
+    }
+
+    /// Enable HTTP bearer authentication.
+    pub fn bearer_auth<T>(self, token: T) -> DeprecatedRequestBuilder
+    where
+        T: fmt::Display,
+    {
+        let header_value = format!("Bearer {}", token);
+        self.header_sensitive(crate::header::AUTHORIZATION, header_value, true)
+    }
+
+    /// Set the request body.
+    pub fn body<T: Into<Body>>(mut self, body: T) -> DeprecatedRequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            *req.body_mut() = Some(body.into());
+        }
+        self
+    }
+
+    /// Enables a request timeout.
+    ///
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished. It affects only this request and overrides
+    /// the timeout configured using `ClientBuilder::timeout()`.
+    pub fn timeout(mut self, timeout: Duration) -> DeprecatedRequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            *req.timeout_mut() = Some(timeout);
+        }
+        self
+    }
+
+    /// Sends a multipart/form-data body.
+    ///
+    /// ```
+    /// # use reqwest::Error;
+    ///
+    /// # async fn run() -> Result<(), Error> {
+    /// let client = reqwest::Client::new();
+    /// let form = reqwest::multipart::Form::new()
+    ///     .text("key3", "value3")
+    ///     .text("key4", "value4");
+    ///
+    ///
+    /// let response = client.post("your url")
+    ///     .multipart(form)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "multipart")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "multipart")))]
+    pub fn multipart(self, mut multipart: multipart::Form) -> DeprecatedRequestBuilder {
+        let mut builder = self.header(
+            CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", multipart.boundary()).as_str(),
+        );
+
+        builder = match multipart.compute_length() {
+            Some(length) => builder.header(CONTENT_LENGTH, length),
+            None => builder,
+        };
+
+        if let Ok(ref mut req) = builder.request {
+            *req.body_mut() = Some(multipart.stream())
+        }
+        builder
+    }
+
+    /// Modify the query string of the URL.
+    ///
+    /// Modifies the URL of this request, adding the parameters provided.
+    /// This method appends and does not overwrite. This means that it can
+    /// be called multiple times and that existing query parameters are not
+    /// overwritten if the same key is used. The key will simply show up
+    /// twice in the query string.
+    /// Calling `.query([("foo", "a"), ("foo", "b")])` gives `"foo=a&foo=b"`.
+    ///
+    /// # Note
+    /// This method does not support serializing a single key-value
+    /// pair. Instead of using `.query(("key", "val"))`, use a sequence, such
+    /// as `.query(&[("key", "val")])`. It's also possible to serialize structs
+    /// and maps into a key-value pair.
+    ///
+    /// # Errors
+    /// This method will fail if the object you provide cannot be serialized
+    /// into a query string.
+    pub fn query<T: Serialize + ?Sized>(mut self, query: &T) -> DeprecatedRequestBuilder {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
+            let url = req.url_mut();
+            let mut pairs = url.query_pairs_mut();
+            let serializer = serde_urlencoded::Serializer::new(&mut pairs);
+
+            if let Err(err) = query.serialize(serializer) {
+                error = Some(crate::error::builder(err));
+            }
+        }
+        if let Ok(ref mut req) = self.request {
+            if let Some("") = req.url().query() {
+                req.url_mut().set_query(None);
+            }
+        }
+        if let Some(err) = error {
+            self.request = Err(err);
+        }
+        self
+    }
+
+    /// Set HTTP version
+    pub fn version(mut self, version: Version) -> DeprecatedRequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            req.version = version;
+        }
+        self
+    }
+
+    /// Send a form body.
+    pub fn form<T: Serialize + ?Sized>(mut self, form: &T) -> DeprecatedRequestBuilder {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
+            match serde_urlencoded::to_string(form) {
+                Ok(body) => {
+                    req.headers_mut().insert(
+                        CONTENT_TYPE,
+                        HeaderValue::from_static("application/x-www-form-urlencoded"),
+                    );
+                    *req.body_mut() = Some(body.into());
+                }
+                Err(err) => error = Some(crate::error::builder(err)),
+            }
+        }
+        if let Some(err) = error {
+            self.request = Err(err);
+        }
+        self
+    }
+
+    /// Send a JSON body.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `json` feature enabled.
+    ///
+    /// # Errors
+    ///
+    /// Serialization can fail if `T`'s implementation of `Serialize` decides to
+    /// fail, or if `T` contains a map with non-string keys.
+    #[cfg(feature = "json")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
+    pub fn json<T: Serialize + ?Sized>(mut self, json: &T) -> DeprecatedRequestBuilder {
+        let mut error = None;
+        if let Ok(ref mut req) = self.request {
+            match serde_json::to_vec(json) {
+                Ok(body) => {
+                    req.headers_mut()
+                        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+                    *req.body_mut() = Some(body.into());
+                }
+                Err(err) => error = Some(crate::error::builder(err)),
+            }
+        }
+        if let Some(err) = error {
+            self.request = Err(err);
+        }
+        self
+    }
+
+    /// Disable CORS on fetching the request.
+    ///
+    /// # WASM
+    ///
+    /// This option is only effective with WebAssembly target.
+    ///
+    /// The [request mode][mdn] will be set to 'no-cors'.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
+    pub fn fetch_mode_no_cors(self) -> DeprecatedRequestBuilder {
+        self
+    }
+
+    /// Build a `Request`, which can be inspected, modified and executed with
+    /// `Client::execute()`.
+    pub fn build(self) -> crate::Result<Request> {
+        self.request
+    }
+
+    /// Constructs the Request and sends it to the target URL, returning a
+    /// future Response.
+    ///
+    /// # Errors
+    ///
+    /// This method fails if there was an error while sending request,
+    /// redirect loop was detected or redirect limit was exhausted.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use reqwest::Error;
+    /// #
+    /// # async fn run() -> Result<(), Error> {
+    /// let response = reqwest::Client::new()
+    ///     .get("https://hyper.rs")
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn send(self) -> impl Future<Output = Result<Response, crate::Error>> {
+        match self.request {
+            Ok(req) => self.client.execute_request(req),
+            Err(err) => Pending::new_err(err),
+        }
+    }
+
+    /// Attempt to clone the DeprecatedRequestBuilder.
+    ///
+    /// `None` is returned if the DeprecatedRequestBuilder can not be cloned,
+    /// i.e. if the request body is a stream.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use reqwest::Error;
+    /// #
+    /// # fn run() -> Result<(), Error> {
+    /// let client = reqwest::Client::new();
+    /// let builder = client.post("http://httpbin.org/post")
+    ///     .body("from a &str!");
+    /// let clone = builder.try_clone();
+    /// assert!(clone.is_some());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_clone(&self) -> Option<DeprecatedRequestBuilder> {
+        self.request
+            .as_ref()
+            .ok()
+            .and_then(|req| req.try_clone())
+            .map(|req| DeprecatedRequestBuilder {
+                client: self.client.clone(),
+                request: Ok(req),
+            })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Client, HttpRequest, Request, Version};

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -605,7 +605,7 @@ impl DeprecatedRequestBuilder {
         HeaderValue: TryFrom<V>,
         <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
     {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.header(key, value) }
     }
 
     /// Add a `Header` to this Request with ability to define if header_value is sensitive.
@@ -616,14 +616,14 @@ impl DeprecatedRequestBuilder {
         HeaderValue: TryFrom<V>,
         <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
     {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.header_sensitive(key, value, sensitive) }
     }
 
     /// Add a set of Headers to the existing ones on this Request.
     ///
     /// The headers will be merged in to any already set.
     pub fn headers(mut self, headers: crate::header::HeaderMap) -> DeprecatedRequestBuilder {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.headers(headers) }
     }
 
     /// Enable HTTP basic authentication.
@@ -632,7 +632,7 @@ impl DeprecatedRequestBuilder {
         U: fmt::Display,
         P: fmt::Display,
     {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.basic_auth(username, password) }
     }
 
     /// Enable HTTP bearer authentication.
@@ -640,12 +640,12 @@ impl DeprecatedRequestBuilder {
     where
         T: fmt::Display,
     {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.bearer_auth(token) }
     }
 
     /// Set the request body.
     pub fn body<T: Into<Body>>(mut self, body: T) -> DeprecatedRequestBuilder {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.body(body) }
     }
 
     /// Enables a request timeout.
@@ -654,7 +654,7 @@ impl DeprecatedRequestBuilder {
     /// response body has finished. It affects only this request and overrides
     /// the timeout configured using `ClientBuilder::timeout()`.
     pub fn timeout(mut self, timeout: Duration) -> DeprecatedRequestBuilder {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.timeout(timeout) }
     }
 
     /// Sends a multipart/form-data body.
@@ -679,7 +679,7 @@ impl DeprecatedRequestBuilder {
     #[cfg(feature = "multipart")]
     #[cfg_attr(docsrs, doc(cfg(feature = "multipart")))]
     pub fn multipart(self, mut multipart: multipart::Form) -> DeprecatedRequestBuilder {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.multipart(multipart) }
     }
 
     /// Modify the query string of the URL.
@@ -701,17 +701,17 @@ impl DeprecatedRequestBuilder {
     /// This method will fail if the object you provide cannot be serialized
     /// into a query string.
     pub fn query<T: Serialize + ?Sized>(mut self, query: &T) -> DeprecatedRequestBuilder {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.query(query) }
     }
 
     /// Set HTTP version
     pub fn version(mut self, version: Version) -> DeprecatedRequestBuilder {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.version(version) }
     }
 
     /// Send a form body.
     pub fn form<T: Serialize + ?Sized>(mut self, form: &T) -> DeprecatedRequestBuilder {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.form(form) }
     }
 
     /// Send a JSON body.
@@ -728,7 +728,7 @@ impl DeprecatedRequestBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json<T: Serialize + ?Sized>(mut self, json: &T) -> DeprecatedRequestBuilder {
 
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.multipart(multipart) }
     }
 
     /// Disable CORS on fetching the request.
@@ -741,7 +741,7 @@ impl DeprecatedRequestBuilder {
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
     pub fn fetch_mode_no_cors(self) -> DeprecatedRequestBuilder {
-        self
+        DeprecatedRequestBuilder {  request_builder: self.request_builder.fetch_mode_no_cors() }
     }
 
     /// Build a `Request`, which can be inspected, modified and executed with

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -74,7 +74,7 @@ mod wait;
 
 pub use self::body::Body;
 pub use self::client::{Client, ClientBuilder};
-pub use self::request::{Request, RequestBuilder};
+pub use self::request::{Request, RequestBuilder, DeprecatedRequestBuilder};
 pub use self::response::Response;
 
 /// Shortcut method to quickly make a *blocking* `GET` request.


### PR DESCRIPTION
Enable to create Request with RequestBuilder independently from the client
So it removes client from request builder and provides a DeprecatedRequestBuilder where necessary to not break existing code
resolve #385 