### PR TITLE
Re-export `bytes`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,7 @@ macro_rules! if_hyper {
 pub use http::header;
 pub use http::Method;
 pub use http::{StatusCode, Version};
+pub use bytes::Bytes;
 pub use url::Url;
 
 // universal mods


### PR DESCRIPTION
This PR fixes an issue where a public transitive dependency of reqwest, the `bytes::Bytes` struct, was not re-exported, which forced users to depend on `bytes` manually to use the struct. Closes issue #1391.