### PR TITLE
Implement tower Service for Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ url = "2.2"
 bytes = "1.0"
 serde = "1.0"
 serde_urlencoded = "0.7.1"
+tower-service = "0.3"
 
 # Optional deps...
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1515,6 +1515,20 @@ impl fmt::Debug for Client {
     }
 }
 
+impl tower_service::Service<Request> for Client {
+    type Response = Response;
+    type Error = crate::Error;
+    type Future = Pending;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        self.execute_request(req)
+    }
+}
+
 impl fmt::Debug for ClientBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = f.debug_struct("ClientBuilder");
@@ -1665,7 +1679,7 @@ impl ClientRef {
 }
 
 pin_project! {
-    pub(super) struct Pending {
+    pub struct Pending {
         #[pin]
         inner: PendingInner,
     }


### PR DESCRIPTION
Is this something desirable? This requires exposing `Pending` which seemed to have been hidden intentionally, is that an okay thing to do?
It's pretty straightforward and would help issues like https://github.com/seanmonstar/reqwest/issues/491 by letting people easily wrap the client in tower services for rate limiting and other desirable functionalities