### PR TITLE
wasm: use Array when converting bytes into JsValue

### DIFF
--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -2,7 +2,7 @@
 use super::multipart::Form;
 /// dox
 use bytes::Bytes;
-use js_sys::Uint8Array;
+use js_sys::{Array, Uint8Array};
 use std::fmt;
 use wasm_bindgen::JsValue;
 
@@ -28,7 +28,9 @@ impl Body {
         match &self.inner {
             Inner::Bytes(body_bytes) => {
                 let body_bytes: &[u8] = body_bytes.as_ref();
-                let body_array: Uint8Array = body_bytes.into();
+                let body_uint8_array: Uint8Array = body_bytes.into();
+                let body_array = Array::new();
+                body_array.push(&body_uint8_array);
                 let js_value: &JsValue = body_array.as_ref();
                 Ok(js_value.to_owned())
             }


### PR DESCRIPTION
In wasm environment, just using `Uint8Array` to convert `&[u8]` to `JsValue` gives wrong result. See:
```
POST / HTTP/1.1
<snip>
-----------------------------39735077602244728713763853857
Content-Disposition: form-data; name="salt"; filename="blob"
Content-Type: application/octet-stream

253215189732323814792583246113167154161341161821110310981725410248203142105158205
-----------------------------39735077602244728713763853857
Content-Disposition: form-data; name="filename"; filename="blob"
Content-Type: application/octet-stream

14792118571925534386625416214323810571220106184438911212196164
-----------------------------39735077602244728713763853857--
```

`application/octet-stream` body is printing weird string, not the binary stream (tested on current `master`).
This patch will fix above issue.