### PR TITLE
add overrides resolver

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1222,11 +1222,13 @@ impl ClientBuilder {
     /// traffic to a particular port you must include this port in the URL
     /// itself, any port in the overridden addr will be ignored and traffic sent
     /// to the conventional port for the given scheme (e.g. 80 for http).
-        pub fn resolver(mut self, overrides_resolver: Box<dyn CustomerDnsOverridesResolver>) -> ClientBuilder {
+    pub fn resolver(
+        mut self,
+        overrides_resolver: Box<dyn CustomerDnsOverridesResolver>,
+    ) -> ClientBuilder {
         self.config.dns_overrides_resolver = Some(overrides_resolver);
         self
     }
-
 }
 
 type HyperClient = hyper::Client<Connector, super::body::ImplStream>;

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -16,6 +16,7 @@ use tokio::sync::{mpsc, oneshot};
 use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::wait;
+use crate::connect::CustomerDnsOverridesResolver;
 #[cfg(feature = "__tls")]
 use crate::tls;
 #[cfg(feature = "__tls")]
@@ -23,7 +24,6 @@ use crate::Certificate;
 #[cfg(any(feature = "native-tls", feature = "__rustls"))]
 use crate::Identity;
 use crate::{async_impl, header, redirect, IntoUrl, Method, Proxy};
-use crate::connect::CustomerDnsOverridesResolver;
 
 /// A `Client` to make Requests with.
 ///
@@ -765,7 +765,10 @@ impl ClientBuilder {
     /// traffic to a particular port you must include this port in the URL
     /// itself, any port in the overridden addr will be ignored and traffic sent
     /// to the conventional port for the given scheme (e.g. 80 for http).
-    pub fn resolver(self, overrides_resolver: Box<dyn CustomerDnsOverridesResolver>) -> ClientBuilder {
+    pub fn resolver(
+        self,
+        overrides_resolver: Box<dyn CustomerDnsOverridesResolver>,
+    ) -> ClientBuilder {
         self.with_inner(|inner| inner.resolver(overrides_resolver))
     }
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -23,6 +23,7 @@ use crate::Certificate;
 #[cfg(any(feature = "native-tls", feature = "__rustls"))]
 use crate::Identity;
 use crate::{async_impl, header, redirect, IntoUrl, Method, Proxy};
+use crate::connect::CustomerDnsOverridesResolver;
 
 /// A `Client` to make Requests with.
 ///
@@ -753,6 +754,19 @@ impl ClientBuilder {
     /// to the conventional port for the given scheme (e.g. 80 for http).
     pub fn resolve(self, domain: &str, addr: SocketAddr) -> ClientBuilder {
         self.with_inner(|inner| inner.resolve(domain, addr))
+    }
+
+    /// Override DNS resolution for specific domains to particular IP addresses
+    /// if return value not NONE
+    ///
+    /// Warning
+    ///
+    /// Since the DNS protocol has no notion of ports, if you wish to send
+    /// traffic to a particular port you must include this port in the URL
+    /// itself, any port in the overridden addr will be ignored and traffic sent
+    /// to the conventional port for the given scheme (e.g. 80 for http).
+    pub fn resolver(self, overrides_resolver: Box<dyn CustomerDnsOverridesResolver>) -> ClientBuilder {
+        self.with_inner(|inner| inner.resolver(overrides_resolver))
     }
 
     // private

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -4,6 +4,7 @@ use std::convert::TryInto;
 use std::fmt;
 use std::future::Future;
 use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -740,6 +741,18 @@ impl ClientBuilder {
     /// Defaults to false.
     pub fn https_only(self, enabled: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.https_only(enabled))
+    }
+
+    /// Override DNS resolution for specific domains to particular IP addresses.
+    ///
+    /// Warning
+    ///
+    /// Since the DNS protocol has no notion of ports, if you wish to send
+    /// traffic to a particular port you must include this port in the URL
+    /// itself, any port in the overridden addr will be ignored and traffic sent
+    /// to the conventional port for the given scheme (e.g. 80 for http).
+    pub fn resolve(self, domain: &str, addr: SocketAddr) -> ClientBuilder {
+        self.with_inner(|inner| inner.resolve(domain, addr))
     }
 
     // private

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -46,9 +46,13 @@ impl HttpConnector {
         Self::Gai(hyper::client::HttpConnector::new())
     }
 
-    pub(crate) fn new_gai_with_overrides(overrides: HashMap<String, SocketAddr>) -> Self {
+    pub(crate) fn new_gai_with_overrides(
+        overrides: HashMap<String, SocketAddr>,
+        overrides_resolver: Option<Box<dyn CustomerDnsOverridesResolver>>,
+    ) -> Self {
         let gai = hyper::client::connect::dns::GaiResolver::new();
-        let overridden_resolver = DnsResolverWithOverrides::new(gai, overrides);
+        let overridden_resolver =
+            DnsResolverWithOverrides::new(gai, overrides, overrides_resolver);
         Self::GaiWithDnsOverrides(hyper::client::HttpConnector::new_with_resolver(
             overridden_resolver,
         ))
@@ -65,9 +69,11 @@ impl HttpConnector {
     #[cfg(feature = "trust-dns")]
     pub(crate) fn new_trust_dns_with_overrides(
         overrides: HashMap<String, SocketAddr>,
+        overrides_resolver: Option<Box<dyn CustomerDnsOverridesResolver>>,
     ) -> crate::Result<HttpConnector> {
         TrustDnsResolver::new()
-            .map(|resolver| DnsResolverWithOverrides::new(resolver, overrides))
+            .map(|resolver|
+                DnsResolverWithOverrides::new(resolver, overrides, overrides_resolver))
             .map(hyper::client::HttpConnector::new_with_resolver)
             .map(Self::TrustDnsWithOverrides)
             .map_err(crate::error::builder)
@@ -1013,13 +1019,26 @@ where
 {
     dns_resolver: Resolver,
     overrides: Arc<HashMap<String, SocketAddr>>,
+    overrides_resolver: Arc<Box<dyn CustomerDnsOverridesResolver>>,
 }
 
 impl<Resolver: Clone> DnsResolverWithOverrides<Resolver> {
-    fn new(dns_resolver: Resolver, overrides: HashMap<String, SocketAddr>) -> Self {
+    fn new(
+        dns_resolver: Resolver,
+        overrides: HashMap<String, SocketAddr>,
+        overrides_resolver: Option<Box<dyn CustomerDnsOverridesResolver>>,
+    ) -> Self {
         DnsResolverWithOverrides {
             dns_resolver,
             overrides: Arc::new(overrides),
+            overrides_resolver: match overrides_resolver {
+                None => {
+                    Arc::new(Box::new(BlankCustomerDnsOverridesResolver))
+                }
+                Some(overrides_resolver) => {
+                    Arc::new(overrides_resolver)
+                }
+            },
         }
     }
 }
@@ -1043,19 +1062,41 @@ where
     }
 
     fn call(&mut self, name: Name) -> Self::Future {
-        match self.overrides.get(name.as_str()) {
+        let name_str = name.as_str();
+        match self.overrides.get(name_str) {
             Some(dest) => {
                 let fut = futures_util::future::ready(Ok(itertools::Either::Right(
                     std::iter::once(dest.to_owned()),
                 )));
-                Either::Right(fut)
+                return Either::Right(fut)
             }
-            None => {
-                let resolver_fut = self.dns_resolver.call(name);
-                let y = WrappedResolverFuture { fut: resolver_fut };
-                Either::Left(y)
-            }
+            None => {}
         }
+        match self.overrides_resolver.resolve(name_str) {
+            Some(dest) => {
+                let fut = futures_util::future::ready(Ok(itertools::Either::Right(
+                    std::iter::once(dest.to_owned()),
+                )));
+                return Either::Right(fut)
+            }
+            None => {}
+        }
+        let resolver_fut = self.dns_resolver.call(name);
+        let y = WrappedResolverFuture { fut: resolver_fut };
+        Either::Left(y)
+    }
+
+}
+
+pub trait CustomerDnsOverridesResolver : Sync + Send {
+    fn resolve(&self, domain:&str)->Option<SocketAddr>;
+}
+
+struct BlankCustomerDnsOverridesResolver;
+
+impl CustomerDnsOverridesResolver for BlankCustomerDnsOverridesResolver {
+    fn resolve(&self, _: &str) -> Option<SocketAddr> {
+        None
     }
 }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -51,8 +51,7 @@ impl HttpConnector {
         overrides_resolver: Option<Box<dyn CustomerDnsOverridesResolver>>,
     ) -> Self {
         let gai = hyper::client::connect::dns::GaiResolver::new();
-        let overridden_resolver =
-            DnsResolverWithOverrides::new(gai, overrides, overrides_resolver);
+        let overridden_resolver = DnsResolverWithOverrides::new(gai, overrides, overrides_resolver);
         Self::GaiWithDnsOverrides(hyper::client::HttpConnector::new_with_resolver(
             overridden_resolver,
         ))
@@ -72,8 +71,7 @@ impl HttpConnector {
         overrides_resolver: Option<Box<dyn CustomerDnsOverridesResolver>>,
     ) -> crate::Result<HttpConnector> {
         TrustDnsResolver::new()
-            .map(|resolver|
-                DnsResolverWithOverrides::new(resolver, overrides, overrides_resolver))
+            .map(|resolver| DnsResolverWithOverrides::new(resolver, overrides, overrides_resolver))
             .map(hyper::client::HttpConnector::new_with_resolver)
             .map(Self::TrustDnsWithOverrides)
             .map_err(crate::error::builder)
@@ -1032,12 +1030,8 @@ impl<Resolver: Clone> DnsResolverWithOverrides<Resolver> {
             dns_resolver,
             overrides: Arc::new(overrides),
             overrides_resolver: match overrides_resolver {
-                None => {
-                    Arc::new(Box::new(BlankCustomerDnsOverridesResolver))
-                }
-                Some(overrides_resolver) => {
-                    Arc::new(overrides_resolver)
-                }
+                None => Arc::new(Box::new(BlankCustomerDnsOverridesResolver)),
+                Some(overrides_resolver) => Arc::new(overrides_resolver),
             },
         }
     }
@@ -1068,7 +1062,7 @@ where
                 let fut = futures_util::future::ready(Ok(itertools::Either::Right(
                     std::iter::once(dest.to_owned()),
                 )));
-                return Either::Right(fut)
+                return Either::Right(fut);
             }
             None => {}
         }
@@ -1077,7 +1071,7 @@ where
                 let fut = futures_util::future::ready(Ok(itertools::Either::Right(
                     std::iter::once(dest.to_owned()),
                 )));
-                return Either::Right(fut)
+                return Either::Right(fut);
             }
             None => {}
         }
@@ -1085,11 +1079,12 @@ where
         let y = WrappedResolverFuture { fut: resolver_fut };
         Either::Left(y)
     }
-
 }
 
-pub trait CustomerDnsOverridesResolver : Sync + Send {
-    fn resolve(&self, domain:&str)->Option<SocketAddr>;
+/// Overrides domains' ip with a function
+pub trait CustomerDnsOverridesResolver: Sync + Send {
+    /// rule
+    fn resolve(&self, domain: &str) -> Option<SocketAddr>;
 }
 
 struct BlankCustomerDnsOverridesResolver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,7 @@ if_hyper! {
     #[cfg(feature = "blocking")]
     pub mod blocking;
     mod connect;
+    pub use connect::CustomerDnsOverridesResolver;
     #[cfg(feature = "cookies")]
     pub mod cookie;
     #[cfg(feature = "trust-dns")]


### PR DESCRIPTION
I  need overrides some domain's ip, or dynamically change the ip address. It used for my application manual choose cdn.
I write it. I think this commit may help others.

Use *resolver* like this codes. impl *CustomerDnsOverridesResolver* for struct , call builder.resolver();

```rust

// overrides *.demo.com

use std::net::SocketAddr;
use regex::Regex;
use reqwest::CustomerDnsOverridesResolver;


struct DnsOverridesResolver {
    regexp: Regex,
    addr: SocketAddr,
}

impl CustomerDnsOverridesResolver for DnsOverridesResolver {
    fn resolve(&self, domain: &str) -> Option<SocketAddr> {
        if self.regexp.is_match(domain) {
            Some(self.addr)
        } else {
            None
        }
    }
}

fn mock() -> Reuslt<T>{
    reqwest::blocking::ClientBuilder::new()
        .resolver(Box::new(
             DnsOverridesResolver {
                 regexp: Regex::new(r"(.+\.)?demo\.com").unwrap(),
                 addr: address.as_str().parse()?,
             }
        ))
       .build().unwrap()
}

```

You can modify codes and comment in this commit, if inaccurate
