### PR TITLE
Keep body around in `Error` when JSON decoding fails

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -252,7 +252,8 @@ impl Response {
     pub async fn json<T: DeserializeOwned>(self) -> crate::Result<T> {
         let full = self.bytes().await?;
 
-        serde_json::from_slice(&full).map_err(crate::error::decode)
+        serde_json::from_slice(&full).map_err(|err|
+                                              crate::error::decode_body(err, full))
     }
 
     /// Get the full response body as `Bytes`.


### PR DESCRIPTION
* Sometimes you want to inspect the JSON data that failed to parse.