### PR TITLE
Enable ALPN for native-tls users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default = ["default-tls"]
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.
-default-tls = ["hyper-tls", "native-tls-crate", "__tls", "tokio-native-tls"]
+default-tls = ["hyper-tls", "native-tls-crate", "native-tls-crate/alpn", "__tls", "tokio-native-tls"]
 
 # Enables native-tls specific functionality not available by default.
 native-tls = ["default-tls"]
@@ -197,7 +197,6 @@ path = "examples/form.rs"
 [[example]]
 name = "simple"
 path = "examples/simple.rs"
-required-features = ["deflate"]
 
 [[test]]
 name = "blocking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,11 @@ default = ["default-tls"]
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.
-default-tls = ["hyper-tls", "native-tls-crate", "native-tls-crate/alpn", "__tls", "tokio-native-tls"]
+default-tls = ["hyper-tls", "native-tls-crate", "__tls", "tokio-native-tls"]
 
 # Enables native-tls specific functionality not available by default.
 native-tls = ["default-tls"]
+native-tls-alpn = ["native-tls", "native-tls-crate/alpn"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 
 rustls-tls = ["rustls-tls-webpki-roots"]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -206,10 +206,14 @@ impl ClientBuilder {
                 #[cfg(feature = "default-tls")]
                 TlsBackend::Default => {
                     let mut tls = TlsConnector::builder();
-                    if config.http2_only {
-                        tls.request_alpns(&["h2"]);
-                    } else {
-                        tls.request_alpns(&["h2", "http/1.1"]);
+
+                    #[cfg(feature = "native-tls-alpn")]
+                    {
+                        if config.http2_only {
+                            tls.request_alpns(&["h2"]);
+                        } else {
+                            tls.request_alpns(&["h2", "http/1.1"]);
+                        }
                     }
 
                     #[cfg(feature = "native-tls")]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -206,6 +206,11 @@ impl ClientBuilder {
                 #[cfg(feature = "default-tls")]
                 TlsBackend::Default => {
                     let mut tls = TlsConnector::builder();
+                    if config.http2_only {
+                        tls.request_alpns(&["h2"]);
+                    } else {
+                        tls.request_alpns(&["h2", "http/1.1"]);
+                    }
 
                     #[cfg(feature = "native-tls")]
                     {

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -691,15 +691,15 @@ mod native_tls_conn {
 
     impl<T: Connection + AsyncRead + AsyncWrite + Unpin> Connection for NativeTlsConn<T> {
         fn connected(&self) -> Connected {
-            if self.inner.get_ref().negotiated_alpn().ok() == Some(Some(b"h2".to_vec())) {
-                self.inner
+            match self.inner.get_ref().negotiated_alpn().ok() {
+                Some(Some(alpn_protocol)) if alpn_protocol == b"h2" => self
+                    .inner
                     .get_ref()
                     .get_ref()
                     .get_ref()
                     .connected()
-                    .negotiated_h2()
-            } else {
-                self.inner.get_ref().get_ref().get_ref().connected()
+                    .negotiated_h2(),
+                _ => self.inner.get_ref().get_ref().get_ref().connected(),
             }
         }
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -324,16 +324,20 @@ impl Connector {
                 let mut http = hyper_tls::HttpsConnector::from((http, tls_connector));
                 let io = http.call(dst).await?;
 
-                if let hyper_tls::MaybeHttpsStream::Https(stream) = &io {
+                if let hyper_tls::MaybeHttpsStream::Https(stream) = io {
                     if !self.nodelay {
                         stream.get_ref().get_ref().get_ref().set_nodelay(false)?;
                     }
+                    Ok(Conn {
+                        inner: self.verbose.wrap(NativeTlsConn { inner: stream }),
+                        is_proxy,
+                    })
+                } else {
+                    Ok(Conn {
+                        inner: self.verbose.wrap(io),
+                        is_proxy,
+                    })
                 }
-
-                Ok(Conn {
-                    inner: self.verbose.wrap(io),
-                    is_proxy,
-                })
             }
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, tls, .. } => {
@@ -687,7 +691,16 @@ mod native_tls_conn {
 
     impl<T: Connection + AsyncRead + AsyncWrite + Unpin> Connection for NativeTlsConn<T> {
         fn connected(&self) -> Connected {
-            self.inner.get_ref().get_ref().get_ref().connected()
+            if self.inner.get_ref().negotiated_alpn().ok() == Some(Some(b"h2".to_vec())) {
+                self.inner
+                    .get_ref()
+                    .get_ref()
+                    .get_ref()
+                    .connected()
+                    .negotiated_h2()
+            } else {
+                self.inner.get_ref().get_ref().get_ref().connected()
+            }
         }
     }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -690,6 +690,7 @@ mod native_tls_conn {
     }
 
     impl<T: Connection + AsyncRead + AsyncWrite + Unpin> Connection for NativeTlsConn<T> {
+        #[cfg(feature = "native-tls-alpn")]
         fn connected(&self) -> Connected {
             match self.inner.get_ref().negotiated_alpn().ok() {
                 Some(Some(alpn_protocol)) if alpn_protocol == b"h2" => self
@@ -701,6 +702,11 @@ mod native_tls_conn {
                     .negotiated_h2(),
                 _ => self.inner.get_ref().get_ref().get_ref().connected(),
             }
+        }
+
+        #[cfg(not(feature = "native-tls-alpn"))]
+        fn connected(&self) -> Connected {
+            self.inner.get_ref().get_ref().get_ref().connected()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@
 //!   over HTTPS.
 //! - **native-tls**: Enables TLS functionality provided by `native-tls`.
 //! - **native-tls-vendored**: Enables the `vendored` feature of `native-tls`.
+//! - **native-tls-alpn**: Enables the `alpn` feature of `native-tls`.
 //! - **rustls-tls**: Enables TLS functionality provided by `rustls`.
 //!   Equivalent to `rustls-tls-webpki-roots`.
 //! - **rustls-tls-manual-roots**: Enables TLS functionality provided by `rustls`,


### PR DESCRIPTION
Thanks to https://github.com/sfackler/rust-native-tls/pull/194, native-tls v0.2.7 now supports ALPN. This should allow native-tls users to initiate an HTTP2 connection without prior knowledge. 

Resolves remaining bits of https://github.com/seanmonstar/reqwest/issues/292