### PR TITLE
Propagate timeout from client to request early on

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1353,7 +1353,7 @@ impl Client {
     /// This method fails whenever the supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
         let req = url.into_url().map(move |url| Request::new(method, url));
-        RequestBuilder::new(self.clone(), req)
+        RequestBuilder::new(self.clone(), req, self.inner.request_timeout)
     }
 
     /// Executes a `Request`.
@@ -1431,10 +1431,7 @@ impl Client {
             .body(body.into_stream())
             .expect("valid request parts");
 
-        let timeout = timeout
-            .or(self.inner.request_timeout)
-            .map(tokio::time::sleep)
-            .map(Box::pin);
+        let timeout = timeout.map(tokio::time::sleep).map(Box::pin);
 
         *req.headers_mut() = headers.clone();
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -163,8 +163,16 @@ impl Request {
 }
 
 impl RequestBuilder {
-    pub(super) fn new(client: Client, request: crate::Result<Request>) -> RequestBuilder {
+    pub(super) fn new(
+        client: Client,
+        request: crate::Result<Request>,
+        request_timeout: Option<Duration>,
+    ) -> RequestBuilder {
         let mut builder = RequestBuilder { client, request };
+
+        if let Ok(request) = &mut builder.request {
+            request.timeout = request_timeout;
+        }
 
         let auth = builder
             .request

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -874,7 +874,7 @@ impl Client {
     /// This method fails whenever supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
         let req = url.into_url().map(move |url| Request::new(method, url));
-        RequestBuilder::new(self.clone(), req)
+        RequestBuilder::new(self.clone(), req, self.inner.timeout.0)
     }
 
     /// Executes a `Request`.
@@ -1019,7 +1019,7 @@ impl ClientHandle {
         let (tx, rx) = oneshot::channel();
         let (req, body) = req.into_async();
         let url = req.url().clone();
-        let timeout = req.timeout().copied().or(self.timeout.0);
+        let timeout = req.timeout().copied();
 
         self.inner
             .tx

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -152,8 +152,16 @@ impl Request {
 }
 
 impl RequestBuilder {
-    pub(crate) fn new(client: Client, request: crate::Result<Request>) -> RequestBuilder {
+    pub(crate) fn new(
+        client: Client,
+        request: crate::Result<Request>,
+        request_timeout: Option<Duration>,
+    ) -> RequestBuilder {
         let mut builder = RequestBuilder { client, request };
+
+        if let Ok(request) = &mut builder.request {
+            *request.timeout_mut() = request_timeout;
+        }
 
         let auth = builder
             .request


### PR DESCRIPTION
This allows not just setting, but also mutating the timeout via `.timeout_mut()`.

For example:
```rust
let mut request = client.post(url).build()?;

// Increase timeout (without this PR, `timeout_mut()` always returns None)
*request.timeout_mut().get_or_insert(Duration::ZERO) += timeout;

let response = client.execute(request).await?;
```

I'm not sure if this is the right approach, but some way of **increasing** timeout would be very useful :)