### PR TITLE
chore: don't use default features in 'brotli' dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ env_logger = "0.8"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "http1", "http2", "client", "server", "runtime"] }
 serde = { version = "1.0", features = ["derive"] }
 libflate = "1.0"
-brotli_crate = { package = "brotli", version = "3.3.0" }
+brotli_crate = { package = "brotli", version = "3.3.0", default-features = false, features = ["std"] }
 doc-comment = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 


### PR DESCRIPTION
Closes https://github.com/seanmonstar/reqwest/issues/1324

This commit disables default feature set of "brotli" crate and instead
uses only "std" feature. This effectively removes "ffi-api" feature from
the dependency which seems to be unused.