### PR TITLE
Bump cookie to 0.16; tokio-util to 0.7; trust-dns-resolver to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ rustls-pemfile = { version = "0.3", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.16", package = "cookie", optional = true }
-cookie_store = { version = "0.15", optional = true }
+cookie_store = { version = "0.16", optional = true }
 proc-macro-hack = { version = "0.5.19", optional = true }
 
 ## compression

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,19 +121,19 @@ rustls-native-certs = { version = "0.6", optional = true }
 rustls-pemfile = { version = "0.3", optional = true }
 
 ## cookies
-cookie_crate = { version = "0.15", package = "cookie", optional = true }
+cookie_crate = { version = "0.16", package = "cookie", optional = true }
 cookie_store = { version = "0.15", optional = true }
 proc-macro-hack = { version = "0.5.19", optional = true }
 
 ## compression
 async-compression = { version = "0.3.7", default-features = false, features = ["tokio"], optional = true }
-tokio-util = { version = "0.6.0", default-features = false, features = ["codec", "io"], optional = true }
+tokio-util = { version = "0.7.0", default-features = false, features = ["codec", "io"], optional = true }
 
 ## socks
 tokio-socks = { version = "0.5.1", optional = true }
 
 ## trust-dns
-trust-dns-resolver = { version = "0.20", optional = true }
+trust-dns-resolver = { version = "0.21", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 env_logger = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ proc-macro-hack = { version = "0.5.19", optional = true }
 
 ## compression
 async-compression = { version = "0.3.7", default-features = false, features = ["tokio"], optional = true }
-tokio-util = { version = "0.7.0", default-features = false, features = ["codec", "io"], optional = true }
+tokio-util = { version = "0.7.1", default-features = false, features = ["codec", "io"], optional = true }
 
 ## socks
 tokio-socks = { version = "0.5.1", optional = true }


### PR DESCRIPTION
which now works that cookie_store has been upgraded to 0.16.0.

Also, trust-dns-resolver 0.21 gets rid of chrono dependency with its outstanding security advisory.

should also resolve #1507 and #1473 