### PR TITLE
Export Upgraded type.

### DIFF
--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -2,6 +2,7 @@ pub use self::body::Body;
 pub use self::client::{Client, ClientBuilder};
 pub use self::request::{Request, RequestBuilder};
 pub use self::response::Response;
+pub use self::upgrade::Upgraded;
 
 #[cfg(feature = "blocking")]
 pub(crate) use self::decoder::Decoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ if_hyper! {
     doctest!("../README.md");
 
     pub use self::async_impl::{
-        Body, Client, ClientBuilder, Request, RequestBuilder, Response,
+        Body, Client, ClientBuilder, Request, RequestBuilder, Response, Upgraded,
     };
     pub use self::proxy::Proxy;
     #[cfg(feature = "__tls")]


### PR DESCRIPTION
Small follow up to #1376. Definitely meant to also export the type so downstream users could actually name it and be able to store it without having to box it up as a trait object.