### PR TITLE
Add ability to clear cookies from a `CookieStore`

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1466,6 +1466,16 @@ impl Client {
             }
         }
     }
+
+    /// If a `CookieStore` is configured for the `Client`, clear any stored
+    /// `Cookie`s.
+    #[cfg(feature = "cookies")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "cookies")))]
+    pub fn clear_cookies(&self) {
+        if let Some(cookie_store) = self.inner.cookie_store.as_ref() {
+            cookie_store.clear();
+        }
+    }
 }
 
 impl fmt::Debug for Client {

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -14,6 +14,8 @@ pub trait CookieStore: Send + Sync {
     fn set_cookies(&self, cookie_headers: &mut dyn Iterator<Item = &HeaderValue>, url: &url::Url);
     /// Get any Cookie values in the store for `url`
     fn cookies(&self, url: &url::Url) -> Option<HeaderValue>;
+    /// Clear the contents of the `CookieStore`
+    fn clear(&self);
 }
 
 /// A single HTTP cookie.
@@ -187,5 +189,9 @@ impl CookieStore for Jar {
         }
 
         HeaderValue::from_maybe_shared(Bytes::from(s)).ok()
+    }
+
+    fn clear(&self) {
+        self.0.write().unwrap().clear()
     }
 }


### PR DESCRIPTION
Addresses #613 for a simple "batteries included" quality-of-life improvement. 

Adds method `clear(&self)` to trait `cookies::CookieStore`, allowing
users to clear a store's contents.

Adds method `clear_cookies(&self)` to `Client` under feature `cookies`.

Alternatively, instead of adding this to the `cookies::CookieStore` trait and expanding the `Client` API, the `cookies::Jar` impl could be extended with the requested method directly. However, this does not seem to be as "batteries included" for users that simply want to utilize the default `Jar` via `ClientBuilder::cookie_store(true)`.