### PR TITLE
Added IntoFuture for RequestBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ stream = ["tokio/fs", "tokio-util"]
 
 socks = ["tokio-socks"]
 
+# Only works on Rust version > 1.64
+into_future = []
+
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at anytime.
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -39,6 +39,17 @@ pub struct RequestBuilder {
     request: crate::Result<Request>,
 }
 
+#[cfg(feature = "into_future")]
+impl std::future::IntoFuture for RequestBuilder {
+    type Output = Result<Response, crate::Error>;
+
+    type IntoFuture = futures_core::future::BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(self.send())
+    }
+}
+
 impl Request {
     /// Constructs a new request.
     #[inline]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -88,6 +88,25 @@ async fn response_text() {
 }
 
 #[tokio::test]
+#[cfg(feature = "into_future")]
+async fn into_fut_response_text() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
+
+    let client = Client::new();
+
+    let res = client
+        .get(&format!("http://{}/text", server.addr()))
+        .await
+        .expect("Failed to get");
+
+    assert_eq!(res.content_length(), Some(5));
+    let text = res.text().await.expect("Failed to get text");
+    assert_eq!("Hello", text);
+}
+
+#[tokio::test]
 async fn response_bytes() {
     let _ = env_logger::try_init();
 


### PR DESCRIPTION
Implements the `IntoFuture` trait for `RequestBuilder`.

Only works for Rust versions greater than 1.64, hence I also added a feature flag for it so that it isn't enabled by default and won't break existing implementations on older Rust versions.