### PR TITLE
Add HTTP/0.9 responses support

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -103,6 +103,7 @@ struct Config {
     #[cfg(feature = "__tls")]
     tls: TlsBackend,
     http_version_pref: HttpVersionPref,
+    http09_responses: bool,
     http1_title_case_headers: bool,
     http2_initial_stream_window_size: Option<u32>,
     http2_initial_connection_window_size: Option<u32>,
@@ -166,6 +167,7 @@ impl ClientBuilder {
                 #[cfg(feature = "__tls")]
                 tls: TlsBackend::default(),
                 http_version_pref: HttpVersionPref::All,
+                http09_responses: false,
                 http1_title_case_headers: false,
                 http2_initial_stream_window_size: None,
                 http2_initial_connection_window_size: None,
@@ -457,6 +459,10 @@ impl ClientBuilder {
         builder.pool_idle_timeout(config.pool_idle_timeout);
         builder.pool_max_idle_per_host(config.pool_max_idle_per_host);
         connector.set_keepalive(config.tcp_keepalive);
+
+        if config.http09_responses {
+            builder.http09_responses(true);
+        }
 
         if config.http1_title_case_headers {
             builder.http1_title_case_headers(true);
@@ -839,6 +845,12 @@ impl ClientBuilder {
     /// Only use HTTP/1.
     pub fn http1_only(mut self) -> ClientBuilder {
         self.config.http_version_pref = HttpVersionPref::Http1;
+        self
+    }
+
+    /// Allow HTTP/0.9 responses
+    pub fn http09_responses(mut self) -> ClientBuilder {
+        self.config.http09_responses = true;
         self
     }
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -412,6 +412,11 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.http1_only())
     }
 
+    /// Allow HTTP/0.9 responses
+    pub fn http09_responses(self) -> ClientBuilder {
+        self.with_inner(|inner| inner.http09_responses())
+    }
+
     /// Only use HTTP/2.
     pub fn http2_prior_knowledge(self) -> ClientBuilder {
         self.with_inner(|inner| inner.http2_prior_knowledge())


### PR DESCRIPTION
This PR just adds an option to ClientBuilder which enables [http09_responses](https://github.com/hyperium/hyper/blob/02f3630af64715daa3c184d3701fadc5918cd0a6/src/client/conn.rs#L568) on the hyper client. As it uses hyper it doesn't have wasm support.

Tell me if anything needs to be changed or if I need to add wasm support.