### PR TITLE
Use default accepts when convert http::Response to reqwest response

### DIFF
--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -343,14 +343,14 @@ impl Stream for IoStream {
 // ===== impl Accepts =====
 
 impl Accepts {
-    pub(super) fn none() -> Self {
+    pub(super) fn all() -> Self {
         Accepts {
             #[cfg(feature = "gzip")]
-            gzip: false,
+            gzip: true,
             #[cfg(feature = "brotli")]
-            brotli: false,
+            brotli: true,
             #[cfg(feature = "deflate")]
-            deflate: false,
+            deflate: true,
         }
     }
 

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -403,7 +403,7 @@ impl<T: Into<Body>> From<http::Response<T>> for Response {
     fn from(r: http::Response<T>) -> Response {
         let (mut parts, body) = r.into_parts();
         let body = body.into();
-        let body = Decoder::detect(&mut parts.headers, body, Accepts::none());
+        let body = Decoder::detect(&mut parts.headers, body, Accepts::all());
         let url = parts
             .extensions
             .remove::<ResponseUrl>()


### PR DESCRIPTION
I believe it is better to detect response body type when converting http::Response to reqwest response.
1. Compressed body can be automatically decompress so `text` and `json` function can work as intented. 
2. We can still read raw bytes after detect response body type easily, however decompressing body is much harder.
3. Cannot find another way to set the body content type. Cannot access `Decoder` and response's `new` function which accepts an `Accepts` param.