### PR TITLE
Add URL API to Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -271,8 +271,36 @@ impl fmt::Display for Error {
 /// Display formatter for an [`Error`] with a possible related URL masked. This
 /// formatter shows that a related URL is present, but the URL itself is not
 /// shown (in case it contains sensitive information)
-#[derive(Debug)]
+///
+/// This also implements `Debug` with the URL masked
 pub struct UrlMaskedError<'a>(&'a Error);
+struct Masked;
+
+impl fmt::Debug for Masked {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<MASKED>")
+    }
+}
+
+impl<'a> fmt::Debug for UrlMaskedError<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "reqwest::UrlMaskedError(")?;
+
+        let mut builder = f.debug_struct("reqwest::Error");
+        builder.field("kind", &self.0.inner.kind);
+
+        if self.0.inner.url.is_some() {
+            builder.field("url", &Masked);
+        }
+        if let Some(ref source) = self.0.inner.source {
+            builder.field("source", source);
+        }
+
+        builder.finish()?;
+
+        write!(f, ")")
+    }
+}
 
 impl<'a> fmt::Display for UrlMaskedError<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -284,8 +312,37 @@ impl<'a> fmt::Display for UrlMaskedError<'a> {
 
 /// Display formatter for an [`Error`] with a possible related URL completely
 /// omitted (in case it contains sensitive information).
-#[derive(Debug)]
+///
+/// This also implements `Debug`, which does not omit the URL, but rather masks
+/// it (similar to [`UrlMaskedError`]) with `"<HIDDEN>"`
 pub struct UrlHiddenError<'a>(&'a Error);
+struct Hidden;
+
+impl fmt::Debug for Hidden {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<HIDDEN>")
+    }
+}
+
+impl<'a> fmt::Debug for UrlHiddenError<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "reqwest::UrlMaskedError(")?;
+
+        let mut builder = f.debug_struct("reqwest::Error");
+        builder.field("kind", &self.0.inner.kind);
+
+        if self.0.inner.url.is_some() {
+            builder.field("url", &Hidden);
+        }
+        if let Some(ref source) = self.0.inner.source {
+            builder.field("source", source);
+        }
+
+        builder.finish()?;
+
+        write!(f, ")")
+    }
+}
 
 impl<'a> fmt::Display for UrlHiddenError<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -296,10 +353,23 @@ impl<'a> fmt::Display for UrlHiddenError<'a> {
 
 /// Display formatter for an [`Error`] with a custom formatting for any related
 /// URL that may be present
-#[derive(Debug)]
+///
+/// Note: Unlike [`UrlMaskedError`] and [`UrlHiddenError`], the `Debug`
+/// implementation of this formatter WILL show the plain URL.
 pub struct UrlFormattedError<'a, F> {
     error: &'a Error,
     formatter: F,
+}
+
+impl<'a, F> fmt::Debug for UrlFormattedError<'a, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "reqwest::UrlFormattedError {{ error: {:?}, formatter: {} }}",
+            self.error,
+            std::any::type_name::<F>()
+        )
+    }
 }
 
 impl<'a, F> fmt::Display for UrlFormattedError<'a, F>
@@ -483,14 +553,18 @@ mod tests {
             format!("{}", err),
             "error sending request for url (https://api.test/?secret=1234): inner"
         );
+        assert_eq!(format!("{:?}", err), "reqwest::Error { kind: Request, url: Url { scheme: \"https\", cannot_be_a_base: false, username: \"\", password: None, host: Some(Domain(\"api.test\")), port: None, path: \"/\", query: Some(\"secret=1234\"), fragment: None }, source: \"inner\" }");
+
+        let masked = err.as_url_masked();
         assert_eq!(
-            format!("{}", err.as_url_masked()),
+            format!("{}", masked),
             "error sending request for url (<MASKED>): inner"
         );
