### PR TITLE
wasm: fix standalone/multipart body conversion to JsValue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,8 @@ features = [
     "Blob",
     "BlobPropertyBag",
     "ServiceWorkerGlobalScope",
-    "RequestCredentials"
+    "RequestCredentials",
+    "File"
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -19,8 +19,10 @@ pub struct Body {
 
 enum Inner {
     Bytes(Bytes),
+    /// MultipartForm holds a multipart/form-data body.
     #[cfg(feature = "multipart")]
     MultipartForm(Form),
+    /// MultipartPart holds the body of a multipart/form-data part.
     #[cfg(feature = "multipart")]
     MultipartPart(Bytes),
 }
@@ -73,6 +75,7 @@ impl Body {
         }
     }
 
+    /// into_part turns a regular body into the body of a mutlipart/form-data part.
     #[cfg(feature = "multipart")]
     pub(crate) fn into_part(self) -> Body {
         match self.inner {

--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -150,7 +150,7 @@ impl Part {
     fn new(value: Body) -> Part {
         Part {
             meta: PartMetadata::new(),
-            value,
+            value: value.into_part(),
         }
     }
 
@@ -191,7 +191,7 @@ impl Part {
         }
 
         // BUG: the return value of to_js_value() is not valid if
-        // it is a Multipart variant.
+        // it is a MultipartForm variant.
         let js_value = self.value.to_js_value()?;
         Blob::new_with_u8_array_sequence_and_options(&js_value, &properties)
             .map_err(crate::error::wasm)


### PR DESCRIPTION
This is an attempt to fix the conflicting conversion code requried to turn a `Body` into a `JsValue` depending if the body is standalone or if it is part of a form (aka multipart/form-data).

The idea is to introduce a new variant to the `crate::wasm::body::Inner` enum that holds the actual content of a body. The new variant allows `Body.to_js_value` to have dedicated codepaths for standalone bodies and form parts. The new variant is contructed by the new `Body.into_part` method. That method is called by the `crate::wasm::multipart::Part::new` constructor and turns an Inner::Body into the new Inner::MultipartPart variant.

The drawback is that the new variant leads to some code duplication in the `Body` methods where it mostly shares code with the `Inner::Bytes` variant.

For clarity the PR renames the `Inner::Multipart` variant to `Inner::MultipartForm`. It also adds new test cases to cover the serialization of different bodies either standalone or multipart.

Thanks to @crapStone for pointing at the `Inner` enum in #1358 and @skystar-p for the original mutlipart conversion code in #1341.