### PR TITLE
Fix HTTP/2: retry requests rejected by a graceful shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
 http-body = "0.4.0"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
+h2 = "0.3.10"
 lazy_static = "1.4"
 log = "0.4"
 mime = "0.3.16"


### PR DESCRIPTION
When a server starts a graceful shutdown, and rejects a set of requests, those request futures would return an HTTP/2 error. This patch now inspects the error, and it is specifically an HTTP/2 graceful shutdown, _and_ the request body can be reused, the request will be retried on a different connection. There is a limit of 2 retries just prevent possible infinite loops.

(It turns out writing a test was difficult, since hyper's graceful shutdown isn't flexible enough to select which extra requests to reject. I have verified it fixes what was reported in #1276.)

Closes #1276 