### PR TITLE
Bump serde_urlencoded to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ http = "0.2"
 url = "2.2"
 bytes = "1.0"
 serde = "1.0"
-serde_urlencoded = "0.7"
+serde_urlencoded = "0.7.1"
 
 # Optional deps...
 


### PR DESCRIPTION
serde_urlencoded 0.7.0 has an incorrect serde version dependency. This causes issues in `cargo update -Z minimal-versions` builds. It's not noticeable while testing in CI because cookie_store depends on serde 1.0.126, however because this is an optional dependency there is a possibility that a project using reqwest won't enable it.