### PR TITLE
 Add Experimental HTTP/3 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.swp
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ tokio-socks = { version = "0.5.1", optional = true }
 ## trust-dns
 trust-dns-resolver = { version = "0.21", optional = true }
 
-# http3 experimental support
+# HTTP/3 experimental support
 h3 = { git = "https://github.com/hyperium/h3" }
 h3-quinn = { git = "https://github.com/hyperium/h3" }
 quinn = { version = "0.8", default-features = false, features = ["tls-rustls", "ring"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = [
 ]
 
 [features]
-default = ["default-tls"]
+default = []
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.
@@ -61,6 +61,9 @@ trust-dns = ["trust-dns-resolver"]
 stream = ["tokio/fs", "tokio-util"]
 
 socks = ["tokio-socks"]
+
+# Experimental HTTP/3 client.
+http3 = ["rustls-tls"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at anytime.
@@ -140,6 +143,8 @@ trust-dns-resolver = { version = "0.21", optional = true }
 h3 = { git = "https://github.com/hyperium/h3" }
 h3-quinn = { git = "https://github.com/hyperium/h3" }
 quinn = { version = "0.8", default-features = false, features = ["tls-rustls", "ring"] }
+futures-channel = "0.3"
+
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 env_logger = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = [
 ]
 
 [features]
-default = []
+default = ["default-tls"]
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ stream = ["tokio/fs", "tokio-util"]
 socks = ["tokio-socks"]
 
 # Experimental HTTP/3 client.
-http3 = ["rustls-tls"]
+http3 = ["rustls-tls", "h3", "h3-quinn", "quinn", "futures-channel"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at anytime.
@@ -140,10 +140,10 @@ tokio-socks = { version = "0.5.1", optional = true }
 trust-dns-resolver = { version = "0.21", optional = true }
 
 # HTTP/3 experimental support
-h3 = { git = "https://github.com/hyperium/h3" }
-h3-quinn = { git = "https://github.com/hyperium/h3" }
-quinn = { version = "0.8", default-features = false, features = ["tls-rustls", "ring"] }
-futures-channel = "0.3"
+h3 = { git = "https://github.com/hyperium/h3", optional = true }
+h3-quinn = { git = "https://github.com/hyperium/h3", optional = true }
+quinn = { version = "0.8", default-features = false, features = ["tls-rustls", "ring"], optional = true  }
+futures-channel = { version="0.3", optional = true}
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ tokio-socks = { version = "0.5.1", optional = true }
 trust-dns-resolver = { version = "0.22", optional = true }
 
 # HTTP/3 experimental support
-h3 = { git = "https://github.com/hyperium/h3", optional = true }
-h3-quinn = { git = "https://github.com/hyperium/h3", optional = true }
+h3 = { version="0.0.1", optional = true }
+h3-quinn = { version="0.0.1", optional = true }
 quinn = { version = "0.8", default-features = false, features = ["tls-rustls", "ring"], optional = true  }
 futures-channel = { version="0.3", optional = true}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,11 @@ tokio-socks = { version = "0.5.1", optional = true }
 ## trust-dns
 trust-dns-resolver = { version = "0.21", optional = true }
 
+# http3 experimental support
+h3 = { git = "https://github.com/hyperium/h3" }
+h3-quinn = { git = "https://github.com/hyperium/h3" }
+quinn = { version = "0.8", default-features = false, features = ["tls-rustls", "ring"] }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 env_logger = "0.8"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "http1", "http2", "client", "server", "runtime"] }

--- a/examples/h3_simple.rs
+++ b/examples/h3_simple.rs
@@ -11,15 +11,10 @@ async fn main() -> Result<(), reqwest::Error> {
     use reqwest::{Client, IntoUrl, Response};
 
     async fn get<T: IntoUrl + Clone>(url: T) -> reqwest::Result<Response> {
-        let client = Client::builder()
+        Client::builder()
             .http3_prior_knowledge()
-            .build()?;
-
-        client.get(url.clone())
-            .version(Version::HTTP_3)
-            .send()
-            .await.unwrap();
-        client.get(url)
+            .build()?
+            .get(url)
             .version(Version::HTTP_3)
             .send()
             .await

--- a/examples/h3_simple.rs
+++ b/examples/h3_simple.rs
@@ -1,30 +1,30 @@
 #![deny(warnings)]
 
-use http::Version;
-use reqwest::{Client, IntoUrl, Response};
-
-async fn get<T: IntoUrl + Clone>(url: T) -> reqwest::Result<Response> {
-    let client = Client::builder()
-        .http3_prior_knowledge()
-        .build()?;
-
-    client.get(url.clone())
-        .version(Version::HTTP_3)
-        .send()
-        .await.unwrap();
-    client.get(url)
-        .version(Version::HTTP_3)
-        .send()
-        .await
-}
-
-
 // This is using the `tokio` runtime. You'll need the following dependency:
 //
 // `tokio = { version = "1", features = ["full"] }`
+#[cfg(feature = "http3")]
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
+    use http::Version;
+    use reqwest::{Client, IntoUrl, Response};
+
+    async fn get<T: IntoUrl + Clone>(url: T) -> reqwest::Result<Response> {
+        let client = Client::builder()
+            .http3_prior_knowledge()
+            .build()?;
+
+        client.get(url.clone())
+            .version(Version::HTTP_3)
+            .send()
+            .await.unwrap();
+        client.get(url)
+            .version(Version::HTTP_3)
+            .send()
+            .await
+    }
+
     // Some simple CLI args requirements...
     let url = match std::env::args().nth(1) {
         Some(url) => url,
@@ -52,5 +52,5 @@ async fn main() -> Result<(), reqwest::Error> {
 // for wasm32 target, because tokio isn't compatible with wasm32.
 // If you aren't building for wasm32, you don't need that line.
 // The two lines below avoid the "'main' function not found" error when building for wasm32 target.
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", not(feature = "http3")))]
 fn main() {}

--- a/examples/h3_simple.rs
+++ b/examples/h3_simple.rs
@@ -4,7 +4,13 @@ use http::Version;
 use reqwest::{Client, IntoUrl, Response};
 
 async fn get<T: IntoUrl>(url: T) -> reqwest::Result<Response> {
-    Client::builder().build()?.get(url).version(Version::HTTP_3).send().await
+    Client::builder()
+        .http3_prior_knowledge()
+        .build()?
+        .get(url)
+        .version(Version::HTTP_3)
+        .send()
+        .await
 }
 
 
@@ -25,10 +31,6 @@ async fn main() -> Result<(), reqwest::Error> {
 
     eprintln!("Fetching {:?}...", url);
 
-    // reqwest::get() is a convenience function.
-    //
-    // In most cases, you should create/build a reqwest::Client and reuse
-    // it for all requests.
     let res = get(url).await?;
 
     eprintln!("Response: {:?} {}", res.version(), res.status());

--- a/examples/h3_simple.rs
+++ b/examples/h3_simple.rs
@@ -1,0 +1,49 @@
+#![deny(warnings)]
+
+use http::Version;
+use reqwest::{Client, IntoUrl, Response};
+
+async fn get<T: IntoUrl>(url: T) -> reqwest::Result<Response> {
+    Client::builder().build()?.get(url).version(Version::HTTP_3).send().await
+}
+
+
+// This is using the `tokio` runtime. You'll need the following dependency:
+//
+// `tokio = { version = "1", features = ["full"] }`
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() -> Result<(), reqwest::Error> {
+    // Some simple CLI args requirements...
+    let url = match std::env::args().nth(1) {
+        Some(url) => url,
+        None => {
+            println!("No CLI URL provided, using default.");
+            "https://hyper.rs".into()
+        }
+    };
+
+    eprintln!("Fetching {:?}...", url);
+
+    // reqwest::get() is a convenience function.
+    //
+    // In most cases, you should create/build a reqwest::Client and reuse
+    // it for all requests.
+    let res = get(url).await?;
+
+    eprintln!("Response: {:?} {}", res.version(), res.status());
+    eprintln!("Headers: {:#?}\n", res.headers());
+
+    let body = res.text().await?;
+
+    println!("{}", body);
+
+    Ok(())
+}
+
+// The [cfg(not(target_arch = "wasm32"))] above prevent building the tokio::main function
+// for wasm32 target, because tokio isn't compatible with wasm32.
+// If you aren't building for wasm32, you don't need that line.
+// The two lines below avoid the "'main' function not found" error when building for wasm32 target.
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/examples/h3_simple.rs
+++ b/examples/h3_simple.rs
@@ -3,11 +3,16 @@
 use http::Version;
 use reqwest::{Client, IntoUrl, Response};
 
-async fn get<T: IntoUrl>(url: T) -> reqwest::Result<Response> {
-    Client::builder()
+async fn get<T: IntoUrl + Clone>(url: T) -> reqwest::Result<Response> {
+    let client = Client::builder()
         .http3_prior_knowledge()
-        .build()?
-        .get(url)
+        .build()?;
+
+    client.get(url.clone())
+        .version(Version::HTTP_3)
+        .send()
+        .await.unwrap();
+    client.get(url)
         .version(Version::HTTP_3)
         .send()
         .await

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -259,15 +259,6 @@ impl ClientBuilder {
                 headers.get(USER_AGENT).cloned()
             }
 
-            #[cfg(feature = "http3")]
-            let h3_resolver: Arc<dyn Resolve> = match config.trust_dns {
-                false => Arc::new(GaiResolver::new()),
-                #[cfg(feature = "trust-dns")]
-                true => Arc::new(TrustDnsResolver::new().map_err(crate::error::builder)?),
-                #[cfg(not(feature = "trust-dns"))]
-                true => unreachable!("trust-dns shouldn't be enabled unless the feature is"),
-            };
-
             let mut resolver: Arc<dyn Resolve> = match config.trust_dns {
                 false => Arc::new(GaiResolver::new()),
                 #[cfg(feature = "trust-dns")]
@@ -521,7 +512,7 @@ impl ClientBuilder {
                         }
 
                         h3_connector = Some(H3Connector::new(
-                            DynResolver::new(h3_resolver),
+                            DynResolver::new(resolver),
                             tls.clone(),
                             config.local_address,
                             transport_config,

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -27,9 +27,9 @@ use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::Body;
 #[cfg(feature = "http3")]
-use crate::async_impl::h3_client::dns::Resolver;
+use crate::async_impl::h3_client::connect::H3Connector;
 #[cfg(feature = "http3")]
-use crate::async_impl::h3_client::H3Connector;
+use crate::async_impl::h3_client::dns::Resolver;
 #[cfg(feature = "http3")]
 use crate::async_impl::h3_client::{H3Builder, H3Client, H3ResponseFuture};
 use crate::connect::{Connector, HttpConnector};

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1897,6 +1897,7 @@ impl PendingRequest {
 }
 
 fn is_retryable_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    // TODO: Does the h3 API provide a way to determine this same type of case?
     if let Some(cause) = err.source() {
         if let Some(err) = cause.downcast_ref::<h2::Error>() {
             // They sent us a graceful shutdown, try with a new connection!

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1389,6 +1389,16 @@ impl ClientBuilder {
         self.config.dns_overrides.insert(domain.to_string(), addr);
         self
     }
+
+    /// Whether to send data on the first flight ("early data") in TLS 1.3 handshakes
+    /// for HTTP/3 connections.
+    ///
+    /// The default is false.
+    #[cfg(feature = "http3")]
+    pub fn set_tls_enable_early_data(mut self, enabled: bool) -> ClientBuilder {
+        self.config.tls_enable_early_data = enabled;
+        self
+    }
 }
 
 type HyperClient = hyper::Client<Connector, super::body::ImplStream>;

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -252,6 +252,14 @@ impl ClientBuilder {
                 }
                 #[cfg(feature = "trust-dns")]
                 true => {
+                    #[cfg(feature = "http3")]
+                    if config.dns_overrides.is_empty() {
+                        resolver = Resolver::new_trust_dns()?;
+                    } else {
+                        resolver =
+                            Resolver::new_trust_dns_with_overrides(config.dns_overrides.clone())?;
+                    }
+
                     if config.dns_overrides.is_empty() {
                         HttpConnector::new_trust_dns()?
                     } else {

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1532,7 +1532,7 @@ impl Client {
         let in_flight = match version {
             #[cfg(feature = "http3")]
             http::Version::HTTP_3 => {
-                let mut req = builder.body(()).expect("valid request parts");
+                let mut req = builder.body(body).expect("valid request parts");
                 *req.headers_mut() = headers.clone();
                 ResponseFuture::H3(self.inner.h3_client.request(req))
             }

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -1,0 +1,85 @@
+use crate::async_impl::h3_client::dns::Resolver;
+use crate::error::BoxError;
+use bytes::Bytes;
+use futures_util::future;
+use h3::client::SendRequest;
+use h3_quinn::{Connection, OpenStreams};
+use http::Uri;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub(crate) struct H3Connector {
+    resolver: Resolver,
+    endpoint: quinn::Endpoint,
+}
+
+impl H3Connector {
+    pub fn new(
+        resolver: Resolver,
+        tls: rustls::ClientConfig,
+        local_addr: Option<IpAddr>,
+    ) -> H3Connector {
+        let config = quinn::ClientConfig::new(Arc::new(tls));
+
+        let socket_addr = match local_addr {
+            Some(ip) => SocketAddr::new(ip, 0),
+            None => "[::]:0".parse::<SocketAddr>().unwrap(),
+        };
+
+        let mut endpoint =
+            quinn::Endpoint::client(socket_addr).expect("unable to create QUIC endpoint");
+        endpoint.set_default_client_config(config);
+
+        Self { resolver, endpoint }
+    }
+
+    pub async fn connect(
+        &mut self,
+        dest: Uri,
+    ) -> Result<SendRequest<OpenStreams, Bytes>, BoxError> {
+        let host = dest.host().ok_or("destination must have a host")?;
+        let port = dest.port_u16().unwrap_or(443);
+
+        let addrs = if let Some(addr) = IpAddr::from_str(host).ok() {
+            // If the host is already an IP address, skip resolving.
+            vec![SocketAddr::new(addr, port)]
+        } else {
+            let addrs = self.resolver.resolve(host).await.into_iter();
+            let addrs = addrs.map(|mut addr| {
+                addr.set_port(port);
+                addr
+            });
+            addrs.collect()
+        };
+
+        self.remote_connect(addrs, host).await
+    }
+
+    async fn remote_connect(
+        &mut self,
+        addrs: Vec<SocketAddr>,
+        server_name: &str,
+    ) -> Result<SendRequest<OpenStreams, Bytes>, BoxError> {
+        let mut err = None;
+        for addr in addrs {
+            match self.endpoint.connect(addr, server_name)?.await {
+                Ok(new_conn) => {
+                    let quinn_conn = Connection::new(new_conn);
+                    let (mut driver, tx) = h3::client::new(quinn_conn).await?;
+                    tokio::spawn(async move {
+                        future::poll_fn(|cx| driver.poll_close(cx)).await.unwrap();
+                    });
+                    return Ok(tx);
+                }
+                Err(e) => err = Some(e),
+            }
+        }
+
+        match err {
+            Some(e) => Err(Box::new(e) as BoxError),
+            None => Err("failed to establish connection for HTTP/3 request".into()),
+        }
+    }
+}

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -1,15 +1,15 @@
 use crate::async_impl::h3_client::dns::resolve;
+use crate::dns::DynResolver;
 use crate::error::BoxError;
 use bytes::Bytes;
 use h3::client::SendRequest;
 use h3_quinn::{Connection, OpenStreams};
 use http::Uri;
+use hyper::client::connect::dns::Name;
 use quinn::{ClientConfig, Endpoint, TransportConfig};
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
-use hyper::client::connect::dns::Name;
-use crate::dns::DynResolver;
 
 type H3Connection = (
     h3::client::Connection<Connection, Bytes>,

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -1,13 +1,17 @@
 use crate::async_impl::h3_client::dns::Resolver;
 use crate::error::BoxError;
 use bytes::Bytes;
-use futures_util::future;
 use h3::client::SendRequest;
 use h3_quinn::{Connection, OpenStreams};
 use http::Uri;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
+
+type H3Connection = (
+    h3::client::Connection<Connection, Bytes>,
+    SendRequest<OpenStreams, Bytes>,
+);
 
 #[derive(Clone)]
 pub(crate) struct H3Connector {
@@ -35,10 +39,7 @@ impl H3Connector {
         Self { resolver, endpoint }
     }
 
-    pub async fn connect(
-        &mut self,
-        dest: Uri,
-    ) -> Result<SendRequest<OpenStreams, Bytes>, BoxError> {
+    pub async fn connect(&mut self, dest: Uri) -> Result<H3Connection, BoxError> {
         let host = dest.host().ok_or("destination must have a host")?;
         let port = dest.port_u16().unwrap_or(443);
 
@@ -61,17 +62,13 @@ impl H3Connector {
         &mut self,
         addrs: Vec<SocketAddr>,
         server_name: &str,
-    ) -> Result<SendRequest<OpenStreams, Bytes>, BoxError> {
+    ) -> Result<H3Connection, BoxError> {
         let mut err = None;
         for addr in addrs {
             match self.endpoint.connect(addr, server_name)?.await {
                 Ok(new_conn) => {
                     let quinn_conn = Connection::new(new_conn);
-                    let (mut driver, tx) = h3::client::new(quinn_conn).await?;
-                    tokio::spawn(async move {
-                        future::poll_fn(|cx| driver.poll_close(cx)).await.unwrap();
-                    });
-                    return Ok(tx);
+                    return Ok(h3::client::new(quinn_conn).await?);
                 }
                 Err(e) => err = Some(e),
             }

--- a/src/async_impl/h3_client/dns.rs
+++ b/src/async_impl/h3_client/dns.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "trust-dns")]
-use crate::dns::trust_dns::TrustDnsResolver;
 use core::task;
 use hyper::client::connect::dns::Name;
 use std::future::Future;

--- a/src/async_impl/h3_client/dns.rs
+++ b/src/async_impl/h3_client/dns.rs
@@ -1,0 +1,43 @@
+use core::task;
+use hyper::client::connect::dns::Name;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::task::Poll;
+use tower_service::Service;
+
+// Trait from hyper to implement DNS resolution for HTTP/3 client.
+pub trait Resolve {
+    type Addrs: Iterator<Item = SocketAddr>;
+    type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
+    type Future: Future<Output = Result<Self::Addrs, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>>;
+    fn resolve(&mut self, name: Name) -> Self::Future;
+}
+
+impl<S> Resolve for S
+where
+    S: Service<Name>,
+    S::Response: Iterator<Item = SocketAddr>,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    type Addrs = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Service::poll_ready(self, cx)
+    }
+
+    fn resolve(&mut self, name: Name) -> Self::Future {
+        Service::call(self, name)
+    }
+}
+
+pub(super) async fn resolve<R>(resolver: &mut R, name: Name) -> Result<R::Addrs, R::Error>
+where
+    R: Resolve,
+{
+    futures_util::future::poll_fn(|cx| resolver.poll_ready(cx)).await?;
+    resolver.resolve(name).await
+}

--- a/src/async_impl/h3_client/dns.rs
+++ b/src/async_impl/h3_client/dns.rs
@@ -1,4 +1,6 @@
 use crate::connect::DnsResolverWithOverrides;
+#[cfg(feature = "trust-dns")]
+use crate::dns::TrustDnsResolver;
 use core::task;
 use hyper::client::connect::dns::{GaiResolver, Name};
 use std::collections::HashMap;
@@ -12,24 +14,57 @@ use tower_service::Service;
 pub(crate) enum Resolver {
     Gai(GaiResolver),
     GaiWithDnsOverrides(DnsResolverWithOverrides<GaiResolver>),
+    #[cfg(feature = "trust-dns")]
+    TrustDns(TrustDnsResolver),
+    #[cfg(feature = "trust-dns")]
+    TrustDnsWithOverrides(DnsResolverWithOverrides<TrustDnsResolver>),
 }
 
 impl Resolver {
     pub fn new_gai() -> Self {
-        Resolver::Gai(GaiResolver::new())
+        Self::Gai(GaiResolver::new())
     }
 
     pub fn new_gai_with_overrides(overrides: HashMap<String, SocketAddr>) -> Self {
-        Resolver::GaiWithDnsOverrides(DnsResolverWithOverrides::new(GaiResolver::new(), overrides))
+        Self::GaiWithDnsOverrides(DnsResolverWithOverrides::new(GaiResolver::new(), overrides))
+    }
+
+    #[cfg(feature = "trust-dns")]
+    pub fn new_trust_dns() -> crate::Result<Self> {
+        TrustDnsResolver::new()
+            .map(Self::TrustDns)
+            .map_err(crate::error::builder)
+    }
+
+    #[cfg(feature = "trust-dns")]
+    pub fn new_trust_dns_with_overrides(
+        overrides: HashMap<String, SocketAddr>,
+    ) -> crate::Result<Self> {
+        TrustDnsResolver::new()
+            .map(|trust_resolver| DnsResolverWithOverrides::new(trust_resolver, overrides))
+            .map(Self::TrustDnsWithOverrides)
+            .map_err(crate::error::builder)
     }
 
     pub async fn resolve(&mut self, server_name: &str) -> Vec<SocketAddr> {
         let res: Vec<SocketAddr> = match self {
-            Resolver::Gai(resolver) => resolve(resolver, Name::from_str(server_name).unwrap())
+            Self::Gai(resolver) => resolve(resolver, Name::from_str(server_name).unwrap())
                 .await
                 .unwrap()
                 .collect(),
-            Resolver::GaiWithDnsOverrides(resolver) => {
+            Self::GaiWithDnsOverrides(resolver) => {
+                resolve(resolver, Name::from_str(server_name).unwrap())
+                    .await
+                    .unwrap()
+                    .collect()
+            }
+            #[cfg(feature = "trust-dns")]
+            Self::TrustDns(resolver) => resolve(resolver, Name::from_str(server_name).unwrap())
+                .await
+                .unwrap()
+                .collect(),
+            #[cfg(feature = "trust-dns")]
+            Self::TrustDnsWithOverrides(resolver) => {
                 resolve(resolver, Name::from_str(server_name).unwrap())
                     .await
                     .unwrap()

--- a/src/async_impl/h3_client/dns.rs
+++ b/src/async_impl/h3_client/dns.rs
@@ -5,7 +5,6 @@ use std::net::SocketAddr;
 use std::task::Poll;
 use tower_service::Service;
 
-
 // Trait from hyper to implement DNS resolution for HTTP/3 client.
 pub trait Resolve {
     type Addrs: Iterator<Item = SocketAddr>;

--- a/src/async_impl/h3_client/dns.rs
+++ b/src/async_impl/h3_client/dns.rs
@@ -1,9 +1,44 @@
+use crate::connect::DnsResolverWithOverrides;
 use core::task;
-use hyper::client::connect::dns::Name;
+use hyper::client::connect::dns::{GaiResolver, Name};
+use std::collections::HashMap;
 use std::future::Future;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::task::Poll;
 use tower_service::Service;
+
+#[derive(Clone)]
+pub(crate) enum Resolver {
+    Gai(GaiResolver),
+    GaiWithDnsOverrides(DnsResolverWithOverrides<GaiResolver>),
+}
+
+impl Resolver {
+    pub fn new_gai() -> Self {
+        Resolver::Gai(GaiResolver::new())
+    }
+
+    pub fn new_gai_with_overrides(overrides: HashMap<String, SocketAddr>) -> Self {
+        Resolver::GaiWithDnsOverrides(DnsResolverWithOverrides::new(GaiResolver::new(), overrides))
+    }
+
+    pub async fn resolve(&mut self, server_name: &str) -> Vec<SocketAddr> {
+        let res: Vec<SocketAddr> = match self {
+            Resolver::Gai(resolver) => resolve(resolver, Name::from_str(server_name).unwrap())
+                .await
+                .unwrap()
+                .collect(),
+            Resolver::GaiWithDnsOverrides(resolver) => {
+                resolve(resolver, Name::from_str(server_name).unwrap())
+                    .await
+                    .unwrap()
+                    .collect()
+            }
+        };
+        res
+    }
+}
 
 // Trait from hyper to implement DNS resolution for HTTP/3 client.
 pub trait Resolve {

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-pub struct H3Builder {
+pub(crate) struct H3Builder {
     pool_idle_timeout: Option<Duration>,
     pool_max_idle_per_host: usize,
     local_addr: Option<IpAddr>,

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -1,24 +1,19 @@
 #![cfg(feature = "http3")]
 
+pub(crate) mod connect;
 pub(crate) mod dns;
 mod pool;
 
-use crate::async_impl::h3_client::dns::Resolver;
 use crate::async_impl::h3_client::pool::{Key, Pool, PoolClient};
 use crate::error::{BoxError, Error, Kind};
 use crate::{error, Body};
-use bytes::Bytes;
+use connect::H3Connector;
 use futures_util::future;
-use h3::client::SendRequest;
-use h3_quinn::{Connection, OpenStreams};
-use http::{Request, Response, Uri};
+use http::{Request, Response};
 use hyper::Body as HyperBody;
 use log::debug;
 use std::future::Future;
-use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
-use std::str::FromStr;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -112,76 +107,5 @@ impl Future for H3ResponseFuture {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.inner.as_mut().poll(cx)
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct H3Connector {
-    resolver: Resolver,
-    endpoint: quinn::Endpoint,
-}
-
-impl H3Connector {
-    pub fn new(
-        resolver: Resolver,
-        tls: rustls::ClientConfig,
-        local_addr: Option<IpAddr>,
-    ) -> H3Connector {
-        let config = quinn::ClientConfig::new(Arc::new(tls));
-        let socket_addr = match local_addr {
-            Some(ip) => SocketAddr::new(ip, 0),
-            None => "[::]:0".parse::<SocketAddr>().unwrap(),
-        };
-
-        let mut endpoint =
-            quinn::Endpoint::client(socket_addr).expect("unable to create QUIC endpoint");
-        endpoint.set_default_client_config(config);
-
-        Self { resolver, endpoint }
-    }
-
-    pub async fn connect(
-        &mut self,
-        dest: Uri,
-    ) -> Result<SendRequest<OpenStreams, Bytes>, BoxError> {
-        let host = dest.host().ok_or("destination must have a host")?;
-        let port = dest.port_u16().unwrap_or(443);
-        let addrs = if let Some(addr) = IpAddr::from_str(host).ok() {
-            vec![SocketAddr::new(addr, port)]
-        } else {
-            let addrs = self.resolver.resolve(host).await.into_iter();
-            let addrs = addrs.map(|mut addr| {
-                addr.set_port(port);
-                addr
-            });
-            addrs.collect()
-        };
-        self.remote_connect(addrs, host).await
-    }
-
-    async fn remote_connect(
-        &mut self,
-        addrs: Vec<SocketAddr>,
-        server_name: &str,
-    ) -> Result<SendRequest<OpenStreams, Bytes>, BoxError> {
-        let mut err = None;
-        for addr in addrs {
-            match self.endpoint.connect(addr, server_name)?.await {
-                Ok(new_conn) => {
-                    let quinn_conn = Connection::new(new_conn);
-                    let (mut driver, tx) = h3::client::new(quinn_conn).await?;
-                    tokio::spawn(async move {
-                        future::poll_fn(|cx| driver.poll_close(cx)).await.unwrap();
-                    });
-                    return Ok(tx);
-                }
-                Err(e) => err = Some(e),
-            }
-        }
-
-        match err {
-            Some(e) => Err(Box::new(e) as BoxError),
-            None => Err("failed to establish connection for HTTP/3 request".into()),
-        }
     }
 }

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -1,0 +1,128 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::SystemTime;
+use rustls::client::ServerCertVerified;
+use rustls::{Error, ServerName};
+use bytes::Bytes;
+use h3::client::SendRequest;
+use http::{Request, Response, Uri};
+use crate::error::BoxError;
+use hyper::Body;
+use bytes::Buf;
+use futures_util::future;
+
+static ALPN: &[u8] = b"h3";
+
+// hyper Client
+#[derive(Clone)]
+pub struct H3Client {
+    connector: H3Connector,
+}
+
+impl H3Client {
+    #[cfg(feature = "__rustls")]
+    pub fn new() -> Self {
+        let tls_config_builder = rustls::ClientConfig::builder()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS13]).unwrap();
+        let mut tls_config = tls_config_builder
+            .with_custom_certificate_verifier(Arc::new(YesVerifier))
+            .with_no_client_auth();
+
+        tls_config.enable_early_data = true;
+        tls_config.alpn_protocols = vec![ALPN.into()];
+
+        Self {
+            connector: H3Connector {
+                config: quinn::ClientConfig::new(Arc::new(tls_config)),
+            },
+        }
+    }
+
+    pub(super) fn request(&self, req: Request<()>) -> H3ResponseFuture {
+        // Connect via connector
+        //H3ResponseFuture{inner: Box::pin(self.clone().connect_request(req))}
+        let mut connector = self.connector.clone();
+        H3ResponseFuture{inner: Box::pin(async move {
+            eprintln!("Trying http3 ...");
+            let mut send_request = connector.connect_to(req.uri().clone()).await.unwrap();
+            let mut stream = send_request.send_request(req).await.unwrap();
+            stream.finish().await.unwrap();
+
+            eprintln!("Receiving response ...");
+            let resp = stream.recv_response().await.unwrap();
+            eprintln!("Response h3 {:?}", resp);
+
+            while let Some(chunk) = stream.recv_data().await.unwrap() {
+                eprintln!("Chunk: {:?}", chunk.chunk());
+            }
+
+            Ok(resp.map(|_| {
+                Body::empty()
+            }))
+        })}
+    }
+}
+
+struct YesVerifier;
+
+impl rustls::client::ServerCertVerifier for YesVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
+
+// hyper HttpConnector
+#[derive(Clone)]
+pub struct H3Connector {
+    // TODO: is cloning this config expensive?
+    config: quinn::ClientConfig,
+}
+
+impl H3Connector {
+    async fn connect_to(&mut self, dest: Uri) -> Result<SendRequest<h3_quinn::OpenStreams, Bytes>, BoxError> {
+        let auth = dest
+            .authority()
+            .ok_or("destination must have a host")?
+            .clone();
+        let port = auth.port_u16().unwrap_or(443);
+        let addr = tokio::net::lookup_host((auth.host(), port))
+            .await?
+            .next()
+            .ok_or("dns found no addresses")?;
+        eprintln!("URI {}", dest);
+        let mut client_endpoint = h3_quinn::quinn::Endpoint::client("[::]:0".parse().unwrap())?;
+        client_endpoint.set_default_client_config(self.config.clone());
+        let quinn_conn = h3_quinn::Connection::new(client_endpoint.connect(addr, auth.host())?.await?);
+        let (mut driver, send_request) = h3::client::new(quinn_conn).await?;
+        tokio::spawn(async move {
+            future::poll_fn(|cx| driver.poll_close(cx)).await.unwrap();
+        });
+        Ok(send_request)
+    }
+}
+
+
+pub struct H3ResponseFuture {
+    inner: Pin<Box<dyn Future<Output = Result<Response<Body>, crate::Error>> + Send>>,
+}
+
+
+impl Future for H3ResponseFuture {
+    type Output = Result<Response<Body>, crate::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
+}

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -1,22 +1,20 @@
+mod pool;
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::time::SystemTime;
-use rustls::client::ServerCertVerified;
-use rustls::{Error, ServerName};
-use bytes::Bytes;
-use h3::client::SendRequest;
-use http::{Request, Response, Uri};
-use crate::error::BoxError;
+use http::{Request, Response};
+use crate::error::{BoxError, Error};
 use hyper::Body;
-use bytes::Buf;
 use futures_util::future;
+use h3_quinn::Connection;
+use crate::async_impl::h3_client::pool::{Key, PoolClient};
 
-// hyper Client
 #[derive(Clone)]
 pub struct H3Client {
-    connector: H3Connector,
+    endpoint: quinn::Endpoint,
+    // pool: Arc<Mutex<PoolInner>>
     // TODO: Since resolution is perform internally in Hyper,
     // we have no way of leveraging that functionality here.
     // resolver: Box<dyn Resolve>,
@@ -26,63 +24,16 @@ impl H3Client {
     #[cfg(feature = "http3")]
     pub fn new(mut tls: rustls::ClientConfig) -> Self {
         tls.enable_early_data = true;
+        let config = quinn::ClientConfig::new(Arc::new(tls));
+        let mut endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap()).unwrap();
+        endpoint.set_default_client_config(config);
         Self {
-            connector: H3Connector {
-                config: quinn::ClientConfig::new(Arc::new(tls)),
-            },
+            endpoint,
         }
     }
 
-    pub(super) fn request(&self, req: Request<()>) -> H3ResponseFuture {
-        // Connect via connector
-        //H3ResponseFuture{inner: Box::pin(self.clone().connect_request(req))}
-        let mut connector = self.connector.clone();
-        H3ResponseFuture{inner: Box::pin(async move {
-            eprintln!("Trying http3 ...");
-            let mut send_request = connector.connect_to(req.uri().clone()).await.unwrap();
-            let mut stream = send_request.send_request(req).await.unwrap();
-            stream.finish().await.unwrap();
-
-            eprintln!("Receiving response ...");
-            let resp = stream.recv_response().await.unwrap();
-            eprintln!("Response h3 {:?}", resp);
-
-            while let Some(chunk) = stream.recv_data().await.unwrap() {
-                eprintln!("Chunk: {:?}", chunk.chunk());
-            }
-
-            Ok(resp.map(|_| {
-                Body::empty()
-            }))
-        })}
-    }
-}
-
-struct YesVerifier;
-
-impl rustls::client::ServerCertVerifier for YesVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &rustls::Certificate,
-        _intermediates: &[rustls::Certificate],
-        _server_name: &ServerName,
-        _scts: &mut dyn Iterator<Item = &[u8]>,
-        _ocsp_response: &[u8],
-        _now: SystemTime,
-    ) -> Result<ServerCertVerified, Error> {
-        Ok(ServerCertVerified::assertion())
-    }
-}
-
-// hyper HttpConnector
-#[derive(Clone)]
-pub struct H3Connector {
-    // TODO: is cloning this config expensive?
-    config: quinn::ClientConfig,
-}
-
-impl H3Connector {
-    async fn connect_to(&mut self, dest: Uri) -> Result<SendRequest<h3_quinn::OpenStreams, Bytes>, BoxError> {
+    async fn get_pooled_client(&self, key: Key) -> Result<PoolClient, BoxError> {
+        let dest = pool::domain_as_uri(key);
         let auth = dest
             .authority()
             .ok_or("destination must have a host")?
@@ -92,23 +43,42 @@ impl H3Connector {
             .await?
             .next()
             .ok_or("dns found no addresses")?;
-        eprintln!("URI {}", dest);
-        let mut client_endpoint = h3_quinn::quinn::Endpoint::client("[::]:0".parse().unwrap())?;
-        client_endpoint.set_default_client_config(self.config.clone());
-        let quinn_conn = h3_quinn::Connection::new(client_endpoint.connect(addr, auth.host())?.await?);
-        let (mut driver, send_request) = h3::client::new(quinn_conn).await?;
+
+        let quinn_conn = Connection::new(
+            self.endpoint.connect(addr, auth.host())?.await?
+        );
+        let (mut driver, tx) = h3::client::new(quinn_conn).await?;
+
+        // TODO: What does poll_close() do?
         tokio::spawn(async move {
             future::poll_fn(|cx| driver.poll_close(cx)).await.unwrap();
         });
-        Ok(send_request)
+
+        Ok(PoolClient::new(tx))
+    }
+
+    async fn send_request(self, key: Key, req: Request<()>) -> Result<Response<Body>, Error> {
+        eprintln!("Trying http3 ...");
+        let mut pooled = match self.get_pooled_client(key).await {
+            Ok(client) => client,
+            Err(_) => panic!("failed to get pooled client")
+        };
+        // TODO: how will requests pass
+        pooled.send_request(req).await
+    }
+
+    pub(super) fn request(&self, mut req: Request<()>) -> H3ResponseFuture {
+        let pool_key = match pool::extract_domain(req.uri_mut(), false) {
+            Ok(s) => s,
+            Err(_) => panic!("invalid pool key")
+        };
+        H3ResponseFuture{inner: Box::pin(self.clone().send_request(pool_key, req))}
     }
 }
-
 
 pub struct H3ResponseFuture {
     inner: Pin<Box<dyn Future<Output = Result<Response<Body>, crate::Error>> + Send>>,
 }
-
 
 impl Future for H3ResponseFuture {
     type Output = Result<Response<Body>, crate::Error>;

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -1,18 +1,24 @@
 #![cfg(feature = "http3")]
 
+mod dns;
 mod pool;
 
+use crate::async_impl::h3_client::dns::Resolve;
 use crate::async_impl::h3_client::pool::{Key, Pool, PoolClient};
 use crate::error::{BoxError, Error, Kind};
 use crate::{error, Body};
+use bytes::Bytes;
 use futures_util::future;
-use h3_quinn::Connection;
-use http::{Request, Response};
+use h3::client::SendRequest;
+use h3_quinn::{Connection, OpenStreams};
+use http::{Request, Response, Uri};
+use hyper::client::connect::dns::{GaiResolver, Name};
 use hyper::Body as HyperBody;
 use log::debug;
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -46,8 +52,11 @@ impl H3Builder {
         endpoint.set_default_client_config(config);
 
         H3Client {
-            endpoint,
             pool: Pool::new(self.pool_max_idle_per_host, self.pool_idle_timeout),
+            connector: H3Connector {
+                resolver: GaiResolver::new(),
+                endpoint,
+            },
         }
     }
 
@@ -66,46 +75,26 @@ impl H3Builder {
 
 #[derive(Clone)]
 pub struct H3Client {
-    endpoint: quinn::Endpoint,
     pool: Pool,
-    // TODO: Since resolution is perform internally in Hyper,
-    // we have no way of leveraging that functionality here.
-    // resolver: Box<dyn Resolve>,
+    connector: H3Connector,
 }
 
 impl H3Client {
-    async fn get_pooled_client(&self, key: Key) -> Result<PoolClient, BoxError> {
+    async fn get_pooled_client(&mut self, key: Key) -> Result<PoolClient, BoxError> {
         if let Some(client) = self.pool.try_pool(&key) {
             debug!("getting client from pool with key {:?}", key);
             return Ok(client);
         }
 
         let dest = pool::domain_as_uri(key.clone());
-        let auth = dest
-            .authority()
-            .ok_or("destination must have a host")?
-            .clone();
-        let port = auth.port_u16().unwrap_or(443);
-        let addr = tokio::net::lookup_host((auth.host(), port))
-            .await?
-            .next()
-            .ok_or("dns found no addresses")?;
-
-        let quinn_conn = Connection::new(self.endpoint.connect(addr, auth.host())?.await?);
-        let (mut driver, tx) = h3::client::new(quinn_conn).await?;
-
-        // TODO: What does poll_close() do?
-        tokio::spawn(async move {
-            future::poll_fn(|cx| driver.poll_close(cx)).await.unwrap();
-        });
-
+        let tx = self.connector.connect(dest).await?;
         let client = PoolClient::new(tx);
         self.pool.put(key, client.clone());
         Ok(client)
     }
 
     async fn send_request(
-        self,
+        mut self,
         key: Key,
         req: Request<Body>,
     ) -> Result<Response<HyperBody>, Error> {
@@ -143,5 +132,63 @@ impl Future for H3ResponseFuture {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.inner.as_mut().poll(cx)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct H3Connector<R = GaiResolver> {
+    resolver: R,
+    endpoint: quinn::Endpoint,
+}
+
+impl<R> H3Connector<R>
+where
+    R: Resolve + Clone + Send + Sync + 'static,
+{
+    pub async fn connect(
+        &mut self,
+        dest: Uri,
+    ) -> Result<SendRequest<OpenStreams, Bytes>, BoxError> {
+        let host = dest.host().ok_or("destination must have a host")?;
+        let port = dest.port_u16().unwrap_or(443);
+        let addrs = if let Some(addr) = IpAddr::from_str(host).ok() {
+            vec![SocketAddr::new(addr, port)]
+        } else {
+            let addrs = dns::resolve(&mut self.resolver, Name::from_str(host)?)
+                .await
+                .map_err(|e| e.into())?;
+            let addrs = addrs.map(|mut addr| {
+                addr.set_port(port);
+                addr
+            });
+            addrs.collect()
+        };
+        self.remote_connect(addrs, host).await
+    }
+
+    async fn remote_connect(
+        &mut self,
+        addrs: Vec<SocketAddr>,
+        server_name: &str,
+    ) -> Result<SendRequest<OpenStreams, Bytes>, BoxError> {
+        let mut err = None;
+        for addr in addrs {
+            match self.endpoint.connect(addr, server_name)?.await {
+                Ok(new_conn) => {
+                    let quinn_conn = Connection::new(new_conn);
+                    let (mut driver, tx) = h3::client::new(quinn_conn).await?;
+                    tokio::spawn(async move {
+                        future::poll_fn(|cx| driver.poll_close(cx)).await.unwrap();
+                    });
+                    return Ok(tx);
+                }
+                Err(e) => err = Some(e),
+            }
+        }
+
+        match err {
+            Some(e) => Err(Box::new(e) as BoxError),
+            None => Err("failed to establish connection for HTTP/3 request".into()),
+        }
     }
 }

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -40,6 +40,7 @@ impl H3Client {
         trace!("did not find connection {:?} in pool so connecting...", key);
 
         let dest = pool::domain_as_uri(key.clone());
+        self.pool.connecting(key.clone())?;
         let (driver, tx) = self.connector.connect(dest).await?;
         Ok(self.pool.new_connection(key, driver, tx))
     }

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -17,31 +17,6 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-pub(crate) struct H3Builder {
-    pool_idle_timeout: Option<Duration>,
-}
-
-impl Default for H3Builder {
-    fn default() -> Self {
-        Self {
-            pool_idle_timeout: Some(Duration::from_secs(90)),
-        }
-    }
-}
-
-impl H3Builder {
-    pub fn build(self, connector: H3Connector) -> H3Client {
-        H3Client {
-            pool: Pool::new(self.pool_idle_timeout),
-            connector,
-        }
-    }
-
-    pub fn set_pool_idle_timeout(&mut self, timeout: Option<Duration>) {
-        self.pool_idle_timeout = timeout;
-    }
-}
-
 #[derive(Clone)]
 pub(crate) struct H3Client {
     pool: Pool,
@@ -49,6 +24,13 @@ pub(crate) struct H3Client {
 }
 
 impl H3Client {
+    pub fn new(connector: H3Connector, pool_timeout: Option<Duration>) -> Self {
+        H3Client {
+            pool: Pool::new(pool_timeout),
+            connector,
+        }
+    }
+
     async fn get_pooled_client(&mut self, key: Key) -> Result<PoolClient, BoxError> {
         if let Some(client) = self.pool.try_pool(&key) {
             trace!("getting client from pool with key {:?}", key);

--- a/src/async_impl/h3_client/pool.rs
+++ b/src/async_impl/h3_client/pool.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use std::collections::HashMap;
+use std::sync::mpsc::{Receiver, TryRecvError};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::time::Instant;
@@ -7,11 +8,13 @@ use tokio::time::Instant;
 use crate::error::{BoxError, Error, Kind};
 use crate::Body;
 use bytes::Buf;
+use futures_util::future;
 use h3::client::SendRequest;
+use h3_quinn::{Connection, OpenStreams};
 use http::uri::{Authority, Scheme};
 use http::{Request, Response, Uri};
 use hyper::Body as HyperBody;
-use log::debug;
+use log::trace;
 
 pub(super) type Key = (Scheme, Authority);
 
@@ -21,76 +24,88 @@ pub struct Pool {
 }
 
 impl Pool {
-    pub fn new(max_idle_per_host: usize, timeout: Option<Duration>) -> Self {
+    pub fn new(timeout: Option<Duration>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(PoolInner {
-                idle: HashMap::new(),
-                max_idle_per_host,
+                idle_conns: HashMap::new(),
                 timeout,
             })),
         }
     }
 
-    pub fn put(&self, key: Key, client: PoolClient) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.put(key, client)
-    }
-
     pub fn try_pool(&self, key: &Key) -> Option<PoolClient> {
         let mut inner = self.inner.lock().unwrap();
         let timeout = inner.timeout;
-        inner.idle.get_mut(&key).and_then(|list| match list.pop() {
-            Some(idle) => {
-                if let Some(duration) = timeout {
-                    if Instant::now().saturating_duration_since(idle.idle_at) > duration {
-                        debug!("pooled client expired");
-                        return None;
-                    }
-                }
-                Some(idle.value)
+        if let Some(conn) = inner.idle_conns.get(&key) {
+            // We check first if the connection still valid
+            // and if not, we remove it from the pool.
+            if conn.is_invalid() {
+                trace!("pooled HTTP/3 connection is invalid so removing it...");
+                inner.idle_conns.remove(&key);
+                return None;
             }
-            None => None,
-        })
+
+            if let Some(duration) = timeout {
+                if Instant::now().saturating_duration_since(conn.idle_timeout) > duration {
+                    trace!("pooled connection expired");
+                    return None;
+                }
+            }
+        }
+
+        inner
+            .idle_conns
+            .get_mut(&key)
+            .and_then(|conn| Some(conn.pool()))
+    }
+
+    pub fn new_connection(
+        &mut self,
+        key: Key,
+        mut driver: h3::client::Connection<Connection, Bytes>,
+        tx: SendRequest<OpenStreams, Bytes>,
+    ) -> PoolClient {
+        let (close_tx, close_rx) = std::sync::mpsc::channel();
+        tokio::spawn(async move {
+            if let Err(e) = future::poll_fn(|cx| driver.poll_close(cx)).await {
+                trace!("poll_close returned error {:?}", e);
+                close_tx.send(e).ok();
+            }
+        });
+
+        let mut inner = self.inner.lock().unwrap();
+
+        let client = PoolClient::new(tx);
+        let conn = PoolConnection::new(client.clone(), close_rx);
+        inner.insert(key, conn);
+
+        client
     }
 }
 
 struct PoolInner {
-    // These are internal Conns sitting in the event loop in the KeepAlive
-    // state, waiting to receive a new Request to send on the socket.
-    idle: HashMap<Key, Vec<Idle>>,
-    max_idle_per_host: usize,
+    idle_conns: HashMap<Key, PoolConnection>,
     timeout: Option<Duration>,
 }
 
 impl PoolInner {
-    fn put(&mut self, key: Key, client: PoolClient) {
-        if self.idle.contains_key(&key) {
-            debug!("connection already exists for key {:?}", key);
-            return;
+    fn insert(&mut self, key: Key, conn: PoolConnection) {
+        if self.idle_conns.contains_key(&key) {
+            trace!("connection already exists for key {:?}", key);
         }
 
-        let idle_list = self.idle.entry(key.clone()).or_default();
-
-        if idle_list.len() >= self.max_idle_per_host {
-            debug!("max idle per host for {:?}, dropping connection", key);
-            return;
-        }
-
-        idle_list.push(Idle {
-            idle_at: Instant::now(),
-            value: client,
-        });
+        self.idle_conns.insert(key, conn);
     }
 }
 
 #[derive(Clone)]
 pub struct PoolClient {
-    tx: SendRequest<h3_quinn::OpenStreams, Bytes>,
+    inner: SendRequest<OpenStreams, Bytes>,
 }
 
 impl PoolClient {
-    pub fn new(tx: SendRequest<h3_quinn::OpenStreams, Bytes>) -> Self {
-        Self { tx }
+    pub fn new(tx: SendRequest<OpenStreams, Bytes>) -> Self {
+        Self { inner: tx }
     }
 
     pub async fn send_request(
@@ -99,7 +114,7 @@ impl PoolClient {
     ) -> Result<Response<HyperBody>, BoxError> {
         let (head, req_body) = req.into_parts();
         let req = Request::from_parts(head, ());
-        let mut stream = self.tx.send_request(req).await?;
+        let mut stream = self.inner.send_request(req).await?;
 
         match req_body.as_bytes() {
             Some(b) if !b.is_empty() => {
@@ -121,9 +136,34 @@ impl PoolClient {
     }
 }
 
-struct Idle {
-    idle_at: Instant,
-    value: PoolClient,
+pub struct PoolConnection {
+    // This receives errors from polling h3 driver.
+    close_rx: Receiver<h3::Error>,
+    client: PoolClient,
+    idle_timeout: Instant,
+}
+
+impl PoolConnection {
+    pub fn new(client: PoolClient, close_rx: Receiver<h3::Error>) -> Self {
+        Self {
+            close_rx,
+            client,
+            idle_timeout: Instant::now(),
+        }
+    }
+
+    pub fn pool(&mut self) -> PoolClient {
+        self.idle_timeout = Instant::now();
+        self.client.clone()
+    }
+
+    pub fn is_invalid(&self) -> bool {
+        match self.close_rx.try_recv() {
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Disconnected) => true,
+            Ok(_) => true,
+        }
+    }
 }
 
 pub(crate) fn extract_domain(uri: &mut Uri) -> Result<Key, Error> {

--- a/src/async_impl/h3_client/pool.rs
+++ b/src/async_impl/h3_client/pool.rs
@@ -1,0 +1,132 @@
+use std::collections::{HashMap, HashSet};
+use std::mem;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use bytes::Bytes;
+use tokio::time::Instant;
+
+use h3::client::SendRequest;
+use http::{Request, Response, Uri};
+use http::uri::{Authority, Scheme};
+use hyper::Body;
+use crate::error::{Kind, Error};
+use bytes::Buf;
+
+pub(super) type Key = (Scheme, Authority); //Arc<String>;
+
+struct Pool {
+    inner: Arc<Mutex<PoolInner>>
+}
+
+impl Pool {
+    fn connecting(&self, key: Key) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        inner.connecting.insert(key)
+    }
+}
+
+struct PoolInner {
+    // A flag that a connection is being established, and the connection
+    // should be shared. This prevents making multiple HTTP/2 connections
+    // to the same host.
+    connecting: HashSet<Key>,
+    // These are internal Conns sitting in the event loop in the KeepAlive
+    // state, waiting to receive a new Request to send on the socket.
+    idle: HashMap<Key, Vec<Idle>>,
+    max_idle_per_host: usize,
+    timeout: Option<Duration>,
+}
+
+impl PoolInner {
+    fn put(&mut self, key: Key, client: PoolClient) {
+        if self.idle.contains_key(&key) {
+            eprintln!("connection alread exists for key {:?}", key);
+            return;
+        }
+
+        let idle_list = self.idle.entry(key).or_default();
+        idle_list.push(Idle {
+            idle_at: Instant::now(),
+            value: client
+        });
+    }
+}
+
+pub(crate) struct PoolClient {
+    tx: SendRequest<h3_quinn::OpenStreams, Bytes>
+}
+
+impl PoolClient {
+    pub fn new(tx: SendRequest<h3_quinn::OpenStreams, Bytes>) -> Self {
+        Self {
+            tx
+        }
+    }
+
+    pub async fn send_request(&mut self, req: Request<()>) -> Result<Response<Body>, Error> {
+        let mut stream = self.tx.send_request(req).await.unwrap();
+        stream.finish().await.unwrap();
+
+        eprintln!("Receiving response ...");
+        let resp = stream.recv_response().await.unwrap();
+        eprintln!("Response h3 {:?}", resp);
+
+        while let Some(chunk) = stream.recv_data().await.unwrap() {
+            eprintln!("Chunk: {:?}", chunk.chunk());
+        }
+
+        Ok(resp.map(|_| {
+            Body::empty()
+        }))
+    }
+}
+
+struct Idle {
+    idle_at: Instant,
+    value: PoolClient,
+}
+
+
+fn set_scheme(uri: &mut Uri, scheme: Scheme) {
+    debug_assert!(
+        uri.scheme().is_none(),
+        "set_scheme expects no existing scheme"
+    );
+    let old = mem::replace(uri, Uri::default());
+    let mut parts: ::http::uri::Parts = old.into();
+    parts.scheme = Some(scheme);
+    parts.path_and_query = Some("/".parse().expect("slash is a valid path"));
+    *uri = Uri::from_parts(parts).expect("scheme is valid");
+}
+
+pub(crate) fn extract_domain(uri: &mut Uri, is_http_connect: bool) -> Result<Key, Error> {
+    let uri_clone = uri.clone();
+    match (uri_clone.scheme(), uri_clone.authority()) {
+        (Some(scheme), Some(auth)) => Ok((scheme.clone(), auth.clone())),
+        (None, Some(auth)) if is_http_connect => {
+            let scheme = match auth.port_u16() {
+                Some(443) => {
+                    set_scheme(uri, Scheme::HTTPS);
+                    Scheme::HTTPS
+                }
+                _ => {
+                    set_scheme(uri, Scheme::HTTP);
+                    Scheme::HTTP
+                }
+            };
+            Ok((scheme, auth.clone()))
+        }
+        _ => {
+            Err(crate::Error::new(Kind::Request, None::<crate::Error>))
+        }
+    }
+}
+
+pub(crate) fn domain_as_uri((scheme, auth): Key) -> Uri {
+    http::uri::Builder::new()
+        .scheme(scheme)
+        .authority(auth)
+        .path_and_query("/")
+        .build()
+        .expect("domain is valid Uri")
+}

--- a/src/async_impl/h3_client/pool.rs
+++ b/src/async_impl/h3_client/pool.rs
@@ -96,6 +96,7 @@ impl PoolClient {
         }
     }
 
+    // TODO: add support for sending data.
     pub async fn send_request(&mut self, req: Request<()>) -> Result<Response<Body>, BoxError> {
         let mut stream = self.tx.send_request(req).await?;
         stream.finish().await?;

--- a/src/async_impl/h3_client/pool.rs
+++ b/src/async_impl/h3_client/pool.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "http3")]
-
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -22,13 +20,12 @@ pub struct Pool {
 }
 
 impl Pool {
-    pub fn new() -> Self {
+    pub fn new(max_idle_per_host: usize, timeout: Option<Duration>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(PoolInner {
                 idle: HashMap::new(),
-                // TODO: we should get this from some config.
-                max_idle_per_host: std::usize::MAX,
-                timeout: None,
+                max_idle_per_host,
+                timeout,
             }))
         }
     }

--- a/src/async_impl/h3_client/pool.rs
+++ b/src/async_impl/h3_client/pool.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "http3")]
+
 use std::collections::HashMap;
 use std::mem;
 use std::sync::{Arc, Mutex};

--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -9,9 +9,9 @@ pub(crate) use self::decoder::Decoder;
 pub mod body;
 pub mod client;
 pub mod decoder;
+pub mod h3_client;
 #[cfg(feature = "multipart")]
 pub mod multipart;
 pub(crate) mod request;
 mod response;
 mod upgrade;
-pub mod h3_client;

--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -14,3 +14,4 @@ pub mod multipart;
 pub(crate) mod request;
 mod response;
 mod upgrade;
+pub mod h3_client;

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -31,7 +31,6 @@ use crate::dns::TrustDnsResolver;
 use crate::error::BoxError;
 use crate::proxy::{Proxy, ProxyScheme};
 
-
 #[derive(Clone)]
 pub(crate) enum HttpConnector {
     Gai(hyper::client::HttpConnector),
@@ -525,11 +524,9 @@ impl Connector {
     #[cfg(feature = "http3")]
     pub fn deep_clone_tls(&self) -> rustls::ClientConfig {
         match &self.inner {
-            Inner::RustlsTls { tls, .. } => {
-                (*(*tls)).clone()
-            }
+            Inner::RustlsTls { tls, .. } => (*(*tls)).clone(),
             #[cfg(feature = "default-tls")]
-            _ => unreachable!("HTTP/3 should only be enabled with Rustls")
+            _ => unreachable!("HTTP/3 should only be enabled with Rustls"),
         }
     }
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -31,6 +31,8 @@ use crate::dns::TrustDnsResolver;
 use crate::error::BoxError;
 use crate::proxy::{Proxy, ProxyScheme};
 
+
+// TODO: add http3 connector
 #[derive(Clone)]
 pub(crate) enum HttpConnector {
     Gai(hyper::client::HttpConnector),
@@ -170,6 +172,7 @@ pub(crate) struct Connector {
     user_agent: Option<HeaderValue>,
 }
 
+// TODO: add http3 connector
 #[derive(Clone)]
 enum Inner {
     #[cfg(not(feature = "__tls"))]
@@ -286,6 +289,28 @@ impl Connector {
         }
     }
 
+    // TODO: add connector for http3
+    // pub(crate) fn new_http3_connector<T>(
+    //     mut http: h3_client::Http3Connector,
+    //     proxies: Arc<Vec<Proxy>>,
+    //     user_agent: Option<HeaderValue>,
+    //     nodelay: bool,
+    // ) -> Connector
+    //     where
+    //         T: Into<Option<IpAddr>>,
+    // {
+    //     Connector {
+    //         inner: Inner::TlsForH3 {
+    //             http,
+    //         },
+    //         proxies,
+    //         verbose: verbose::OFF,
+    //         timeout: None,
+    //         nodelay,
+    //         user_agent,
+    //     }
+    // }
+
     pub(crate) fn set_timeout(&mut self, timeout: Option<Duration>) {
         self.timeout = timeout;
     }
@@ -352,6 +377,7 @@ impl Connector {
         })
     }
 
+    // TODO: add http3 logic
     async fn connect_with_maybe_proxy(self, dst: Uri, is_proxy: bool) -> Result<Conn, BoxError> {
         match self.inner {
             #[cfg(not(feature = "__tls"))]

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -520,15 +520,6 @@ impl Connector {
             Inner::Http(http) => http.set_keepalive(dur),
         }
     }
-
-    #[cfg(feature = "http3")]
-    pub fn deep_clone_tls(&self) -> rustls::ClientConfig {
-        match &self.inner {
-            Inner::RustlsTls { tls, .. } => (*(*tls)).clone(),
-            #[cfg(feature = "default-tls")]
-            _ => unreachable!("HTTP/3 should only be enabled with Rustls"),
-        }
-    }
 }
 
 fn into_uri(scheme: Scheme, host: Authority) -> Uri {
@@ -1023,7 +1014,7 @@ where
 }
 
 impl<Resolver: Clone> DnsResolverWithOverrides<Resolver> {
-    fn new(dns_resolver: Resolver, overrides: HashMap<String, SocketAddr>) -> Self {
+    pub(crate) fn new(dns_resolver: Resolver, overrides: HashMap<String, SocketAddr>) -> Self {
         DnsResolverWithOverrides {
             dns_resolver,
             overrides: Arc::new(overrides),

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -171,7 +171,6 @@ pub(crate) struct Connector {
     user_agent: Option<HeaderValue>,
 }
 
-// TODO: add http3 connector
 #[derive(Clone)]
 enum Inner {
     #[cfg(not(feature = "__tls"))]
@@ -354,7 +353,6 @@ impl Connector {
         })
     }
 
-    // TODO: add http3 logic
     async fn connect_with_maybe_proxy(self, dst: Uri, is_proxy: bool) -> Result<Conn, BoxError> {
         match self.inner {
             #[cfg(not(feature = "__tls"))]

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -530,6 +530,8 @@ impl Connector {
             Inner::RustlsTls { tls, .. } => {
                 (*(*tls)).clone()
             }
+            #[cfg(feature = "default-tls")]
+            _ => unreachable!("HTTP/3 should only be enabled with Rustls")
         }
     }
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -32,7 +32,6 @@ use crate::error::BoxError;
 use crate::proxy::{Proxy, ProxyScheme};
 
 
-// TODO: add http3 connector
 #[derive(Clone)]
 pub(crate) enum HttpConnector {
     Gai(hyper::client::HttpConnector),
@@ -289,28 +288,6 @@ impl Connector {
         }
     }
 
-    // TODO: add connector for http3
-    // pub(crate) fn new_http3_connector<T>(
-    //     mut http: h3_client::Http3Connector,
-    //     proxies: Arc<Vec<Proxy>>,
-    //     user_agent: Option<HeaderValue>,
-    //     nodelay: bool,
-    // ) -> Connector
-    //     where
-    //         T: Into<Option<IpAddr>>,
-    // {
-    //     Connector {
-    //         inner: Inner::TlsForH3 {
-    //             http,
-    //         },
-    //         proxies,
-    //         verbose: verbose::OFF,
-    //         timeout: None,
-    //         nodelay,
-    //         user_agent,
-    //     }
-    // }
-
     pub(crate) fn set_timeout(&mut self, timeout: Option<Duration>) {
         self.timeout = timeout;
     }
@@ -544,6 +521,15 @@ impl Connector {
             Inner::RustlsTls { http, .. } => http.set_keepalive(dur),
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => http.set_keepalive(dur),
+        }
+    }
+
+    #[cfg(feature = "http3")]
+    pub fn deep_clone_tls(&self) -> rustls::ClientConfig {
+        match &self.inner {
+            Inner::RustlsTls { tls, .. } => {
+                (*(*tls)).clone()
+            }
         }
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -342,6 +342,8 @@ impl Version {
 }
 
 pub(crate) enum TlsBackend {
+    // This is the default and HTTP/3 feature does not use it so suppress it.
+    #[allow(dead_code)]
     #[cfg(feature = "default-tls")]
     Default,
     #[cfg(feature = "native-tls")]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -373,12 +373,12 @@ impl fmt::Debug for TlsBackend {
 
 impl Default for TlsBackend {
     fn default() -> TlsBackend {
-        #[cfg(feature = "default-tls")]
+        #[cfg(all(feature = "default-tls", not(feature = "http3")))]
         {
             TlsBackend::Default
         }
 
-        #[cfg(all(feature = "__rustls", not(feature = "default-tls")))]
+        #[cfg(any(all(feature = "__rustls", not(feature = "default-tls")), feature = "http3"))]
         {
             TlsBackend::Rustls
         }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -380,7 +380,10 @@ impl Default for TlsBackend {
             TlsBackend::Default
         }
 
-        #[cfg(any(all(feature = "__rustls", not(feature = "default-tls")), feature = "http3"))]
+        #[cfg(any(
+            all(feature = "__rustls", not(feature = "default-tls")),
+            feature = "http3"
+        ))]
         {
             TlsBackend::Rustls
         }


### PR DESCRIPTION
#1558  

- [x] Add small pool of HTTP/3 connections.
- [x] Using (`Rustls`) TLS config for setting up connection.
- [x]  Use the `SendRequest` to start sending a request.
- [x] Reuse DNS resolvers. 
        
It would be great to get some feedback. Thanks in advance.