### PR TITLE
wasm: don't send request body as plain uint8 array

### DIFF
--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -2,7 +2,7 @@
 use super::multipart::Form;
 /// dox
 use bytes::Bytes;
-use js_sys::{Array, Uint8Array};
+use js_sys::{Uint8Array};
 use std::fmt;
 use wasm_bindgen::JsValue;
 
@@ -40,8 +40,7 @@ impl Body {
             Inner::Bytes(body_bytes) => {
                 let body_bytes: &[u8] = body_bytes.as_ref();
                 let body_uint8_array: Uint8Array = body_bytes.into();
-                let body_array = Array::from(&body_uint8_array);
-                let js_value: &JsValue = body_array.as_ref();
+                let js_value: &JsValue = body_uint8_array.as_ref();
                 Ok(js_value.to_owned())
             }
             #[cfg(feature = "multipart")]
@@ -131,8 +130,8 @@ impl fmt::Debug for Body {
 
 #[cfg(test)]
 mod tests {
-    use js_sys::{Array, Uint8Array};
-    use wasm_bindgen::{prelude::*, JsValue};
+    // use js_sys::{Array, Uint8Array};
+    use wasm_bindgen::{prelude::*};
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -157,20 +156,17 @@ mod tests {
     async fn test_body_js() {
         use crate::Body;
 
-        let body = Body::from("TEST");
+        let body_value = "TEST";
+        let body = Body::from(body_value);
+        
+        let mut init = web_sys::RequestInit::new();
+        init.method("POST");
+        init.body(Some(body.to_js_value().expect("could not convert body to JsValue").as_ref()));
 
-        let arr = [84u8, 69, 83, 84];
-        let u8_arr: Uint8Array = arr.as_ref().into();
-        let expected = JsValue::from(Array::from(&u8_arr));
+        let js_req = web_sys::Request::new_with_str_and_init("", &init).expect("could not create JS request");
+        let text_promise = js_req.text().expect("could not get text promise");
+        let text = crate::wasm::promise::<JsValue>(text_promise).await.expect("could not get request body as text");
 
-        // ty JS -.-
-        assert_eq!(
-            format!("{:#?}", expected),
-            format!(
-                "{:#?}",
-                body.to_js_value()
-                    .expect("could not convert body to JsValue")
-            )
-        );
+        assert_eq!(text.as_string().expect("text is not a string"), body_value);
     }
 }


### PR DESCRIPTION
#1354 claims to fix the issue that bodies are sent as plain uint8 array. But, for me, this is unfortunately still the case.

This MR would add:
* A fix for the issue
* An improved test case that generates a request and checks the body contains what it should.