### PR TITLE
WASM: Add `try_clone` implementations to `Request` and `RequestBuilder`

### DIFF
--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -17,6 +17,7 @@ pub struct Body {
     inner: Inner,
 }
 
+#[derive(Clone)]
 enum Inner {
     Bytes(Bytes),
     #[cfg(feature = "multipart")]
@@ -54,6 +55,12 @@ impl Body {
             Inner::Bytes(bytes) => bytes.is_empty(),
             #[cfg(feature = "multipart")]
             Inner::Multipart(form) => form.is_empty(),
+        }
+    }
+
+    pub(crate) fn clone(&self) -> Body {
+        Self {
+            inner: self.inner.clone(),
         }
     }
 }


### PR DESCRIPTION
Currently the wasm client does not implement `try_clone` on `Request` or `RequestBuilder` like the blocking and async clients.

This PR adds infallible `try_clone` implementations to the wasm client to improve the API parity.

*Note*: Even though these APIs are infallible on wasm (no streaming bodies), I chose to keep the API identical.