### PR TITLE
`trust-dns-optional` crate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ json = ["serde_json"]
 multipart = ["mime_guess"]
 
 trust-dns = ["trust-dns-resolver"]
+# Enable trust-dns, but don't set it as the default resolver
+trust-dns-optional = ["trust-dns"]
 
 stream = ["tokio/fs", "tokio-util"]
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -175,7 +175,7 @@ impl ClientBuilder {
                 http2_max_frame_size: None,
                 local_address: None,
                 nodelay: true,
-                trust_dns: cfg!(feature = "trust-dns"),
+                trust_dns: cfg!(all(feature = "trust-dns", not(feature="trust-dns-optional"))),
                 #[cfg(feature = "cookies")]
                 cookie_store: None,
                 https_only: false,


### PR DESCRIPTION
This feature allows one to enable use of the `trust-dns` resolver, while
not setting it as the default.
This is useful in large monorepo codebases where trust-dns is only
desirable in a small number of callsites, but feature sets are global.