### PR TITLE
feat: enable client to be a service without ownership

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1577,6 +1577,20 @@ impl tower_service::Service<Request> for Client {
     }
 }
 
+impl tower_service::Service<Request> for &'_ Client {
+    type Response = Response;
+    type Error = crate::Error;
+    type Future = Pending;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        self.execute_request(req)
+    }
+}
+
 impl fmt::Debug for ClientBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = f.debug_struct("ClientBuilder");


### PR DESCRIPTION
With the current impl on `Client`, using a client as a service requires ownership. This can be done relatively cheaply by cloning, but is a bit of a UX sore. We can improve this by adding an impl on the shared reference. This will enable usage of a client as a service in a way that doesn't require explicit cloning for repeated use where not required. This is analogous to the impls on the `hyper::Client`.