### PR TITLE
Allow opting-out of response headers modification when auto-decompression is enabled

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -706,6 +706,20 @@ impl ClientBuilder {
         self
     }
 
+    /// Disable response headers modifications when decompressing the body.
+    ///
+    /// If used, `Content-Encoding` and `Content-Length` will not be removed after decompressing
+    /// the response body.
+    #[cfg(any(feature = "gzip", feature = "brotli", feature = "deflate"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "gzip", feature = "brotli", feature = "deflate")))
+    )]
+    pub fn decompress_without_header_modification(mut self) -> ClientBuilder {
+        self.config.accepts.decompress_without_header_modification = true;
+        self
+    }
+
     /// Disable auto response body gzip decompression.
     ///
     /// This method exists even if the optional `gzip` feature is not enabled.

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -282,6 +282,19 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.deflate(enable))
     }
 
+    /// Disable response headers modifications when decompressing the body.
+    ///
+    /// If used, `Content-Encoding` and `Content-Length` will not be removed after decompressing
+    /// the response body.
+    #[cfg(any(feature = "gzip", feature = "brotli", feature = "deflate"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "gzip", feature = "brotli", feature = "deflate")))
+    )]
+    pub fn decompress_without_header_modification(self) -> ClientBuilder {
+        self.with_inner(|inner| inner.decompress_without_header_modification())
+    }
+
     /// Disable auto response body gzip decompression.
     ///
     /// This method exists even if the optional `gzip` feature is not enabled.


### PR DESCRIPTION
Whenever reqwest receives a compressed response, and the corresponding decompressor is enabled, both `Content-Encoding` and `Content-Length` are removed from the response headers’ set.

This PR adds `decompress_without_header_modification()` to the `ClientBuilder` for opting out of that behavior.