### PR TITLE
Allow users to configure the trust-dns resolver used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.11.9
+
+- Add `client.dns_config()` for custom configuration
+
 ## v0.11.8
 
 - Update internal webpki-roots dependency.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest"
-version = "0.11.8" # remember to update html_root_url
+version = "0.11.9" # remember to update html_root_url
 description = "higher level HTTP client library"
 keywords = ["http", "request", "client"]
 categories = ["web-programming::http-client", "wasm"]

--- a/examples/dns_config.rs
+++ b/examples/dns_config.rs
@@ -1,0 +1,44 @@
+#![deny(warnings)]
+
+// This is using the `tokio` runtime. You'll need the following dependency:
+//
+// `tokio = { version = "1", features = ["full"] }`
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "trust-dns")]
+#[tokio::main]
+async fn main() -> Result<(), reqwest::Error> {
+    use reqwest::dns::{ResolverConfig, ResolverOpts};
+    use std::time::Duration;
+
+    let config = ResolverConfig::default();
+    let opts = ResolverOpts {
+        negative_max_ttl: Some(Duration::from_secs(60)),
+        positive_max_ttl: Some(Duration::from_secs(60 * 60)),
+        ..Default::default()
+    };
+    let client = reqwest::Client::builder()
+        .dns_config(config, opts)
+        .build()
+        .expect("unable to build reqwest client");
+
+    let res = client.get("https://doc.rust-lang.org").send().await?;
+
+    println!("Status: {}", res.status());
+
+    let body = res.text().await?;
+
+    println!("Body:\n\n{}...", &body[..512]);
+
+    Ok(())
+}
+
+// The [cfg(not(target_arch = "wasm32"))] above prevent building the tokio::main function
+// for wasm32 target, because tokio isn't compatible with wasm32.
+// If you aren't building for wasm32, you don't need that line.
+// The two lines below avoid the "'main' function not found" error when building for wasm32 target.
+#[cfg(any(target_arch = "wasm32", not(feature = "trust-dns")))]
+fn main() {
+    eprintln!(
+        "this example must run with \"--features=trust-dns\" and outside of a wasm32 context"
+    );
+}

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -24,6 +24,9 @@ use crate::Certificate;
 use crate::Identity;
 use crate::{async_impl, header, redirect, IntoUrl, Method, Proxy};
 
+#[cfg(feature = "trust-dns")]
+use crate::dns::{ResolverConfig, ResolverOpts};
+
 /// A `Client` to make Requests with.
 ///
 /// The Client has various configuration values to tweak, but the defaults
