### PR TITLE
Allow to clone a Identity

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -37,11 +37,13 @@ enum Cert {
 }
 
 /// Represents a private key and X509 cert as a client certificate.
+#[derive(Clone)]
 pub struct Identity {
     #[cfg_attr(not(any(feature = "native-tls", feature = "__rustls")), allow(unused))]
     inner: ClientCert,
 }
 
+#[derive(Clone)]
 enum ClientCert {
     #[cfg(feature = "native-tls")]
     Pkcs12(native_tls_crate::Identity),


### PR DESCRIPTION
For example, it can be useful when we need to store an Identity in a hash map. (I'm facing exactly this problem in a small project I'm developing)