### PR TITLE
Update async body doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! There are several ways you can set the body of a request. The basic one is
 //! by using the `body()` method of a [`RequestBuilder`][builder]. This lets you set the
 //! exact raw bytes of what the body should be. It accepts various types,
-//! including `String`, `Vec<u8>`, and `File`. If you wish to pass a custom
+//! including `String` and `Vec<u8>`. If you wish to pass a custom
 //! type, you can use the `reqwest::Body` constructors.
 //!
 //! ```rust


### PR DESCRIPTION
Remove `File` from examples of what `.body()` accept, as far as I can tell `File` is only available in [blocking](https://github.com/seanmonstar/reqwest/blob/master/src/blocking/body.rs#L201-L209) and not in [async](https://github.com/seanmonstar/reqwest/blob/master/src/async_impl/body.rs)