-        assert_eq!(
-            format!("{}", err.as_url_hidden()),
-            "error sending request: inner"
-        );
+        assert_eq!(format!("{:?}", masked), "reqwest::UrlMaskedError(reqwest::Error { kind: Request, url: <MASKED>, source: \"inner\" })");
+
+        let hidden = err.as_url_hidden();
+        assert_eq!(format!("{}", hidden), "error sending request: inner");
+        assert_eq!(format!("{:?}", hidden), "reqwest::UrlMaskedError(reqwest::Error { kind: Request, url: <HIDDEN>, source: \"inner\" })");
 
         let formatted = err.as_url_formatted(|url, f| {
             if let Some(host) = url.host() {
@@ -499,10 +573,17 @@ mod tests {
                 write!(f, "no host")
             }
         });
-
         assert_eq!(
             format!("{}", formatted),
             "error sending request for url (api.test): inner"
+        );
+        // TODO: this could be flaky, with trying to get the type name of the closure
+        assert_eq!(
+            format!("{:?}", formatted),
+            format!(
+                "reqwest::UrlFormattedError {{ error: {:?}, formatter: {}::formats::{{{{closure}}}} }}",
+                err, module_path!()
+            ),
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,13 @@ use crate::{StatusCode, Url};
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// The Errors that may occur when processing a `Request`.
+///
+/// Note: Errors may include the full URL used to make the `Request`. If the URL
+/// contains sensitive information (e.g. an API key as a query parameter), be
+/// sure to remove it ([`clear_url`](Error::clear_url),
+/// [`without_url`](Error::without_url), etc.) or use a formatter (
+/// [`as_url_masked`](Error::as_url_masked),
+/// [`as_url_hidden`](Error::as_url_hidden) that does not display the full url).
 pub struct Error {
     inner: Box<Inner>,
 }
@@ -54,6 +61,63 @@ impl Error {
     /// ```
     pub fn url(&self) -> Option<&Url> {
         self.inner.url.as_ref()
+    }
+
+    /// Returns a mutable referene to the URL related to this error
+    ///
+    /// This is useful if you need to remove sensitive information from the URL
+    /// (e.g. an API key in the query), but do not want to remove the URL
+    /// entirely.
+    pub fn url_mut(&mut self) -> Option<&mut Url> {
+        self.inner.url.as_mut()
+    }
+
+    /// Set the URL related to this error
+    pub fn set_url(&mut self, url: Url) -> &mut Self {
+        self.inner.url = Some(url);
+        self
+    }
+
+    /// Clear a possible URL related to the error (in case it contains sensitive
+    /// information)
+    pub fn clear_url(&mut self) -> &mut Self {
+        self.inner.url = None;
+        self
+    }
+
+    /// Add a url related to this error (overwriting any existing)
+    pub fn with_url(mut self, url: Url) -> Self {
+        self.inner.url = Some(url);
+        self
+    }
+
+    /// Strip the related url from this error (if, for example, it contains
+    /// sensitive information)
+    pub fn without_url(mut self) -> Self {
+        self.inner.url = None;
+        self
+    }
+
+    /// Return a formatter for the error that masks any related URL
+    pub fn as_url_masked(&self) -> UrlMaskedError<'_> {
+        UrlMaskedError(self)
+    }
+
+    /// Return a formatter for the error that omits any related URL
+    pub fn as_url_hidden(&self) -> UrlHiddenError<'_> {
+        UrlHiddenError(self)
+    }
+
+    /// Return a formatter for the error with a custom display format for
+    /// any related URL.
+    pub fn as_url_formatted<F: Fn(&Url, &mut fmt::Formatter) -> fmt::Result>(
+        &self,
+        formatter: F,
+    ) -> UrlFormattedError<'_, F> {
+        UrlFormattedError {
+            error: self,
+            formatter,
+        }
     }
 
     /// Returns true if the error is from a type Builder.
@@ -128,14 +192,54 @@ impl Error {
 
     // private
 
-    pub(crate) fn with_url(mut self, url: Url) -> Error {
-        self.inner.url = Some(url);
-        self
-    }
-
     #[allow(unused)]
     pub(crate) fn into_io(self) -> io::Error {
         io::Error::new(io::ErrorKind::Other, self)
+    }
+
+    fn write_kind(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.inner.kind {
+            Kind::Builder => f.write_str("builder error")?,
+            Kind::Request => f.write_str("error sending request")?,
+            Kind::Body => f.write_str("request or response body error")?,
+            Kind::Decode => f.write_str("error decoding response body")?,
+            Kind::Redirect => f.write_str("error following redirect")?,
+            Kind::Status(ref code) => {
+                let prefix = if code.is_client_error() {
+                    "HTTP status client error"
+                } else {
+                    debug_assert!(code.is_server_error());
+                    "HTTP status server error"
+                };
+                write!(f, "{} ({})", prefix, code)?;
+            }
+        };
+        Ok(())
+    }
+
+    fn write_url_plain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(url) = &self.inner.url {
+            write!(f, " for url ({})", url.as_str())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn write_url_masked(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.inner.url.is_some() {
+            write!(f, " for url (<MASKED>)")
+        } else {
+            Ok(())
+        }
+    }
+
+    // fn write_url_formatted ?
+
+    fn write_source(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref e) = self.inner.source {
+            write!(f, ": {}", e)?;
+        }
+        Ok(())
     }
 }
 
@@ -158,42 +262,59 @@ impl fmt::Debug for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        struct ForUrl<'a>(Option<&'a Url>);
+        self.write_kind(f)?;
+        self.write_url_plain(f)?;
+        self.write_source(f)
+    }
+}
 
