### PR TITLE
Add option to disable http2 upgrade

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -404,6 +404,11 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.http1_title_case_headers())
     }
 
+    /// Only use HTTP/1.
+    pub fn http1_only(self) -> ClientBuilder {
+        self.with_inner(|inner| inner.http1_only())
+    }
+
     /// Only use HTTP/2.
     pub fn http2_prior_knowledge(self) -> ClientBuilder {
         self.with_inner(|inner| inner.http2_prior_knowledge())


### PR DESCRIPTION
This can be helpful when there is a need to make an HTTP/1.0 or HTTP/1.1 connection but the server supports upgrading to HTTP/2.

```rust
let client = reqwest::Client::builder()
    .use_rustls_tls()
    .http1_only()
    .build()?;
let request = client
    .request(reqwest::Method::GET, "https://www.google.com")
    .version(reqwest::Version::HTTP_10)
    .build()?;
let res = client.execute(request).await?;
println!("Status: {:?}", res.version()); // Status: HTTP/1.0

let client = reqwest::Client::builder().use_rustls_tls().build()?;
let request = client
    .request(reqwest::Method::GET, "https://www.google.com")
    .version(reqwest::Version::HTTP_2)
    .build()?;
let res = client.execute(request).await?;
println!("Status: {:?}", res.version()); // Status: HTTP/2
```

Resolves https://github.com/seanmonstar/reqwest/issues/1290