### PR TITLE
Support for redirecting requests to trusted hosts including sensitive headers

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1965,7 +1965,7 @@ impl Future for PendingRequest {
                         .check(res.status(), &loc, &self.urls);
 
                     match action {
-                        redirect::ActionKind::Follow => {
+                        redirect::ActionKind::Follow(is_trusted) => {
                             debug!("redirecting '{}' to '{}'", self.url, loc);
 
                             if self.client.https_only && loc.scheme() != "https" {
@@ -1979,7 +1979,9 @@ impl Future for PendingRequest {
                             let mut headers =
                                 std::mem::replace(self.as_mut().headers(), HeaderMap::new());
 
-                            remove_sensitive_headers(&mut headers, &self.url, &self.urls);
+                            if !is_trusted {
+                                remove_sensitive_headers(&mut headers, &self.url, &self.urls);
+                            }
                             let uri = expect_uri(&self.url);
                             let body = match self.body {
                                 Some(Some(ref body)) => Body::reusable(body.clone()),

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -174,10 +174,19 @@ impl<'a> Attempt<'a> {
     pub fn previous(&self) -> &[Url] {
         self.previous
     }
+
     /// Returns an action meaning reqwest should follow the next URL.
     pub fn follow(self) -> Action {
         Action {
-            inner: ActionKind::Follow,
+            inner: ActionKind::Follow(false),
+        }
+    }
+
+    /// Returns an action meaning reqwest should follow the next URL,
+    /// including sensitive headers such as Authorization and Cookies.
+    pub fn follow_trusted(self) -> Action {
+        Action {
+            inner: ActionKind::Follow(true),
         }
     }
 
@@ -226,7 +235,7 @@ impl fmt::Debug for PolicyKind {
 
 #[derive(Debug)]
 pub(crate) enum ActionKind {
-    Follow,
+    Follow(bool),
     Stop,
     Error(Box<dyn StdError + Send + Sync>),
 }
@@ -265,7 +274,7 @@ fn test_redirect_policy_limit() {
         .collect::<Vec<_>>();
 
     match policy.check(StatusCode::FOUND, &next, &previous) {
-        ActionKind::Follow => (),
+        ActionKind::Follow(false) => (),
         other => panic!("unexpected {:?}", other),
     }
 
@@ -289,7 +298,7 @@ fn test_redirect_policy_custom() {
 
     let next = Url::parse("http://bar/baz").unwrap();
     match policy.check(StatusCode::FOUND, &next, &[]) {
-        ActionKind::Follow => (),
+        ActionKind::Follow(false) => (),
         other => panic!("unexpected {:?}", other),
     }
 


### PR DESCRIPTION
Hi,

This PR allows a custom `Policy` to include sensitive headers when redirecting a request. This change is backwards compatible as the default behavior is still to remove all sensitive headers. To follow a redirect request to a trusted host, users need to use the `Attempt::follow_trusted` method instead.

All tests are passing but please let me know your thoughts. 

Thanks.