@@ -753,6 +756,12 @@ impl ClientBuilder {
     /// to the conventional port for the given scheme (e.g. 80 for http).
     pub fn resolve(self, domain: &str, addr: SocketAddr) -> ClientBuilder {
         self.with_inner(|inner| inner.resolve(domain, addr))
+    }
+
+    /// Override trust DNS resolver configuration
+    #[cfg(feature = "trust-dns")]
+    pub fn dns_config(self, config: ResolverConfig, opts: ResolverOpts) -> ClientBuilder {
+        self.with_inner(|inner| inner.dns_config(config, opts))
     }
 
     // private

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -27,7 +27,7 @@ use self::native_tls_conn::NativeTlsConn;
 #[cfg(feature = "__rustls")]
 use self::rustls_tls_conn::RustlsTlsConn;
 #[cfg(feature = "trust-dns")]
-use crate::dns::TrustDnsResolver;
+use crate::dns::{ResolverConfig, ResolverOpts, TrustDnsResolver};
 use crate::error::BoxError;
 use crate::proxy::{Proxy, ProxyScheme};
 
@@ -55,8 +55,10 @@ impl HttpConnector {
     }
 
     #[cfg(feature = "trust-dns")]
-    pub(crate) fn new_trust_dns() -> crate::Result<HttpConnector> {
-        TrustDnsResolver::new()
+    pub(crate) fn new_trust_dns(
+        runtime_config: Option<(ResolverConfig, ResolverOpts)>,
+    ) -> crate::Result<HttpConnector> {
+        TrustDnsResolver::new(runtime_config)
             .map(hyper::client::HttpConnector::new_with_resolver)
             .map(Self::TrustDns)
             .map_err(crate::error::builder)
@@ -64,9 +66,10 @@ impl HttpConnector {
 
     #[cfg(feature = "trust-dns")]
     pub(crate) fn new_trust_dns_with_overrides(
+        runtime_config: Option<(ResolverConfig, ResolverOpts)>,
         overrides: HashMap<String, SocketAddr>,
     ) -> crate::Result<HttpConnector> {
-        TrustDnsResolver::new()
+        TrustDnsResolver::new(runtime_config)
             .map(|resolver| DnsResolverWithOverrides::new(resolver, overrides))
             .map(hyper::client::HttpConnector::new_with_resolver)
             .map(Self::TrustDnsWithOverrides)

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,3 +1,28 @@
+//! DNS client resolution options
+//!
+//! ```
+//! # use reqwest::Error;
+//! #
+//! # async fn run() -> Result<(), Error> {
+//! use reqwest::dns::{ResolverConfig, ResolverOpts};
+//! use std::time::Duration;
+//!
+//! let config = ResolverConfig::default();
+//! let opts = ResolverOpts {
+//!     negative_max_ttl: Some(Duration::from_secs(60)),
+//!     positive_max_ttl: Some(Duration::from_secs(60 * 60)),
+//!     ..Default::default()
+//! };
+//! let client = reqwest::Client::builder()
+//!     .dns_config(config, opts)
+//!     .build()
+//!     .expect("unable to build reqwest client");
+//!
+//! let res = client.get("https://doc.rust-lang.org").send().await?;
+//! # Ok(())
+//! # }
+//! ```
+
 use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
@@ -9,12 +34,14 @@ use hyper::client::connect::dns as hyper_dns;
 use hyper::service::Service;
 use tokio::sync::Mutex;
 use trust_dns_resolver::{
-    config::{ResolverConfig, ResolverOpts},
-    lookup_ip::LookupIpIntoIter,
-    system_conf, AsyncResolver, TokioConnection, TokioConnectionProvider, TokioHandle,
+    lookup_ip::LookupIpIntoIter, system_conf, AsyncResolver, TokioConnection,
+    TokioConnectionProvider, TokioHandle,
 };
 
 use crate::error::BoxError;
+
+// make them accessible for consuming applications
+pub use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 
 type SharedResolver = Arc<AsyncResolver<TokioConnection, TokioConnectionProvider>>;
 
@@ -33,21 +60,48 @@ pub(crate) struct SocketAddrs {
 }
 
 enum State {
-    Init,
+    Init(Option<(ResolverConfig, ResolverOpts)>),
     Ready(SharedResolver),
 }
 
+impl State {
+    async fn get_resolver(&mut self) -> Result<SharedResolver, BoxError> {
+        let resolver = match self {
+            State::Init(user_config) => {
+                let (config, opts) = if let Some(user) = &*user_config {
+                    // TODO this clone is pointless, hope for copy elision
+                    user.clone()
+                } else {
+                    let system: &(ResolverConfig, ResolverOpts) = SYSTEM_CONF
+                        .as_ref()
+                        .expect("can't construct TrustDnsResolver if SYSTEM_CONF is error");
+                    system.clone()
+                };
+                let resolver = Arc::new(AsyncResolver::new(config, opts, TokioHandle)?);
+                *self = State::Ready(resolver.clone());
+                resolver
+            }
+            State::Ready(resolver) => resolver.clone(),
+        };
+        Ok(resolver)
+    }
+}
+
 impl TrustDnsResolver {
-    pub(crate) fn new() -> io::Result<Self> {
-        SYSTEM_CONF.as_ref().map_err(|e| {
-            io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e))
-        })?;
+    pub(crate) fn new(user_config: Option<(ResolverConfig, ResolverOpts)>) -> io::Result<Self> {
+        if user_config.is_none() {
+            // only touch and load the system config if no configuration is supplied so users get an early error
+            SYSTEM_CONF.as_ref().map_err(|e| {
+                io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e))
+            })?;
+        }
 
         // At this stage, we might not have been called in the context of a
         // Tokio Runtime, so we must delay the actual construction of the
         // resolver.
         Ok(TrustDnsResolver {
-            state: Arc::new(Mutex::new(State::Init)),
+            state: Arc::new(Mutex::new(State::Init(user_config))),
+            //runtime_config,
         })
     }
 }
@@ -66,14 +120,7 @@ impl Service<hyper_dns::Name> for TrustDnsResolver {
         Box::pin(async move {
             let mut lock = resolver.state.lock().await;
 
-            let resolver = match &*lock {
-                State::Init => {
-                    let resolver = new_resolver().await?;
-                    *lock = State::Ready(resolver.clone());
-                    resolver
-                }
-                State::Ready(resolver) => resolver.clone(),
-            };
+            let resolver = lock.get_resolver().await?;
 
             // Don't keep lock once the resolver is constructed, otherwise
             // only one lookup could be done at a time.
@@ -93,13 +140,4 @@ impl Iterator for SocketAddrs {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|ip_addr| SocketAddr::new(ip_addr, 0))
     }
-}
-
-async fn new_resolver() -> Result<SharedResolver, BoxError> {
-    let (config, opts) = SYSTEM_CONF
-        .as_ref()
-        .expect("can't construct TrustDnsResolver if SYSTEM_CONF is error")
-        .clone();
-    let resolver = AsyncResolver::new(config, opts, TokioHandle)?;
-    Ok(Arc::new(resolver))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/reqwest/0.11.8")]
+#![doc(html_root_url = "https://docs.rs/reqwest/0.11.9")]
 
 //! # reqwest
 //!
@@ -313,7 +313,7 @@ if_hyper! {
     #[cfg(feature = "cookies")]
     pub mod cookie;
     #[cfg(feature = "trust-dns")]
-    mod dns;
+    pub mod dns;
     mod proxy;
     pub mod redirect;
     #[cfg(feature = "__tls")]


### PR DESCRIPTION
Hi all

I implemented a configuration interface for trust-dns to solve timeout problems after a network change, [see this issue](https://gitlab.com/news-flash/news_flash_gtk/-/issues/298).
It is not yet able to use [`trust_dns::Resolver.clear_cache`](https://github.com/bluejekyll/trust-dns/pull/1611) but setting the timeout low enough should fix the inside vs. outside view problem.

I reexport the configuration structs from trust-dns to prevent the users from mixing versions in their code so everything should stay compatible even if they use a newer/older version of trust-dns elsewhere.

Currently, this is a first implementation: Feedback is very welcome :blush: 

Cheers,
Stefan

For reference:
* https://github.com/seanmonstar/reqwest/issues/1407
* https://github.com/bluejekyll/trust-dns/issues/1608
* https://github.com/bluejekyll/trust-dns/pull/1611