### PR TITLE
Migrate lazy_static to once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ futures-util = { version = "0.3.0", default-features = false }
 http-body = "0.4.0"
 hyper = { version = "0.14.18", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
 h2 = "0.3.10"
-lazy_static = "1.4"
+once_cell = "1"
 log = "0.4"
 mime = "0.3.16"
 percent-encoding = "2.1"

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -7,6 +7,7 @@ use std::task::{self, Poll};
 
 use hyper::client::connect::dns as hyper_dns;
 use hyper::service::Service;
+use once_cell::sync::Lazy;
 use tokio::sync::Mutex;
 use trust_dns_resolver::{
     config::{ResolverConfig, ResolverOpts},
@@ -18,10 +19,8 @@ use crate::error::BoxError;
 
 type SharedResolver = Arc<AsyncResolver<TokioConnection, TokioConnectionProvider>>;
 
-lazy_static! {
-    static ref SYSTEM_CONF: io::Result<(ResolverConfig, ResolverOpts)> =
-        system_conf::read_system_conf().map_err(io::Error::from);
-}
+static SYSTEM_CONF: Lazy<io::Result<(ResolverConfig, ResolverOpts)>> =
+    Lazy::new(|| system_conf::read_system_conf().map_err(io::Error::from));
 
 #[derive(Clone)]
 pub(crate) struct TrustDnsResolver {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,9 +289,6 @@ if_hyper! {
     #[macro_use]
     extern crate doc_comment;
 
-    #[macro_use]
-    extern crate lazy_static;
-
     #[cfg(test)]
     doctest!("../README.md");
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -7,6 +7,7 @@ use crate::into_url::{IntoUrl, IntoUrlSealed};
 use crate::Url;
 use http::{header::HeaderValue, Uri};
 use ipnet::IpNet;
+use once_cell::sync::Lazy;
 use percent_encoding::percent_decode;
 use std::collections::HashMap;
 use std::env;
@@ -755,9 +756,8 @@ impl Dst for Uri {
     }
 }
 
-lazy_static! {
-    static ref SYS_PROXIES: Arc<SystemProxyMap> = Arc::new(get_sys_proxies(get_from_registry()));
-}
+static SYS_PROXIES: Lazy<Arc<SystemProxyMap>> =
+    Lazy::new(|| Arc::new(get_sys_proxies(get_from_registry())));
 
 /// Get system proxies information.
 ///
@@ -934,7 +934,7 @@ fn parse_registry_values(registry_values: RegistryProxyValues) -> SystemProxyMap
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use std::sync::Mutex;
 
     impl Dst for Url {
@@ -1074,9 +1074,7 @@ mod tests {
     // Smallest possible content for a mutex
     struct MutexInner;
 
-    lazy_static! {
-        static ref ENVLOCK: Mutex<MutexInner> = Mutex::new(MutexInner);
-    }
+    static ENVLOCK: Lazy<Mutex<MutexInner>> = Lazy::new(|| Mutex::new(MutexInner));
 
     #[test]
     fn test_get_sys_proxies_parsing() {


### PR DESCRIPTION
once_cell has been accepted into `std` (currently nightly). Migrating to once_cell would help to eventually move to the std version and save 1 dependency.