### PR TITLE
Dns overrides with a function

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1260,9 +1260,9 @@ impl ClientBuilder {
     /// to the conventional port for the given scheme (e.g. 80 for http).
     pub fn resolve_fn(
         mut self,
-        func: Box<dyn Fn(String) -> Option<SocketAddr> + Send + Sync>,
+        func: impl Fn(String) -> Option<SocketAddr> + Send + Sync + 'static,
     ) -> ClientBuilder {
-        self.config.dns_overrides_fn = Some(func);
+        self.config.dns_overrides_fn = Some(Box::new(func));
         self
     }
 }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -760,6 +760,23 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.resolve(domain, addr))
     }
 
+    /// Override DNS resolution for specific domains to particular IP addresses.
+    /// If both are specified, overrides has priority.
+    /// Results will be cached, rebuild the client to apply the modified rules.
+    ///
+    /// Warning
+    ///
+    /// Since the DNS protocol has no notion of ports, if you wish to send
+    /// traffic to a particular port you must include this port in the URL
+    /// itself, any port in the overridden addr will be ignored and traffic sent
+    /// to the conventional port for the given scheme (e.g. 80 for http).
+    pub fn resolve_fn(
+        self,
+        func: Box<dyn Fn(String) -> Option<SocketAddr> + Send + Sync>,
+    ) -> ClientBuilder {
+        self.with_inner(|inner| inner.resolve_fn(func))
+    }
+
     // private
 
     fn with_inner<F>(mut self, func: F) -> ClientBuilder

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -772,7 +772,7 @@ impl ClientBuilder {
     /// to the conventional port for the given scheme (e.g. 80 for http).
     pub fn resolve_fn(
         self,
-        func: Box<dyn Fn(String) -> Option<SocketAddr> + Send + Sync>,
+        func: impl Fn(String) -> Option<SocketAddr> + Send + Sync + 'static,
     ) -> ClientBuilder {
         self.with_inner(|inner| inner.resolve_fn(func))
     }


### PR DESCRIPTION
Can overrides dns with a function

```rust
reqwest::ClientBuilder::new()
    .resolve_fn(move |domain| {
        if Regex::new(r"(.+\.)?abc\.com")
            .unwrap()
            .is_match(domain.as_str())
        {
            Some("1.2.3.4:443".parse().unwrap())
        } else {
            None
        }
    })
    .build()
    .unwrap();
```