### PR TITLE
Provide methods for configuring particular tls backends.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
             features: "--features native-tls"
           - name: "feat.: default-tls and rustls-tls"
             features: "--features rustls-tls"
+          - name: "feat.: default-tls, rustls-tls, native-tls, and unstable-tls-config"
+            features: "--features rustls-tls,native-tls,unstable_tls_config"
           - name: "feat.: cookies"
             features: "--features cookies"
           - name: "feat.: blocking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ rustls-tls-manual-roots = ["__rustls"]
 rustls-tls-webpki-roots = ["webpki-roots", "__rustls"]
 rustls-tls-native-roots = ["rustls-native-certs", "__rustls"]
 
+unstable-tls-config = []
+
 blocking = ["futures-util/io", "tokio/rt-multi-thread", "tokio/sync"]
 
 cookies = ["cookie_crate", "cookie_store", "proc-macro-hack"]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1176,6 +1176,73 @@ impl ClientBuilder {
         self
     }
 
+    /// Use a preconfigured Rustls backend.
+    ///
+    /// ```rust
+    /// let root_cert_store = rustls::RootCertStore::empty();
+    /// let tls = rustls::ClientConfig::builder()
+    ///     .with_safe_defaults()
+    ///     .with_root_certificates(root_cert_store)
+    ///     .with_no_client_auth();
+    /// let client = reqwest::Client::builder()
+    ///     .use_preconfigured_rustls_tls(tls)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// # Semver-exempt
+    ///
+    /// This method is exempt from semver compatiblity guarantees.
+    /// Minor or patch version updates to reqwest may update the version
+    /// of rustls to a semver incompatible version, which will manifest
+    /// as a compile-time type mismatch on the [`rustls::ClientConfig`].  
+    ///
+    /// # Optional
+    ///
+    /// This method requires both the `rustls-tls` and `unstable-tls-config` features
+    /// to be enabled.  Enabling the `unstable-tls-config` feature means opting
+    /// into the semver compatibility risks of this method.
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    #[cfg(all(feature = "unstable-tls-config", feature = "__rustls"))]
+    pub fn use_preconfigured_rustls_tls(mut self, tls: rustls::ClientConfig) -> ClientBuilder {
+        self.config.tls = crate::tls::TlsBackend::BuiltRustls(tls);
+        self
+    }
+
+    /// Use a preconfigured Native TLS backend.
+    ///
+    /// ```rust
+    /// # use native_tls_crate as native_tls;
+    /// let tls = native_tls::TlsConnector::builder()
+    ///     .build()
+    ///     .expect("tls builder");
+    /// let client = reqwest::Client::builder()
+    ///     .use_preconfigured_native_tls(tls)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// # Semver-exempt
+    ///
+    /// This method is exempt from semver compatiblity guarantees.  Minor or 
+    /// patch version updates to reqwest may update the version of rustls to a 
+    /// semver incompatible version, which will manifest as a compile-time type
+    /// mismatch on the [`native_tls::TlsConnector`](native_tls_crate::TlsConnector).  
+    ///
+    /// # Optional
+    ///
+    /// This method requires both the `native-tls` and `unstable-tls-config` features
+    /// to be enabled.  Enabling the `unstable-tls-config` feature means opting
+    /// into the semver compatibility risks of this method.
+    #[cfg(all(feature = "unstable-tls-config", feature = "native-tls"))]
+    pub fn use_preconfigured_native_tls(
+        mut self,
+        tls: native_tls_crate::TlsConnector,
+    ) -> ClientBuilder {
+        self.config.tls = crate::tls::TlsBackend::BuiltNativeTls(tls);
+        self
+    }
+
     /// Enables the [trust-dns](trust_dns_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
     ///
     /// If the `trust-dns` feature is turned on, the default option is enabled.

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1154,9 +1154,7 @@ impl ClientBuilder {
                 (&mut tls as &mut dyn Any).downcast_mut::<Option<native_tls_crate::TlsConnector>>()
             {
                 let tls = conn.take().expect("is definitely Some");
-                let tls = crate::tls::TlsBackend::BuiltNativeTls(tls);
-                self.config.tls = tls;
-                return self;
+                return self.use_preconfigured_native_tls(tls);
             }
         }
         #[cfg(feature = "__rustls")]
@@ -1165,9 +1163,7 @@ impl ClientBuilder {
                 (&mut tls as &mut dyn Any).downcast_mut::<Option<rustls::ClientConfig>>()
             {
                 let tls = conn.take().expect("is definitely Some");
-                let tls = crate::tls::TlsBackend::BuiltRustls(tls);
-                self.config.tls = tls;
-                return self;
+                return self.use_preconfigured_rustls_tls(tls);
             }
         }
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -714,6 +714,72 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))
     }
 
