### PR TITLE
More clearer error when http proxy can't reach destination

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -714,6 +714,8 @@ where
         // else read more
         } else if recvd.starts_with(b"HTTP/1.1 407") {
             return Err("proxy authentication required".into());
+        } else if recvd.starts_with(b"HTTP/1.1 404") || recvd.starts_with(b"HTTP/1.1 523") {
+            return Err("proxy can't reach destination".into());
         } else {
             return Err("unsuccessful tunnel".into());
         }


### PR DESCRIPTION
Currently there is no way to tell whether the http proxy is able to reach destination or not. This should give more info on error instead of getting `unsuccessful tunnel`