### PR TITLE
make use_preconfigured_tls more type-safe

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -128,20 +128,20 @@ impl Default for ClientBuilder {
 }
 
 pub trait TlsConfig {
-    fn to_tls_backend(self) -> crate::tls::TlsBackend;
+    fn to_tls_backend(self, builder: &mut ClientBuilder);
 }
 
 #[cfg(feature = "native-tls")]
 impl TlsConfig for native_tls_crate::TlsConnector {
-    fn to_tls_backend(self) -> crate::tls::TlsBackend {
-        crate::tls::TlsBackend::BuiltNativeTls(self)
+    fn to_tls_backend(self, builder: &mut ClientBuilder) {
+        builder.config.tls = crate::tls::TlsBackend::BuiltNativeTls(self)
     }
 }
 
 #[cfg(feature = "__rustls")]
 impl TlsConfig for rustls::ClientConfig {
-    fn to_tls_backend(self) -> crate::tls::TlsBackend {
-        crate::tls::TlsBackend::BuiltRustls(self)
+    fn to_tls_backend(self, builder: &mut ClientBuilder) {
+        builder.config.tls = crate::tls::TlsBackend::BuiltRustls(self);
     }
 }
 
@@ -1256,7 +1256,7 @@ impl ClientBuilder {
     #[cfg(any(feature = "native-tls", feature = "__rustls",))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
     pub fn use_preconfigured_tls(mut self, tls: impl TlsConfig) -> ClientBuilder {
-        self.config.tls = tls.to_tls_backend();
+        tls.to_tls_backend(&mut self);
         self
     }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -466,12 +466,6 @@ impl ClientBuilder {
                         config.nodelay,
                     )
                 }
-                #[cfg(any(feature = "native-tls", feature = "__rustls",))]
-                TlsBackend::UnknownPreconfigured => {
-                    return Err(crate::error::builder(
-                        "Unknown TLS backend passed to `use_preconfigured_tls`",
-                    ));
-                }
             }
 
             #[cfg(not(feature = "__tls"))]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1,5 +1,3 @@
-#[cfg(any(feature = "native-tls", feature = "__rustls",))]
-use std::any::Any;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -129,21 +127,21 @@ impl Default for ClientBuilder {
     }
 }
 
-trait TlsConfig {
+pub trait TlsConfig {
     fn to_tls_backend(self) -> crate::tls::TlsBackend;
 }
 
 #[cfg(feature = "native-tls")]
 impl TlsConfig for native_tls_crate::TlsConnector {
-    fn to_tls_backend(self) {
-        crate::tls::TlsBackend::BuiltNativeTls(tls)
+    fn to_tls_backend(self) -> crate::tls::TlsBackend {
+        crate::tls::TlsBackend::BuiltNativeTls(self)
     }
 }
 
 #[cfg(feature = "__rustls")]
-impl TlsConfig for native_tls_crate::ClientBuilder {
-    fn to_tls_backend(self) {
-        crate::tls::TlsBackend::BuiltRustls(tls)
+impl TlsConfig for rustls::ClientConfig {
+    fn to_tls_backend(self) -> crate::tls::TlsBackend {
+        crate::tls::TlsBackend::BuiltRustls(self)
     }
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -341,7 +341,8 @@ impl Version {
     }
 }
 
-pub(crate) enum TlsBackend {
+#[allow(missing_docs)]
+pub enum TlsBackend {
     #[cfg(feature = "default-tls")]
     Default,
     #[cfg(feature = "native-tls")]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -341,8 +341,7 @@ impl Version {
     }
 }
 
-#[allow(missing_docs)]
-pub enum TlsBackend {
+pub(crate) enum TlsBackend {
     #[cfg(feature = "default-tls")]
     Default,
     #[cfg(feature = "native-tls")]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -350,8 +350,6 @@ pub(crate) enum TlsBackend {
     Rustls,
     #[cfg(feature = "__rustls")]
     BuiltRustls(rustls::ClientConfig),
-    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
-    UnknownPreconfigured,
 }
 
 impl fmt::Debug for TlsBackend {
@@ -365,8 +363,6 @@ impl fmt::Debug for TlsBackend {
             TlsBackend::Rustls => write!(f, "Rustls"),
             #[cfg(feature = "__rustls")]
             TlsBackend::BuiltRustls(_) => write!(f, "BuiltRustls"),
-            #[cfg(any(feature = "native-tls", feature = "__rustls",))]
-            TlsBackend::UnknownPreconfigured => write!(f, "UnknownPreconfigured"),
         }
     }
 }


### PR DESCRIPTION
The current implementation of `use_preconfigured_tls` permits any type to be passed at compile-time, and does not even give a runtime error. As only two types are actually supported, I added a trait to make it a compile-time error to pass another type.