### PR TITLE
Expose http::Extensions in Response

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -122,6 +122,16 @@ impl Response {
             .map(|info| info.remote_addr())
     }
 
+    /// Returns a reference to the associated extensions.
+    pub fn extensions(&self) -> &http::Extensions {
+        &self.extensions
+    }
+
+    /// Returns a mutable reference to the associated extensions.
+    pub fn extensions_mut(&mut self) -> &mut http::Extensions {
+        &mut self.extensions
+    }
+
     // body methods
 
     /// Get the full response text.

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -178,6 +178,16 @@ impl Response {
         self.inner.remote_addr()
     }
 
+    /// Returns a reference to the associated extensions.
+    pub fn extensions(&self) -> &http::Extensions {
+        self.inner.extensions()
+    }
+
+    /// Returns a mutable reference to the associated extensions.
+    pub fn extensions_mut(&mut self) -> &mut http::Extensions {
+        self.inner.extensions_mut()
+    }
+
     /// Get the content-length of the response, if it is known.
     ///
     /// Reasons it may not be known:


### PR DESCRIPTION
This PR introduces two methods for accessing and mutating `extensions` in `reqwest::Response` and `reqwest::blocking::Response`.

Resolves #1475