### PR TITLE
Hack in DNS filtering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/reqwest/0.11.12")]
+#![feature(ip)]
 
 //! # reqwest
 //!


### PR DESCRIPTION
This is a temporary hack to allow filtering of non-global IPs in DNS resolution via `reqwest`. This should be revisited in the future with a more permanent solution.