### PR TITLE
Fix typo in `Client::new()` docs

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1273,7 +1273,7 @@ impl Client {
     ///
     /// # Panics
     ///
-    /// This method panics if a TLS backend cannot initialized, or the resolver
+    /// This method panics if a TLS backend cannot be initialized, or the resolver
     /// cannot load the system configuration.
     ///
     /// Use `Client::builder()` if you wish to handle the failure as an `Error`


### PR DESCRIPTION
`s/cannot initialized/cannot be initialized/`