### PR TITLE
Adds amplifying note about private key formats

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -183,6 +183,8 @@ impl Identity {
     /// The input should contain a PEM encoded private key
     /// and at least one PEM encoded certificate.
     ///
+    /// Note: The private key must be in RSA or PKCS#8 format.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
I'll leave this to the discretion of the maintainers on whether or not this is worth merging. The context is I had some code that relied on using TLS client certificate/keys and was occasionally running into issues where it would throw the "private key or certificate not found" error.

After further investigation, I found that, at least in one reproducible case, the client key was in the standard ECSDA PEM format:

```
-----BEGIN EC PRIVATE KEY-----
contents
-----END EC PRIVATE KEY-----
```

Obviously, the two calls to `pkcs8_keys` and `rsa_private_keys` [shown here](https://github.com/seanmonstar/reqwest/blob/master/src/tls.rs#L215) were both returning an empty vec. At face value, it's not obvious that this is going on under the hood and was confusing since I know that `rustls` supports these types of keys. The solution, in my case, was to simply convert the key to the PKCS#8 format in order to conform to what the crate was expecting. It's also worth noting that I was using `curl` as my sanity check which does support this key format out of the box - so there's even more chance of someone getting confused in this case. 

An alternative solution is changing the error message to indicate this possibility - but I thought starting with the documentation was a cleaner approach (it would have saved me about an hour). 
