### PR TITLE
Update to webpki-roots 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 hyper-rustls = { version = "0.23", default-features = false, optional = true }
 rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }
 tokio-rustls = { version = "0.23", optional = true }
-webpki-roots = { version = "0.21", optional = true }
+webpki-roots = { version = "0.22", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 rustls-pemfile = { version = "0.2", optional = true }
 


### PR DESCRIPTION
This bumps `webpki-roots` to the latest version so that it can depend on `webpki 0.22` instead of `0.21` so that downstream consumers of `request` and `webpki-roots` separately can avoid duplicated dependencies.  

This is not a breaking change.