### PR TITLE
Fix compile error when target is wasm and multipart feature is enabled.

### DIFF
--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -13,6 +13,7 @@ use wasm_bindgen::JsValue;
 /// passing many things (like a string or vector of bytes).
 ///
 /// [builder]: ./struct.RequestBuilder.html#method.body
+#[derive(Clone)]
 pub struct Body {
     inner: Inner,
 }
@@ -55,12 +56,6 @@ impl Body {
             Inner::Bytes(bytes) => bytes.is_empty(),
             #[cfg(feature = "multipart")]
             Inner::Multipart(form) => form.is_empty(),
-        }
-    }
-
-    pub(crate) fn clone(&self) -> Body {
-        Self {
-            inner: self.inner.clone(),
         }
     }
 }

--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -63,7 +63,7 @@ impl Body {
                 inner: Inner::Bytes(bytes.clone()),
             }),
             #[cfg(feature = "multipart")]
-            Inner::Multipart(_) => None
+            Inner::Multipart(_) => None,
         }
     }
 }

--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -58,10 +58,11 @@ impl Body {
     }
 
     pub(crate) fn try_clone(&self) -> Option<Body> {
-        match self.inner {
-            Inner::Bytes(ref bytes) => Some(Self {
+        match &self.inner {
+            Inner::Bytes(bytes) => Some(Self {
                 inner: Inner::Bytes(bytes.clone()),
             }),
+            #[cfg(feature = "multipart")]
             Inner::Multipart(_) => None
         }
     }

--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -13,12 +13,10 @@ use wasm_bindgen::JsValue;
 /// passing many things (like a string or vector of bytes).
 ///
 /// [builder]: ./struct.RequestBuilder.html#method.body
-#[derive(Clone)]
 pub struct Body {
     inner: Inner,
 }
 
-#[derive(Clone)]
 enum Inner {
     Bytes(Bytes),
     #[cfg(feature = "multipart")]
@@ -56,6 +54,15 @@ impl Body {
             Inner::Bytes(bytes) => bytes.is_empty(),
             #[cfg(feature = "multipart")]
             Inner::Multipart(form) => form.is_empty(),
+        }
+    }
+
+    pub(crate) fn try_clone(&self) -> Option<Body> {
+        match self.inner {
+            Inner::Bytes(ref bytes) => Some(Self {
+                inner: Inner::Bytes(bytes.clone()),
+            }),
+            Inner::Multipart(_) => None
         }
     }
 }

--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -9,6 +9,7 @@ use web_sys::FormData;
 use super::Body;
 
 /// An async multipart/form-data request.
+#[derive(Clone)]
 pub struct Form {
     inner: FormParts<Part>,
 }
@@ -20,15 +21,18 @@ impl Form {
 }
 
 /// A field in a multipart form.
+#[derive(Clone)]
 pub struct Part {
     meta: PartMetadata,
     value: Body,
 }
 
+#[derive(Clone)]
 pub(crate) struct FormParts<P> {
     pub(crate) fields: Vec<(Cow<'static, str>, P)>,
 }
 
+#[derive(Clone)]
 pub(crate) struct PartMetadata {
     mime: Option<Mime>,
     file_name: Option<Cow<'static, str>>,

--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -9,7 +9,6 @@ use web_sys::FormData;
 use super::Body;
 
 /// An async multipart/form-data request.
-#[derive(Clone)]
 pub struct Form {
     inner: FormParts<Part>,
 }
@@ -21,18 +20,15 @@ impl Form {
 }
 
 /// A field in a multipart form.
-#[derive(Clone)]
 pub struct Part {
     meta: PartMetadata,
     value: Body,
 }
 
-#[derive(Clone)]
 pub(crate) struct FormParts<P> {
     pub(crate) fields: Vec<(Cow<'static, str>, P)>,
 }
 
-#[derive(Clone)]
 pub(crate) struct PartMetadata {
     mime: Option<Mime>,
     file_name: Option<Cow<'static, str>>,

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -92,8 +92,7 @@ impl Request {
 
     /// Attempts to clone the `Request`.
     ///
-    /// None is returned if a body is which can not be cloned. This method
-    /// currently always returns `Some`, but that may change in the future.
+    /// None is returned if a body is which can not be cloned.
     pub fn try_clone(&self) -> Option<Request> {
         let body = match self.body.as_ref() {
             Some(ref body) => Some(body.try_clone()?),
@@ -358,8 +357,7 @@ impl RequestBuilder {
 
     /// Attempt to clone the RequestBuilder.
     ///
-    /// `None` is returned if the RequestBuilder can not be cloned. This method
-    /// currently always returns `Some`, but that may change in the future.
+    /// `None` is returned if the RequestBuilder can not be cloned.
     ///
     /// # Examples
     ///

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -95,11 +95,16 @@ impl Request {
     /// None is returned if a body is which can not be cloned. This method
     /// currently always returns `Some`, but that may change in the future.
     pub fn try_clone(&self) -> Option<Request> {
+        let body = match self.body.as_ref() {
+            Some(ref body) => Some(body.try_clone()?),
+            None => None,
+        };
+
         Some(Self {
             method: self.method.clone(),
             url: self.url.clone(),
             headers: self.headers.clone(),
-            body: self.body.as_ref().map(|body| body.clone()),
+            body,
             cors: self.cors,
             credentials: self.credentials.clone(),
         })


### PR DESCRIPTION
This PR aims to close #1295.

Without this fix master (and v0.11.4) fails to compile with this command:
`cargo build --target wasm32-unknown-unknown --features multipart` 

@seanmonstar Your initial suggestion was to remove #[derive(Clone)] from enum Inner, and change clone() method to try_clone() that matches on the inner type.

But after some research I found out that clone could be implemented for both Inner::Bytes and Inner::Multipart with minimal changes. (I added several #[derive(Clone)] attributes) 

What do you think about this change? I am open to implementing your initial suggestion.

I am open to feedback and I will address comments asap.