-        impl fmt::Display for ForUrl<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                if let Some(url) = self.0 {
-                    write!(f, " for url ({})", url.as_str())
-                } else {
-                    Ok(())
-                }
-            }
+/// Display formatter for an [`Error`] with a possible related URL masked. This
+/// formatter shows that a related URL is present, but the URL itself is not
+/// shown (in case it contains sensitive information)
+#[derive(Debug)]
+pub struct UrlMaskedError<'a>(&'a Error);
+
+impl<'a> fmt::Display for UrlMaskedError<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.write_kind(f)?;
+        self.0.write_url_masked(f)?;
+        self.0.write_source(f)
+    }
+}
+
+/// Display formatter for an [`Error`] with a possible related URL completely
+/// omitted (in case it contains sensitive information).
+#[derive(Debug)]
+pub struct UrlHiddenError<'a>(&'a Error);
+
+impl<'a> fmt::Display for UrlHiddenError<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.write_kind(f)?;
+        self.0.write_source(f)
+    }
+}
+
+/// Display formatter for an [`Error`] with a custom formatting for any related
+/// URL that may be present
+#[derive(Debug)]
+pub struct UrlFormattedError<'a, F> {
+    error: &'a Error,
+    formatter: F,
+}
+
+impl<'a, F> fmt::Display for UrlFormattedError<'a, F>
+where
+    F: Fn(&Url, &mut fmt::Formatter<'_>) -> fmt::Result,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.write_kind(f)?;
+        if let Some(url) = &self.error.inner.url {
+            let formatter = &self.formatter;
+            write!(f, " for url (")?;
+            formatter(url, f)?;
+            write!(f, ")")?;
         }
-
-        match self.inner.kind {
-            Kind::Builder => f.write_str("builder error")?,
-            Kind::Request => f.write_str("error sending request")?,
-            Kind::Body => f.write_str("request or response body error")?,
-            Kind::Decode => f.write_str("error decoding response body")?,
-            Kind::Redirect => f.write_str("error following redirect")?,
-            Kind::Status(ref code) => {
-                let prefix = if code.is_client_error() {
-                    "HTTP status client error"
-                } else {
-                    debug_assert!(code.is_server_error());
-                    "HTTP status server error"
-                };
-                write!(f, "{} ({})", prefix, code)?;
-            }
-        };
-
-        ForUrl(self.inner.url.as_ref()).fmt(f)?;
-
-        if let Some(ref e) = self.inner.source {
-            write!(f, ": {}", e)?;
-        }
-
-        Ok(())
+        self.error.write_source(f)
     }
 }
 
@@ -351,5 +472,37 @@ mod tests {
         let io = io::Error::new(io::ErrorKind::Other, err);
         let nested = super::request(io);
         assert!(nested.is_timeout());
+    }
+
+    #[test]
+    fn formats() {
+        let err =
+            super::request("inner").with_url(Url::parse("https://api.test?secret=1234").unwrap());
+
+        assert_eq!(
+            format!("{}", err),
+            "error sending request for url (https://api.test/?secret=1234): inner"
+        );
+        assert_eq!(
+            format!("{}", err.as_url_masked()),
+            "error sending request for url (<MASKED>): inner"
+        );
+        assert_eq!(
+            format!("{}", err.as_url_hidden()),
+            "error sending request: inner"
+        );
+
+        let formatted = err.as_url_formatted(|url, f| {
+            if let Some(host) = url.host() {
+                write!(f, "{}", host)
+            } else {
+                write!(f, "no host")
+            }
+        });
+
+        assert_eq!(
+            format!("{}", formatted),
+            "error sending request for url (api.test): inner"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -179,12 +179,6 @@ impl fmt::Debug for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        struct ForUrl<'a>(Option<&'a Url>);
-
-        impl fmt::Display for ForUrl<'_> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {}
-        }
-
         match self.inner.kind {
             Kind::Builder => f.write_str("builder error")?,
             Kind::Request => f.write_str("error sending request")?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ mod error;
 mod into_url;
 mod response;
 
-pub use self::error::{Error, Result};
+pub use self::error::{Error, Result, UrlFormattedError, UrlHiddenError, UrlMaskedError};
 pub use self::into_url::IntoUrl;
 pub use self::response::ResponseBuilderExt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ mod error;
 mod into_url;
 mod response;
 
-pub use self::error::{Error, Result, UrlFormattedError, UrlHiddenError, UrlMaskedError};
+pub use self::error::{Error, Result};
 pub use self::into_url::IntoUrl;
 pub use self::response::ResponseBuilderExt;
 


### PR DESCRIPTION
Closes #297 by adding methods to manipulate the URL in `Error` (`url_mut`, `set_url`, `clear_url`, `without_url`, making `with_url` public) and methods to generate formatters (`as_url_masked` for `UrlMaskedError`, `as_url_hidden` for `UrlHiddenError`, `as_url_formatted` for `UrlFormattedError`) which implement `Display` on a borrowed `Error`.

Private formatting methods for kind (`write_kind`) and source (`write_source`) are added for consistency across formats, as well as `write_url_plain` and `write_url_masked` for different URL displays.

Finally, a test was added to make sure the formatters work as expected.

---

See also, #1299 for prior implementation of some of these

---

Note: The `set_url`/`clear_url` and `with_url`/`without_url` pairs are a bit redundant, though the ergonomics are different. I'd be open to removing one of those pairs to make things a little simpler.