### PR TITLE
Don't panic when parsing invalid Url to Uri

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1381,7 +1381,10 @@ impl Client {
             }
         }
 
-        let uri = expect_uri(&url);
+        let uri = match expect_uri(&url) {
+            Ok(uri) => uri,
+            _ => return Pending::new_err(error::url_invalid_uri(url)),
+        };
 
         let (reusable, body) = match body {
             Some(body) => {
@@ -1794,7 +1797,7 @@ impl Future for PendingRequest {
                                 std::mem::replace(self.as_mut().headers(), HeaderMap::new());
 
                             remove_sensitive_headers(&mut headers, &self.url, &self.urls);
-                            let uri = expect_uri(&self.url);
+                            let uri = expect_uri(&self.url)?;
                             let body = match self.body {
                                 Some(Some(ref body)) => Body::reusable(body.clone()),
                                 _ => Body::empty(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -257,6 +257,10 @@ pub(crate) fn url_bad_scheme(url: Url) -> Error {
     Error::new(Kind::Builder, Some("URL scheme is not allowed")).with_url(url)
 }
 
+pub(crate) fn url_invalid_uri(url: Url) -> Error {
+    Error::new(Kind::Builder, Some("Parsed Url is not a valid Uri")).with_url(url)
+}
+
 if_wasm! {
     pub(crate) fn wasm(js_val: wasm_bindgen::JsValue) -> BoxError {
         format!("{:?}", js_val).into()

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -64,10 +64,10 @@ impl<'a> IntoUrlSealed for String {
 }
 
 if_hyper! {
-    pub(crate) fn expect_uri(url: &Url) -> http::Uri {
+    pub(crate) fn expect_uri(url: &Url) -> crate::Result<http::Uri> {
         url.as_str()
             .parse()
-            .expect("a parsed Url should always be a valid Uri")
+            .map_err(|_| crate::error::url_invalid_uri(url.clone()))
     }
 
     pub(crate) fn try_uri(url: &Url) -> Option<http::Uri> {


### PR DESCRIPTION
This provides a way to handle the parsing error up the call stack instead of panicking.
See #668.

This change should not impact the public API as `Pending` still gets returned from `execute_request`.

@timvisee fyi