+    /// Use a preconfigured Rustls backend.
+    ///
+    /// ```rust
+    /// let root_cert_store = rustls::RootCertStore::empty();
+    /// let tls = rustls::ClientConfig::builder()
+    ///     .with_safe_defaults()
+    ///     .with_root_certificates(root_cert_store)
+    ///     .with_no_client_auth();
+    /// let client = reqwest::blocking::Client::builder()
+    ///     .use_preconfigured_rustls_tls(tls)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// # Semver-exempt
+    ///
+    /// This method is exempt from semver compatiblity guarantees.
+    /// Minor or patch version updates to reqwest may update the version
+    /// of rustls to a semver incompatible version, which will manifest
+    /// as a compile-time type mismatch on the [`rustls::ClientConfig`].  
+    ///
+    /// # Optional
+    ///
+    /// This method requires both the `rustls-tls` and `unstable-tls-config` features
+    /// to be enabled.  Enabling the `unstable-tls-config` feature means opting
+    /// into the semver compatibility risks of this method.
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    #[cfg(all(feature = "unstable-tls-config", feature = "__rustls"))]
+    pub fn use_preconfigured_rustls_tls(self, tls: rustls::ClientConfig) -> ClientBuilder {
+        self.with_inner(move |inner| inner.use_preconfigured_rustls_tls(tls))
+    }
+
+    /// Use a preconfigured Native TLS backend.
+    ///
+    /// ```rust
+    /// # use native_tls_crate as native_tls;
+    /// let tls = native_tls::TlsConnector::builder()
+    ///     .build()
+    ///     .expect("tls builder");
+    /// let client = reqwest::blocking::Client::builder()
+    ///     .use_preconfigured_native_tls(tls)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    ///
+    /// # Semver-exempt
+    ///
+    ///
+    /// This method is exempt from semver compatiblity guarantees.  Minor or 
+    /// patch version updates to reqwest may update the version of rustls to a 
+    /// semver incompatible version, which will manifest as a compile-time type
+    /// mismatch on the [`native_tls::TlsConnector`](native_tls_crate::TlsConnector).  
+    /// 
+    /// # Optional
+    ///
+    /// This method requires both the `native-tls` and `unstable-tls-config` features
+    /// to be enabled.  Enabling the `unstable-tls-config` feature means opting
+    /// into the semver compatibility risks of this method.
+    #[cfg(all(feature = "unstable-tls-config", feature = "native-tls"))]
+    pub fn use_preconfigured_native_tls(
+        self,
+        tls: native_tls_crate::TlsConnector,
+    ) -> ClientBuilder {
+        self.with_inner(move |inner| inner.use_preconfigured_native_tls(tls))
+    }
+
     /// Enables the [trust-dns](trust_dns_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
     ///
     /// If the `trust-dns` feature is turned on, the default option is enabled.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,9 @@
 //!   while using root certificates from the `webpki-roots` crate.
 //! - **rustls-tls-native-roots**: Enables TLS functionality provided by `rustls`,
 //!   while using root certificates from the `rustls-native-certs` crate.
+//! - **unstable-tls-config**: In conjunction with `rustls-tls` or `native-tls`,
+//!   enables manual configuration of TLS connectors.  *Warning:* the methods
+//!   provided by this feature are not guaranteed to be semver compatible.  
 //! - **blocking**: Provides the [blocking][] client API.
 //! - **cookies**: Provides cookie session support.
 //! - **gzip**: Provides response body gzip decompression.


### PR DESCRIPTION
In which I add two methods, guarded by a new "unstable-tls-config" feature flag, to add compile-time guarantees that a compatible tls configuration is provided:

```rust
impl ClientConfig {
     #[cfg(all(feature = "unstable-tls-config", feature = "__rustls"))]
     fn use_preconfigured_rustls_tls(mut self, tls: rustls::ClientBuilder) -> ClientConfig;
     #[cfg(all(feature = "unstable-tls-config", feature = "native-tls"))]
     fn use_preconfigured_native_tls(mut self, tls: native_tls_crate::TlsConnector) -> ClientConfig;
}
```

## Rationale

The closed issue #1403 was causing me some pain (as described in my comment on that issue), and I wanted to come up with a way to make it less painful.  Though it is impossible to guarantee that a provided rustls config coming from outside reqwest will always come from the same version of rustls that reqwest supports, moving the error from runtime to compile time comes pretty close, and would have saved me (and the author of that issue) a lot of headache, as the error would have been caught earlier in the development cycle.

These methods introduce a semver incompatibility, which is mitigated by  putting them behind a new opt-in feature flag that calls out the semver risk to the user.

I understand if you don't want to take on maintenance of this feature, but please consider it seriously first; from a user perspective, these methods are strictly less risky than the already-provided use_preconfigured_tls, because they catch errors deterministically at compile time, instead of having bugs show up at runtime, if the right code path is hit.  Providing a feature flag to allow users to opt-in to semver incompatibility is comparable in its stance toward rigor as rust providing the `unsafe` keyword.

## Alternatives

* I don't believe there is a way to provide a method outside of `reqwest` that would reliably catch this error at compile time, as Cargo doesn't have a way to specify "use the version that this other crate is using," but an alternative to adding these methods would be to add a specific suggestion to the `Advanced` section of the `use_preconfigured_tls` docs saying that users should add a test to their crates that verifies any function that calls `use_preconfigured_tls`, so that type mismatches can be caught more reliably.

* Leave the situation alone until rustls and native-tls release a 1.0 version, then provide type-safe methods that are semver-stable with those releases.   Looking in the documentation and github issues for the two projects, I have not found a roadmap, timeline, or tracking issue for a 1.0 release either rustls or native-tls, so the timeline for this solution is unclear.  Rustls does have a note in their readme that "There are no major breaking interface changes envisioned after the set included in the 0.20 release."  

* Do nothing.  The current documentation calls out the risk accurately.  The errors that crop up can be tested against, and are likely to manifest as non-running apps, rather than silently misbehaving SSL protection.