### PR TITLE
Support bytes_stream() for wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ multipart = ["mime_guess"]
 
 trust-dns = ["trust-dns-resolver"]
 
-stream = ["tokio/fs", "tokio-util"]
+stream = ["tokio/fs", "tokio-util", "wasm-streams"]
 
 socks = ["tokio-socks"]
 
@@ -83,6 +83,8 @@ bytes = "1.0"
 serde = "1.0"
 serde_urlencoded = "0.7.1"
 tower-service = "0.3"
+futures-core = { version = "0.3.0", default-features = false }
+futures-util = { version = "0.3.0", default-features = false }
 
 # Optional deps...
 
@@ -93,8 +95,6 @@ mime_guess = { version = "2.0", default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 encoding_rs = "0.8"
-futures-core = { version = "0.3.0", default-features = false }
-futures-util = { version = "0.3.0", default-features = false }
 http-body = "0.4.0"
 hyper = { version = "0.14.18", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
 h2 = "0.3.10"
@@ -155,6 +155,7 @@ js-sys = "0.3.45"
 serde_json = "1.0"
 wasm-bindgen = "0.2.68"
 wasm-bindgen-futures = "0.4.18"
+wasm-streams = { version = "0.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"
@@ -170,7 +171,8 @@ features = [
     "BlobPropertyBag",
     "ServiceWorkerGlobalScope",
     "RequestCredentials",
-    "File"
+    "File",
+    "ReadableStream"
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -5,6 +5,10 @@ use http::{HeaderMap, StatusCode};
 use js_sys::Uint8Array;
 use url::Url;
 
+use wasm_bindgen::JsCast;
+use wasm_streams::ReadableStream;
+use futures_util::stream::StreamExt;
+
 #[cfg(feature = "json")]
 use serde::de::DeserializeOwned;
 
@@ -116,6 +120,25 @@ impl Response {
         let mut bytes = vec![0; buffer.length() as usize];
         buffer.copy_to(&mut bytes);
         Ok(bytes.into())
+    }
+   
+    /// Convert the response into a `Stream` of `Bytes` from the body.
+    #[cfg(feature = "stream")]
+    pub fn bytes_stream(self) -> impl futures_core::Stream<Item = crate::Result<Bytes>> {
+        let web_response = self.http.into_body();
+        let body = web_response.body()
+            .expect("could not create wasm byte stream");
+        let body = ReadableStream::from_raw(body.unchecked_into());
+        body.into_stream().map(|buf_js| {
+            let buffer = Uint8Array::new(
+                &buf_js
+                    .map_err(crate::error::wasm)
+                    .map_err(crate::error::decode)?,
+            );
+            let mut bytes = vec![0; buffer.length() as usize];
+            buffer.copy_to(&mut bytes);
+            Ok(bytes.into())
+        })
     }
 
     // util methods


### PR DESCRIPTION
This is derived from the [earlier PR](https://github.com/seanmonstar/reqwest/pull/1372) to add support for the `bytes_stream()` function for wasm32 but can be cleanly merged with current HEAD.

The only difference is that it uses a `LocalBoxStream` so it meets the `!Send` requirement for futures in wasm32.

I am trying to get the [reqwest_eventsource](https://github.com/jpopesculian/reqwest-eventsource) library working in wasm32 which depends on the `bytes_stream()` function.

Thanks a lot for the `reqwest` library and I hope we can see this land 🙏 
