### PR TITLE
Add req.set_header method for append or replace header

### DIFF
--- a/examples/wasm_github_fetch/src/lib.rs
+++ b/examples/wasm_github_fetch/src/lib.rs
@@ -37,6 +37,7 @@ pub async fn run() -> Result<JsValue, JsValue> {
     let res = reqwest::Client::new()
         .get("https://api.github.com/repos/rustwasm/wasm-bindgen/branches/master")
         .header("Accept", "application/vnd.github.v3+json")
+        .set_header("User-Agent", "rust-wasm-examples")
         .send()
         .await?;
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -187,11 +187,28 @@ impl RequestBuilder {
         HeaderValue: TryFrom<V>,
         <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
     {
-        self.header_sensitive(key, value, false)
+        self.header_sensitive(key, value, false, false)
+    }
+
+    /// Sets a new value for an existing `Header`, or adds the `Header` if it does not already exist.
+    pub fn set_header<K, V>(self, key: K, value: V) -> RequestBuilder
+    where
+        HeaderName: TryFrom<K>,
+        <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
+        HeaderValue: TryFrom<V>,
+        <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
+    {
+        self.header_sensitive(key, value, false, true)
     }
 
     /// Add a `Header` to this Request with ability to define if header_value is sensitive.
-    fn header_sensitive<K, V>(mut self, key: K, value: V, sensitive: bool) -> RequestBuilder
+    fn header_sensitive<K, V>(
+        mut self,
+        key: K,
+        value: V,
+        sensitive: bool,
+        replace: bool,
+    ) -> RequestBuilder
     where
         HeaderName: TryFrom<K>,
         <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
@@ -204,7 +221,11 @@ impl RequestBuilder {
                 Ok(key) => match <HeaderValue as TryFrom<V>>::try_from(value) {
                     Ok(mut value) => {
                         value.set_sensitive(sensitive);
-                        req.headers_mut().append(key, value);
+                        let headers = req.headers_mut();
+                        if replace {
+                            headers.remove(&key);
+                        }
+                        headers.append(key, value);
                     }
                     Err(e) => error = Some(crate::error::builder(e.into())),
                 },
@@ -243,7 +264,7 @@ impl RequestBuilder {
             }
         }
 
-        self.header_sensitive(crate::header::AUTHORIZATION, header_value, true)
+        self.header_sensitive(crate::header::AUTHORIZATION, header_value, true, true)
     }
 
     /// Enable HTTP bearer authentication.
@@ -252,7 +273,7 @@ impl RequestBuilder {
         T: fmt::Display,
     {
         let header_value = format!("Bearer {}", token);
-        self.header_sensitive(crate::header::AUTHORIZATION, header_value, true)
+        self.header_sensitive(crate::header::AUTHORIZATION, header_value, true, true)
     }
 
     /// Set the request body.
@@ -690,6 +711,27 @@ mod tests {
         assert_eq!(foo.len(), 2);
         assert_eq!(foo[0], "bar");
         assert_eq!(foo[1], "baz");
+    }
+
+    #[test]
+    fn test_replace_header() {
+        let client = Client::new();
+        let some_url = "https://localhost/";
+
+        let req = client
+            .get(some_url)
+            .header("foo", "foo")
+            .header("foo", "foo1")
+            .set_header("bar", "dar")
+            .set_header("bar", "new-bar")
+            .build()
+            .expect("request build");
+
+        assert_eq!(
+            req.headers().get_all("foo").iter().collect::<Vec<_>>(),
+            vec!["foo", "foo1"]
+        );
+        assert_eq!(req.headers()["bar"], "new-bar");
     }
 
     #[test]

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -36,7 +36,8 @@ pub struct Request {
 #[must_use = "RequestBuilder does nothing until you 'send' it"]
 pub struct RequestBuilder {
     client: Client,
-    request: crate::Result<Request>,
+    /// The request of this builder.
+    pub request: crate::Result<Request>,
 }
 
 impl Request {
@@ -246,6 +247,15 @@ impl RequestBuilder {
             crate::util::replace_headers(req.headers_mut(), headers);
         }
         self
+    }
+
+    /// Get the current headers on this Request.
+    pub fn get_headers(self) -> crate::header::HeaderMap {
+        if let Ok(ref req) = self.request {
+            req.headers().clone()
+        } else {
+            crate::header::HeaderMap::new()
+        }
     }
 
     /// Enable HTTP basic authentication.
@@ -732,6 +742,16 @@ mod tests {
             vec!["foo", "foo1"]
         );
         assert_eq!(req.headers()["bar"], "new-bar");
+    }
+
+    #[test]
+    fn test_builder_request() {
+        let client = Client::new();
+        let some_url = "https://localhost/";
+
+        let req = client.get(some_url);
+
+        assert!(req.request.is_ok());
     }
 
     #[test]

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -29,7 +29,8 @@ pub struct Request {
 #[must_use = "RequestBuilder does nothing until you 'send' it"]
 pub struct RequestBuilder {
     client: Client,
-    request: crate::Result<Request>,
+    /// The request of this builder.
+    pub request: crate::Result<Request>,
 }
 
 impl Request {
@@ -1001,6 +1002,16 @@ mod tests {
             vec!["foo", "foo1"]
         );
         assert_eq!(req.headers()["bar"], "new-bar");
+    }
+
+    #[test]
+    fn test_builder_request() {
+        let client = Client::new();
+        let some_url = "https://localhost/";
+
+        let req = client.get(some_url);
+
+        assert!(req.request.is_ok());
     }
 
     #[test]

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -25,7 +25,8 @@ pub struct Request {
 /// A builder to construct the properties of a `Request`.
 pub struct RequestBuilder {
     client: Client,
-    request: crate::Result<Request>,
+    /// The request of this builder.
+    pub request: crate::Result<Request>,
 }
 
 impl Request {


### PR DESCRIPTION
## Add set_header method for RequestBuilder for possibility to override an exist header.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/Headers/set

Need export a way to easily to override a exist `Header` key (Not append), because in sometimes, we may wants set not append.

In before:

```rs
let req = client
    .get(some_url)
    .header("timestamp", "123456")
    .header("timestamp", "456789")
    .build()
    .expect("request build");

// headers["timestamp"] is "123456, 456789" but we not wants that.
```
```rs
let req = client
    .get(some_url)
    .set_header("timestamp", "123456")
    .set_header("timestamp", "456789")
    .build()
    .expect("request build");

assert_eq!(req.headers()["timestamp"], "456789");
```

## Make RequestBuilder's `request` field as public

Use this `req.request` to do more complex things.

If not have this way, when we wants get `headers`, `method`, `url`, we must build builder.

```rs
let req = client.get("/foo").header("foo", "bar")
let builder = self.try_clone().unwrap();
let request = builder.build().unwrap();
let headers = request.headers();
```

