### PR TITLE
Add options for specifying the TLS version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ ipnet = "2.3"
 
 ## default-tls
 hyper-tls = { version = "0.5", optional = true }
-native-tls-crate = { version = "0.2.7", optional = true, package = "native-tls" }
+native-tls-crate = { version = "0.2.8", optional = true, package = "native-tls" }
 tokio-native-tls = { version = "0.3.0", optional = true }
 
 # rustls-tls

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1044,7 +1044,7 @@ impl ClientBuilder {
     ///
     /// # Errors
     ///
-    /// A value of `tls::Version::Tlsv1_3` will cause an error with the
+    /// A value of `tls::Version::TLS_1_3` will cause an error with the
     /// `native-tls`/`default-tls` backend. This does not mean the version
     /// isn't supported, just that it can't be set as a minimum due to
     /// technical limitations.
@@ -1076,7 +1076,7 @@ impl ClientBuilder {
     ///
     /// # Errors
     ///
-    /// A value of `tls::Version::Tlsv1_3` will cause an error with the
+    /// A value of `tls::Version::TLS_1_3` will cause an error with the
     /// `native-tls`/`default-tls` backend. This does not mean the version
     /// isn't supported, just that it can't be set as a maximum due to
     /// technical limitations.

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -16,7 +16,7 @@ use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::wait;
 #[cfg(feature = "__tls")]
-use crate::tls::TlsVersion;
+use crate::tls;
 #[cfg(feature = "__tls")]
 use crate::Certificate;
 #[cfg(any(feature = "native-tls", feature = "__rustls"))]
@@ -614,7 +614,7 @@ impl ClientBuilder {
     ///
     /// # Errors
     ///
-    /// A value of `TlsVersion::Tlsv1_3` will cause an error with the
+    /// A value of `tls::Version::Tlsv1_3` will cause an error with the
     /// `native-tls`/`default-tls` backend. This does not mean the version
     /// isn't supported, just that it can't be set as a minimum due to
     /// technical limitations.
@@ -634,7 +634,7 @@ impl ClientBuilder {
     )]
     pub fn min_tls_version<V>(self, version: V) -> ClientBuilder
     where
-        V: Into<Option<TlsVersion>>,
+        V: Into<Option<tls::Version>>,
     {
         self.with_inner(|inner| inner.min_tls_version(version))
     }
@@ -645,7 +645,7 @@ impl ClientBuilder {
     ///
     /// # Errors
     ///
-    /// A value of `TlsVersion::Tlsv1_3` will cause an error with the
+    /// A value of `tls::Version::Tlsv1_3` will cause an error with the
     /// `native-tls`/`default-tls` backend. This does not mean the version
     /// isn't supported, just that it can't be set as a maximum due to
     /// technical limitations.
@@ -665,7 +665,7 @@ impl ClientBuilder {
     )]
     pub fn max_tls_version<V>(self, version: V) -> ClientBuilder
     where
-        V: Into<Option<TlsVersion>>,
+        V: Into<Option<tls::Version>>,
     {
         self.with_inner(|inner| inner.max_tls_version(version))
     }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -16,6 +16,8 @@ use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::wait;
 #[cfg(feature = "__tls")]
+use crate::tls::TlsVersion;
+#[cfg(feature = "__tls")]
 use crate::Certificate;
 #[cfg(any(feature = "native-tls", feature = "__rustls"))]
 use crate::Identity;
@@ -601,6 +603,71 @@ impl ClientBuilder {
     )]
     pub fn danger_accept_invalid_certs(self, accept_invalid_certs: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.danger_accept_invalid_certs(accept_invalid_certs))
+    }
+
+    /// Set the minimum required TLS version for connections.
+    ///
+    /// If `None`, all versions supported by the backend are enabled,
+    /// potentially including old insecure ones.
+    ///
+    /// By default the TLS backend's own default is used.
+    ///
+    /// # Errors
+    ///
+    /// A value of `TlsVersion::Tlsv1_3` will cause an error with the
+    /// `native-tls`/`default-tls` backend. This does not mean the version
+    /// isn't supported, just that it can't be set as a minimum due to
+    /// technical limitations.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "default-tls",
+            feature = "native-tls",
+            feature = "rustls-tls"
+        )))
+    )]
+    pub fn min_tls_version<V>(self, version: V) -> ClientBuilder
+    where
+        V: Into<Option<TlsVersion>>,
+    {
+        self.with_inner(|inner| inner.min_tls_version(version))
+    }
+
+    /// Set the maximum allowed TLS version for connections.
+    ///
+    /// If `None` (the default), there's no maximum.
+    ///
+    /// # Errors
+    ///
+    /// A value of `TlsVersion::Tlsv1_3` will cause an error with the
+    /// `native-tls`/`default-tls` backend. This does not mean the version
+    /// isn't supported, just that it can't be set as a maximum due to
+    /// technical limitations.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "default-tls",
+            feature = "native-tls",
+            feature = "rustls-tls"
+        )))
+    )]
+    pub fn max_tls_version<V>(self, version: V) -> ClientBuilder
+    where
+        V: Into<Option<TlsVersion>>,
+    {
+        self.with_inner(|inner| inner.max_tls_version(version))
     }
 
     /// Force using the native TLS backend.

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -614,7 +614,7 @@ impl ClientBuilder {
     ///
     /// # Errors
     ///
-    /// A value of `tls::Version::Tlsv1_3` will cause an error with the
+    /// A value of `tls::Version::TLS_1_3` will cause an error with the
     /// `native-tls`/`default-tls` backend. This does not mean the version
     /// isn't supported, just that it can't be set as a minimum due to
     /// technical limitations.
@@ -645,7 +645,7 @@ impl ClientBuilder {
     ///
     /// # Errors
     ///
-    /// A value of `tls::Version::Tlsv1_3` will cause an error with the
+    /// A value of `tls::Version::TLS_1_3` will cause an error with the
     /// `native-tls`/`default-tls` backend. This does not mean the version
     /// isn't supported, just that it can't be set as a maximum due to
     /// technical limitations.

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -607,9 +607,6 @@ impl ClientBuilder {
 
     /// Set the minimum required TLS version for connections.
     ///
-    /// If `None`, all versions supported by the backend are enabled,
-    /// potentially including old insecure ones.
-    ///
     /// By default the TLS backend's own default is used.
     ///
     /// # Errors
@@ -632,16 +629,13 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
-    pub fn min_tls_version<V>(self, version: V) -> ClientBuilder
-    where
-        V: Into<Option<tls::Version>>,
-    {
+    pub fn min_tls_version(self, version: tls::Version) -> ClientBuilder {
         self.with_inner(|inner| inner.min_tls_version(version))
     }
 
     /// Set the maximum allowed TLS version for connections.
     ///
-    /// If `None` (the default), there's no maximum.
+    /// By default there's no maximum.
     ///
     /// # Errors
     ///
@@ -663,10 +657,7 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
-    pub fn max_tls_version<V>(self, version: V) -> ClientBuilder
-    where
-        V: Into<Option<tls::Version>>,
-    {
+    pub fn max_tls_version(self, version: tls::Version) -> ClientBuilder {
         self.with_inner(|inner| inner.max_tls_version(version))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,8 @@ if_hyper! {
     };
     pub use self::proxy::Proxy;
     #[cfg(feature = "__tls")]
-    pub use self::tls::{Certificate, Identity, TlsVersion};
+    // Re-exports, to be removed in a future release
+    pub use tls::{Certificate, Identity};
     #[cfg(feature = "multipart")]
     pub use self::async_impl::multipart;
 
@@ -314,7 +315,7 @@ if_hyper! {
     mod proxy;
     pub mod redirect;
     #[cfg(feature = "__tls")]
-    mod tls;
+    pub mod tls;
     mod util;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ if_hyper! {
     };
     pub use self::proxy::Proxy;
     #[cfg(feature = "__tls")]
-    pub use self::tls::{Certificate, Identity};
+    pub use self::tls::{Certificate, Identity, TlsVersion};
     #[cfg(feature = "multipart")]
     pub use self::async_impl::multipart;
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,3 +1,16 @@
+//! TLS configuration
+//!
+//! By default, a `Client` will make use of system-native transport layer
+//! security to connect to HTTPS destinations. This means schannel on Windows,
+//! Security-Framework on macOS, and OpenSSL on Linux.
+//!
+//! - Additional X509 certificates can be configured on a `ClientBuilder` with the
+//!   [`Certificate`](Certificate) type.
+//! - Client certificates can be add to a `ClientBuilder` with the
+//!   [`Identity`][Identity] type.
+//! - Various parts of TLS can also be configured or even disabled on the
+//!   `ClientBuilder`.
+
 #[cfg(feature = "__rustls")]
 use rustls::{
     internal::msgs::handshake::DigitallySignedStruct, HandshakeSignatureValid, RootCertStore,
@@ -272,7 +285,7 @@ impl fmt::Debug for Identity {
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
-pub enum TlsVersion {
+pub enum Version {
     // Sslv2 is not supported by either backend, though rustls
     // does include it in its enum
     Sslv3,
@@ -284,15 +297,15 @@ pub enum TlsVersion {
 
 // These could perhaps be From/TryFrom implementations, but those would be
 // part of the public API so let's be careful
-impl TlsVersion {
+impl Version {
     #[cfg(feature = "default-tls")]
     pub(crate) fn to_native_tls(self) -> Option<native_tls_crate::Protocol> {
         match self {
-            TlsVersion::Sslv3 => Some(native_tls_crate::Protocol::Sslv3),
-            TlsVersion::Tlsv1_0 => Some(native_tls_crate::Protocol::Tlsv10),
-            TlsVersion::Tlsv1_1 => Some(native_tls_crate::Protocol::Tlsv11),
-            TlsVersion::Tlsv1_2 => Some(native_tls_crate::Protocol::Tlsv12),
-            TlsVersion::Tlsv1_3 => None,
+            Version::Sslv3 => Some(native_tls_crate::Protocol::Sslv3),
+            Version::Tlsv1_0 => Some(native_tls_crate::Protocol::Tlsv10),
+            Version::Tlsv1_1 => Some(native_tls_crate::Protocol::Tlsv11),
+            Version::Tlsv1_2 => Some(native_tls_crate::Protocol::Tlsv12),
+            Version::Tlsv1_3 => None,
         }
     }
 
@@ -300,11 +313,11 @@ impl TlsVersion {
     pub(crate) fn from_rustls(version: rustls::ProtocolVersion) -> Option<Self> {
         match version {
             rustls::ProtocolVersion::SSLv2 => None,
-            rustls::ProtocolVersion::SSLv3 => Some(TlsVersion::Sslv3),
-            rustls::ProtocolVersion::TLSv1_0 => Some(TlsVersion::Tlsv1_0),
-            rustls::ProtocolVersion::TLSv1_1 => Some(TlsVersion::Tlsv1_1),
-            rustls::ProtocolVersion::TLSv1_2 => Some(TlsVersion::Tlsv1_2),
-            rustls::ProtocolVersion::TLSv1_3 => Some(TlsVersion::Tlsv1_3),
+            rustls::ProtocolVersion::SSLv3 => Some(Version::Sslv3),
+            rustls::ProtocolVersion::TLSv1_0 => Some(Version::Tlsv1_0),
+            rustls::ProtocolVersion::TLSv1_1 => Some(Version::Tlsv1_1),
+            rustls::ProtocolVersion::TLSv1_2 => Some(Version::Tlsv1_2),
+            rustls::ProtocolVersion::TLSv1_3 => Some(Version::Tlsv1_3),
             _ => None,
         }
     }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -282,30 +282,37 @@ impl fmt::Debug for Identity {
 }
 
 /// A TLS protocol version.
-#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version(InnerVersion);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
-pub enum Version {
-    // Sslv2 is not supported by either backend, though rustls
-    // does include it in its enum
-    Sslv3,
-    Tlsv1_0,
-    Tlsv1_1,
-    Tlsv1_2,
-    Tlsv1_3,
+enum InnerVersion {
+    Tls1_0,
+    Tls1_1,
+    Tls1_2,
+    Tls1_3,
 }
 
 // These could perhaps be From/TryFrom implementations, but those would be
 // part of the public API so let's be careful
 impl Version {
+    /// Version 1.0 of the TLS protocol.
+    pub const TLS_1_0: Version = Version(InnerVersion::Tls1_0);
+    /// Version 1.1 of the TLS protocol.
+    pub const TLS_1_1: Version = Version(InnerVersion::Tls1_1);
+    /// Version 1.2 of the TLS protocol.
+    pub const TLS_1_2: Version = Version(InnerVersion::Tls1_2);
+    /// Version 1.3 of the TLS protocol.
+    pub const TLS_1_3: Version = Version(InnerVersion::Tls1_3);
+
     #[cfg(feature = "default-tls")]
     pub(crate) fn to_native_tls(self) -> Option<native_tls_crate::Protocol> {
-        match self {
-            Version::Sslv3 => Some(native_tls_crate::Protocol::Sslv3),
-            Version::Tlsv1_0 => Some(native_tls_crate::Protocol::Tlsv10),
-            Version::Tlsv1_1 => Some(native_tls_crate::Protocol::Tlsv11),
-            Version::Tlsv1_2 => Some(native_tls_crate::Protocol::Tlsv12),
-            Version::Tlsv1_3 => None,
+        match self.0 {
+            InnerVersion::Tls1_0 => Some(native_tls_crate::Protocol::Tlsv10),
+            InnerVersion::Tls1_1 => Some(native_tls_crate::Protocol::Tlsv11),
+            InnerVersion::Tls1_2 => Some(native_tls_crate::Protocol::Tlsv12),
+            InnerVersion::Tls1_3 => None,
         }
     }
 
@@ -313,11 +320,11 @@ impl Version {
     pub(crate) fn from_rustls(version: rustls::ProtocolVersion) -> Option<Self> {
         match version {
             rustls::ProtocolVersion::SSLv2 => None,
-            rustls::ProtocolVersion::SSLv3 => Some(Version::Sslv3),
-            rustls::ProtocolVersion::TLSv1_0 => Some(Version::Tlsv1_0),
-            rustls::ProtocolVersion::TLSv1_1 => Some(Version::Tlsv1_1),
-            rustls::ProtocolVersion::TLSv1_2 => Some(Version::Tlsv1_2),
-            rustls::ProtocolVersion::TLSv1_3 => Some(Version::Tlsv1_3),
+            rustls::ProtocolVersion::SSLv3 => None,
+            rustls::ProtocolVersion::TLSv1_0 => Some(Self(InnerVersion::Tls1_0)),
+            rustls::ProtocolVersion::TLSv1_1 => Some(Self(InnerVersion::Tls1_1)),
+            rustls::ProtocolVersion::TLSv1_2 => Some(Self(InnerVersion::Tls1_2)),
+            rustls::ProtocolVersion::TLSv1_3 => Some(Self(InnerVersion::Tls1_3)),
             _ => None,
         }
     }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -268,6 +268,48 @@ impl fmt::Debug for Identity {
     }
 }
 
+/// A TLS protocol version.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum TlsVersion {
+    // Sslv2 is not supported by either backend, though rustls
+    // does include it in its enum
+    Sslv3,
+    Tlsv1_0,
+    Tlsv1_1,
+    Tlsv1_2,
+    Tlsv1_3,
+}
+
+// These could perhaps be From/TryFrom implementations, but those would be
+// part of the public API so let's be careful
+impl TlsVersion {
+    #[cfg(feature = "default-tls")]
+    pub(crate) fn to_native_tls(self) -> Option<native_tls_crate::Protocol> {
+        match self {
+            TlsVersion::Sslv3 => Some(native_tls_crate::Protocol::Sslv3),
+            TlsVersion::Tlsv1_0 => Some(native_tls_crate::Protocol::Tlsv10),
+            TlsVersion::Tlsv1_1 => Some(native_tls_crate::Protocol::Tlsv11),
+            TlsVersion::Tlsv1_2 => Some(native_tls_crate::Protocol::Tlsv12),
+            TlsVersion::Tlsv1_3 => None,
+        }
+    }
+
+    #[cfg(feature = "__rustls")]
+    pub(crate) fn from_rustls(version: rustls::ProtocolVersion) -> Option<Self> {
+        match version {
+            rustls::ProtocolVersion::SSLv2 => None,
+            rustls::ProtocolVersion::SSLv3 => Some(TlsVersion::Sslv3),
+            rustls::ProtocolVersion::TLSv1_0 => Some(TlsVersion::Tlsv1_0),
+            rustls::ProtocolVersion::TLSv1_1 => Some(TlsVersion::Tlsv1_1),
+            rustls::ProtocolVersion::TLSv1_2 => Some(TlsVersion::Tlsv1_2),
+            rustls::ProtocolVersion::TLSv1_3 => Some(TlsVersion::Tlsv1_3),
+            _ => None,
+        }
+    }
+}
+
 pub(crate) enum TlsBackend {
     #[cfg(feature = "default-tls")]
     Default,


### PR DESCRIPTION
See #1314.

The relationship between supported TLS versions and backends is a little weird (rustls only implements 1.2 and 1.3, native-tls may implement 1.3 but doesn't let you specify it) but I think it turned out acceptable.

`max_tls_version` is less obviously useful than `min_tls_version`. My immediate use case is to see what a server does if faced with an old TLS version (see ducaale/xh#120). For that an API that lets you force a single fixed TLS version would be enough, so that might be worth considering instead, but this maps cleanly onto the API of native-tls.

Should this have tests? I wasn't sure how to write them.