### PR TITLE
Note that authentication headers do not survive redirects

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -227,7 +227,8 @@ impl RequestBuilder {
         self
     }
 
-    /// Enable HTTP basic authentication.
+    /// Enable HTTP basic authentication. Beware authentication
+    /// headers are stripped on redirection.
     ///
     /// ```rust
     /// # use reqwest::Error;

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -250,7 +250,8 @@ impl RequestBuilder {
         self
     }
 
-    /// Enable HTTP basic authentication.
+    /// Enable HTTP basic authentication. Beware authentication
+    /// headers are stripped on redirection.
     ///
     /// ```rust
     /// # fn run() -> Result<(), Box<std::error::Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,10 @@
 //! maximum redirect chain of 10 hops. To customize this behavior, a
 //! [`redirect::Policy`][redirect] can be used with a `ClientBuilder`.
 //!
+//! **NOTE**: unlike some clients like `libcurl`, when `reqwest`
+//! performs redirects, it strips out sensitive headers, including
+//! those used for authentication.
+//!
 //! ## Cookies
 //!
 //! The automatic storing and sending of session cookies can be enabled with


### PR DESCRIPTION
I lost a few hours of productivity due to the fact that `reqwest` doesn't pass authentication headers during redirects. `libcurl` does this. Python's `requests` library does this. I understand the security benefits, so I'm not asking to take out the feature, but I think this really needs to be better documented so that users like me don't have break out a MITM proxy to figure out why standard auth flows just don't work with `reqwest`.