### PR TITLE
Fix bare url warnings in `multipart` docs

### DIFF
--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -408,7 +408,7 @@ impl PartMetadata {
     }
 }
 
-/// https://url.spec.whatwg.org/#fragment-percent-encode-set
+// https://url.spec.whatwg.org/#fragment-percent-encode-set
 const FRAGMENT_ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
     .add(b' ')
     .add(b'"')
@@ -416,12 +416,12 @@ const FRAGMENT_ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
     .add(b'>')
     .add(b'`');
 
-/// https://url.spec.whatwg.org/#path-percent-encode-set
+// https://url.spec.whatwg.org/#path-percent-encode-set
 const PATH_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'#').add(b'?').add(b'{').add(b'}');
 
 const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &PATH_ENCODE_SET.add(b'/').add(b'%');
 
-/// https://tools.ietf.org/html/rfc8187#section-3.2.1
+// https://tools.ietf.org/html/rfc8187#section-3.2.1
 const ATTR_CHAR_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'!')
     .remove(b'#')


### PR DESCRIPTION
The comments are not intended as doc comments.

<details>
<summary>Warnings</summary>

```
warning: this URL is not a hyperlink
   --> src/async_impl/multipart.rs:411:5
    |
411 | /// https://url.spec.whatwg.org/#fragment-percent-encode-set
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://url.spec.whatwg.org/#fragment-percent-encode-set>`
    |
    = note: `#[warn(rustdoc::bare_urls)]` on by default
    = note: bare URLs are not automatically turned into clickable links

warning: this URL is not a hyperlink
   --> src/async_impl/multipart.rs:419:5
    |
419 | /// https://url.spec.whatwg.org/#path-percent-encode-set
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://url.spec.whatwg.org/#path-percent-encode-set>`
    |
    = note: bare URLs are not automatically turned into clickable links

warning: this URL is not a hyperlink
   --> src/async_impl/multipart.rs:424:5
    |
424 | /// https://tools.ietf.org/html/rfc8187#section-3.2.1
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://tools.ietf.org/html/rfc8187#section-3.2.1>`
    |
    = note: bare URLs are not automatically turned into clickable links
```
</details>