### PR TITLE
Fix documentation of http1_title_case_headers()

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -731,7 +731,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Enable case sensitive headers.
+    /// Send headers as title case instead of lowercase.
     pub fn http1_title_case_headers(mut self) -> ClientBuilder {
         self.config.http1_title_case_headers = true;
         self

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -399,7 +399,7 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.pool_max_idle_per_host(max))
     }
 
-    /// Enable case sensitive headers.
+    /// Send headers as title case instead of lowercase.
     pub fn http1_title_case_headers(self) -> ClientBuilder {
         self.with_inner(|inner| inner.http1_title_case_headers())
     }


### PR DESCRIPTION
Case is not preserved either way, so the old text was misleading.