### PR TITLE
Issue-1154 Expose hyper HTTP2 keep-alive config.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,25 @@ jobs:
           profile: minimal
           override: true
 
+      - name: Add mingw32 to path for i686-gnu
+        run: |
+          echo "C:\msys64\mingw32\bin" >> $GITHUB_PATH
+          echo "C:\msys64\usr\bin" >> $GITHUB_PATH
+        if: matrix.target == 'i686-pc-windows-gnu'
+        shell: bash
+      - name: Add mingw64 to path for x86_64-gnu
+        run: |
+          echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
+          echo "C:\msys64\usr\bin" >> $GITHUB_PATH
+        if: matrix.target == 'x86_64-pc-windows-gnu'
+        shell: bash
+      - name: Update gcc
+        if: matrix.target == 'x86_64-pc-windows-gnu'
+        run: pacman.exe -Sy --noconfirm mingw-w64-x86_64-toolchain
+      - name: Update gcc
+        if: matrix.target == 'i686-pc-windows-gnu'
+        run: pacman.exe -Sy --noconfirm mingw-w64-i686-toolchain
+
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ cookie_store = { version = "0.16", optional = true }
 proc-macro-hack = { version = "0.5.19", optional = true }
 
 ## compression
-async-compression = { version = "0.3.7", default-features = false, features = ["tokio"], optional = true }
+async-compression = { version = "0.3.13", default-features = false, features = ["tokio"], optional = true }
 tokio-util = { version = "0.7.1", default-features = false, features = ["codec", "io"], optional = true }
 
 ## socks

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -954,11 +954,14 @@ impl ClientBuilder {
     ///
     /// Pass `None` to disable HTTP2 keep-alive.
     /// Default is currently disabled.
-    pub fn http2_keep_alive_interval(mut self, interval: impl Into<Option<Duration>>) -> ClientBuilder {
+    pub fn http2_keep_alive_interval(
+        mut self,
+        interval: impl Into<Option<Duration>>,
+    ) -> ClientBuilder {
         self.config.http2_keep_alive_interval = interval.into();
         self
     }
-    
+
     /// Sets a timeout for receiving an acknowledgement of the keep-alive ping.
     ///
     /// If the ping is not acknowledged within the timeout, the connection will be closed.
@@ -968,7 +971,7 @@ impl ClientBuilder {
         self.config.http2_keep_alive_timeout = Some(timeout);
         self
     }
-    
+
     /// Sets whether HTTP2 keep-alive should apply while the connection is idle.
     ///
     /// If disabled, keep-alive pings are only sent while there are open request/responses streams.

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -110,6 +110,9 @@ struct Config {
     http2_initial_connection_window_size: Option<u32>,
     http2_adaptive_window: bool,
     http2_max_frame_size: Option<u32>,
+    http2_keep_alive_interval: Option<Duration>,
+    http2_keep_alive_timeout: Option<Duration>,
+    http2_keep_alive_while_idle: bool,
     local_address: Option<IpAddr>,
     nodelay: bool,
     #[cfg(feature = "cookies")]
@@ -175,6 +178,9 @@ impl ClientBuilder {
                 http2_initial_connection_window_size: None,
                 http2_adaptive_window: false,
                 http2_max_frame_size: None,
+                http2_keep_alive_interval: None,
+                http2_keep_alive_timeout: None,
+                http2_keep_alive_while_idle: false,
                 local_address: None,
                 nodelay: true,
                 trust_dns: cfg!(feature = "trust-dns"),
@@ -475,6 +481,15 @@ impl ClientBuilder {
         }
         if let Some(http2_max_frame_size) = config.http2_max_frame_size {
             builder.http2_max_frame_size(http2_max_frame_size);
+        }
+        if let Some(http2_keep_alive_interval) = config.http2_keep_alive_interval {
+            builder.http2_keep_alive_interval(http2_keep_alive_interval);
+        }
+        if let Some(http2_keep_alive_timeout) = config.http2_keep_alive_timeout {
+            builder.http2_keep_alive_timeout(http2_keep_alive_timeout);
+        }
+        if config.http2_keep_alive_while_idle {
+            builder.http2_keep_alive_while_idle(true);
         }
 
         builder.pool_idle_timeout(config.pool_idle_timeout);
@@ -932,6 +947,36 @@ impl ClientBuilder {
     /// Default is currently 16,384 but may change internally to optimize for common uses.
     pub fn http2_max_frame_size(mut self, sz: impl Into<Option<u32>>) -> ClientBuilder {
         self.config.http2_max_frame_size = sz.into();
+        self
+    }
+
+    /// Sets an interval for HTTP2 Ping frames should be sent to keep a connection alive.
+    ///
+    /// Pass `None` to disable HTTP2 keep-alive.
+    /// Default is currently disabled.
+    pub fn http2_keep_alive_interval(mut self, interval: impl Into<Option<Duration>>) -> ClientBuilder {
+        self.config.http2_keep_alive_interval = interval.into();
+        self
+    }
+    
+    /// Sets a timeout for receiving an acknowledgement of the keep-alive ping.
+    ///
+    /// If the ping is not acknowledged within the timeout, the connection will be closed.
+    /// Does nothing if `http2_keep_alive_interval` is disabled.
+    /// Default is currently disabled.
+    pub fn http2_keep_alive_timeout(mut self, timeout: Duration) -> ClientBuilder {
+        self.config.http2_keep_alive_timeout = Some(timeout);
+        self
+    }
+    
+    /// Sets whether HTTP2 keep-alive should apply while the connection is idle.
+    ///
+    /// If disabled, keep-alive pings are only sent while there are open request/responses streams.
+    /// If enabled, pings are also sent when no streams are active.
+    /// Does nothing if `http2_keep_alive_interval` is disabled.
+    /// Default is `false`.
+    pub fn http2_keep_alive_while_idle(mut self, enabled: bool) -> ClientBuilder {
+        self.config.http2_keep_alive_while_idle = enabled;
         self
     }
 


### PR DESCRIPTION
## Background

hyper provides HTTP2 keep-alive features such as `http2_keep_alive_interval`, `http2_keep_alive_timeout`, `http2_keep_alive_while_idle`. We have a desire to use these features on reqwest as well.

## Change

Expose hyper HTTP2 keep-alive config.
Fixes https://github.com/seanmonstar/reqwest/issues/1154