### PR TITLE
Added conversion method for reqwest::Response to http::Response<_>

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -418,6 +418,16 @@ impl<T: Into<Body>> From<http::Response<T>> for Response {
     }
 }
 
+/// Converts a reqwest::Response into an http::Response<T>.
+/// Type that you want to put inside http::Response<T> must implement From<Decoder>
+impl<T: From<Decoder>> Into<http::Response<T>> for Response {
+    fn into(self) -> http::Response<T> {
+        let parts = self.res.into_parts();
+        let body: T = (parts.1).into();
+        http::Response::from_parts(parts.0, body)
+    }
+}
+
 /// A `Response` can be piped as the `Body` of another request.
 impl From<Response> for Body {
     fn from(r: Response) -> Body {


### PR DESCRIPTION
As mentioned in #1258 
- [x] Created an Into method to convert request::Response -> http::Response<T>
Now what you have to do is implementing From<Decoder> for what you want to convert.

Feedback appreciated as this is my first contribution to the project.
Thanks!