### PR TITLE
support for custom DNS resolution

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,162 +1,31 @@
-use futures_util::future::Either;
 #[cfg(feature = "__tls")]
 use http::header::HeaderValue;
 use http::uri::{Authority, Scheme};
 use http::Uri;
-use hyper::client::connect::{
-    dns::{GaiResolver, Name},
-    Connected, Connection,
-};
+use hyper::client::connect::{Connected, Connection};
 use hyper::service::Service;
 #[cfg(feature = "native-tls-crate")]
 use native_tls_crate::{TlsConnector, TlsConnectorBuilder};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use pin_project_lite::pin_project;
-use std::io::IoSlice;
+use std::future::Future;
+use std::io::{self, IoSlice};
 use std::net::IpAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use std::{collections::HashMap, io};
-use std::{future::Future, net::SocketAddr};
 
 #[cfg(feature = "default-tls")]
 use self::native_tls_conn::NativeTlsConn;
 #[cfg(feature = "__rustls")]
 use self::rustls_tls_conn::RustlsTlsConn;
-#[cfg(feature = "trust-dns")]
-use crate::dns::TrustDnsResolver;
+use crate::dns::DynResolver;
 use crate::error::BoxError;
 use crate::proxy::{Proxy, ProxyScheme};
 
-#[derive(Clone)]
-pub(crate) enum HttpConnector {
-    Gai(hyper::client::HttpConnector),
-    GaiWithDnsOverrides(hyper::client::HttpConnector<DnsResolverWithOverrides<GaiResolver>>),
-    #[cfg(feature = "trust-dns")]
-    TrustDns(hyper::client::HttpConnector<TrustDnsResolver>),
-    #[cfg(feature = "trust-dns")]
-    TrustDnsWithOverrides(hyper::client::HttpConnector<DnsResolverWithOverrides<TrustDnsResolver>>),
-}
-
-impl HttpConnector {
-    pub(crate) fn new_gai() -> Self {
-        Self::Gai(hyper::client::HttpConnector::new())
-    }
-
-    pub(crate) fn new_gai_with_overrides(overrides: HashMap<String, Vec<SocketAddr>>) -> Self {
-        let gai = hyper::client::connect::dns::GaiResolver::new();
-        let overridden_resolver = DnsResolverWithOverrides::new(gai, overrides);
-        Self::GaiWithDnsOverrides(hyper::client::HttpConnector::new_with_resolver(
-            overridden_resolver,
-        ))
-    }
-
-    #[cfg(feature = "trust-dns")]
-    pub(crate) fn new_trust_dns() -> crate::Result<HttpConnector> {
-        TrustDnsResolver::new()
-            .map(hyper::client::HttpConnector::new_with_resolver)
-            .map(Self::TrustDns)
-            .map_err(crate::error::builder)
-    }
-
-    #[cfg(feature = "trust-dns")]
-    pub(crate) fn new_trust_dns_with_overrides(
-        overrides: HashMap<String, Vec<SocketAddr>>,
-    ) -> crate::Result<HttpConnector> {
-        TrustDnsResolver::new()
-            .map(|resolver| DnsResolverWithOverrides::new(resolver, overrides))
-            .map(hyper::client::HttpConnector::new_with_resolver)
-            .map(Self::TrustDnsWithOverrides)
-            .map_err(crate::error::builder)
-    }
-}
-
-macro_rules! impl_http_connector {
-    ($(fn $name:ident(&mut self, $($par_name:ident: $par_type:ty),*)$( -> $return:ty)?;)+) => {
-        #[allow(dead_code)]
-        impl HttpConnector {
-            $(
-                fn $name(&mut self, $($par_name: $par_type),*)$( -> $return)? {
-                    match self {
-                        Self::Gai(resolver) => resolver.$name($($par_name),*),
-                        Self::GaiWithDnsOverrides(resolver) => resolver.$name($($par_name),*),
-                        #[cfg(feature = "trust-dns")]
-                        Self::TrustDns(resolver) => resolver.$name($($par_name),*),
-                        #[cfg(feature = "trust-dns")]
-                        Self::TrustDnsWithOverrides(resolver) => resolver.$name($($par_name),*),
-                    }
-                }
-            )+
-        }
-    };
-}
-
-impl_http_connector! {
-    fn set_local_address(&mut self, addr: Option<IpAddr>);
-    fn enforce_http(&mut self, is_enforced: bool);
-    fn set_nodelay(&mut self, nodelay: bool);
-    fn set_keepalive(&mut self, dur: Option<Duration>);
-}
-
-impl Service<Uri> for HttpConnector {
-    type Response = <hyper::client::HttpConnector as Service<Uri>>::Response;
-    type Error = <hyper::client::HttpConnector as Service<Uri>>::Error;
-    #[cfg(feature = "trust-dns")]
-    type Future =
-        Either<
-            Either<
-                <hyper::client::HttpConnector as Service<Uri>>::Future,
-                <hyper::client::HttpConnector<DnsResolverWithOverrides<GaiResolver>> as Service<
-                    Uri,
-                >>::Future,
-            >,
-            Either<
-                    <hyper::client::HttpConnector<TrustDnsResolver> as Service<Uri>>::Future,
-                <hyper::client::HttpConnector<DnsResolverWithOverrides<TrustDnsResolver>> as Service<Uri>>::Future
-                 >
-        >;
-    #[cfg(not(feature = "trust-dns"))]
-    type Future =
-        Either<
-            Either<
-                <hyper::client::HttpConnector as Service<Uri>>::Future,
-                <hyper::client::HttpConnector<DnsResolverWithOverrides<GaiResolver>> as Service<
-                    Uri,
-                >>::Future,
-            >,
-            Either<
-                <hyper::client::HttpConnector as Service<Uri>>::Future,
-                <hyper::client::HttpConnector as Service<Uri>>::Future,
-            >,
-        >;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match self {
-            Self::Gai(resolver) => resolver.poll_ready(cx),
-            Self::GaiWithDnsOverrides(resolver) => resolver.poll_ready(cx),
-            #[cfg(feature = "trust-dns")]
-            Self::TrustDns(resolver) => resolver.poll_ready(cx),
-            #[cfg(feature = "trust-dns")]
-            Self::TrustDnsWithOverrides(resolver) => resolver.poll_ready(cx),
-        }
-    }
-
-    fn call(&mut self, dst: Uri) -> Self::Future {
-        match self {
-            Self::Gai(resolver) => Either::Left(Either::Left(resolver.call(dst))),
-            Self::GaiWithDnsOverrides(resolver) => Either::Left(Either::Right(resolver.call(dst))),
-            #[cfg(feature = "trust-dns")]
-            Self::TrustDns(resolver) => Either::Right(Either::Left(resolver.call(dst))),
-            #[cfg(feature = "trust-dns")]
-            Self::TrustDnsWithOverrides(resolver) => {
-                Either::Right(Either::Right(resolver.call(dst)))
-            }
-        }
-    }
-}
+pub(crate) type HttpConnector = hyper::client::HttpConnector<DynResolver>;
 
 #[derive(Clone)]
 pub(crate) struct Connector {
@@ -957,103 +826,6 @@ mod socks {
         };
 
         Ok(stream.into_inner())
-    }
-}
-
-pub(crate) mod itertools {
-    pub(crate) enum Either<A, B> {
-        Left(A),
-        Right(B),
-    }
-
-    impl<A, B> Iterator for Either<A, B>
-    where
-        A: Iterator,
-        B: Iterator<Item = <A as Iterator>::Item>,
-    {
-        type Item = <A as Iterator>::Item;
-
-        fn next(&mut self) -> Option<Self::Item> {
-            match self {
-                Either::Left(a) => a.next(),
-                Either::Right(b) => b.next(),
-            }
-        }
-    }
-}
-
-pin_project! {
-    pub(crate) struct WrappedResolverFuture<Fut> {
-        #[pin]
-        fut: Fut,
-    }
-}
-
-impl<Fut, FutOutput, FutError> std::future::Future for WrappedResolverFuture<Fut>
-where
-    Fut: std::future::Future<Output = Result<FutOutput, FutError>>,
-    FutOutput: Iterator<Item = SocketAddr>,
-{
-    type Output = Result<itertools::Either<FutOutput, std::vec::IntoIter<SocketAddr>>, FutError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        this.fut
-            .poll(cx)
-            .map(|result| result.map(itertools::Either::Left))
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct DnsResolverWithOverrides<Resolver>
-where
-    Resolver: Clone,
-{
-    dns_resolver: Resolver,
-    overrides: Arc<HashMap<String, Vec<SocketAddr>>>,
-}
-
-impl<Resolver: Clone> DnsResolverWithOverrides<Resolver> {
-    fn new(dns_resolver: Resolver, overrides: HashMap<String, Vec<SocketAddr>>) -> Self {
-        DnsResolverWithOverrides {
-            dns_resolver,
-            overrides: Arc::new(overrides),
-        }
-    }
-}
-
-impl<Resolver, Iter> Service<Name> for DnsResolverWithOverrides<Resolver>
-where
-    Resolver: Service<Name, Response = Iter> + Clone,
-    Iter: Iterator<Item = SocketAddr>,
-{
-    type Response = itertools::Either<Iter, std::vec::IntoIter<SocketAddr>>;
-    type Error = <Resolver as Service<Name>>::Error;
-    type Future = Either<
-        WrappedResolverFuture<<Resolver as Service<Name>>::Future>,
-        futures_util::future::Ready<
-            Result<itertools::Either<Iter, std::vec::IntoIter<SocketAddr>>, Self::Error>,
-        >,
-    >;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.dns_resolver.poll_ready(cx)
-    }
-
-    fn call(&mut self, name: Name) -> Self::Future {
-        match self.overrides.get(name.as_str()) {
-            Some(dest) => {
-                let fut = futures_util::future::ready(Ok(itertools::Either::Right(
-                    dest.clone().into_iter(),
-                )));
-                Either::Right(fut)
-            }
-            None => {
-                let resolver_fut = self.dns_resolver.call(name);
-                let y = WrappedResolverFuture { fut: resolver_fut };
-                Either::Left(y)
-            }
-        }
     }
 }
 

--- a/src/dns/gai.rs
+++ b/src/dns/gai.rs
@@ -1,0 +1,32 @@
+use futures_util::future::FutureExt;
+use hyper::client::connect::dns::{GaiResolver as HyperGaiResolver, Name};
+use hyper::service::Service;
+
+use crate::dns::{Addrs, Resolve, Resolving};
+use crate::error::BoxError;
+
+#[derive(Debug)]
+pub struct GaiResolver(HyperGaiResolver);
+
+impl GaiResolver {
+    pub fn new() -> Self {
+        Self(HyperGaiResolver::new())
+    }
+}
+
+impl Default for GaiResolver {
+    fn default() -> Self {
+        GaiResolver::new()
+    }
+}
+
+impl Resolve for GaiResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let this = &mut self.0.clone();
+        Box::pin(Service::<Name>::call(this, name).map(|result| {
+            result
+                .map(|addrs| -> Addrs { Box::new(addrs) })
+                .map_err(|err| -> BoxError { Box::new(err) })
+        }))
+    }
+}

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -1,0 +1,9 @@
+//! DNS resolution
+
+pub use resolve::{Addrs, Resolve, Resolving};
+pub(crate) use resolve::{DnsResolverWithOverrides, DynResolver};
+
+pub(crate) mod gai;
+pub(crate) mod resolve;
+#[cfg(feature = "trust-dns")]
+pub(crate) mod trust_dns;

--- a/src/dns/resolve.rs
+++ b/src/dns/resolve.rs
@@ -1,0 +1,84 @@
+use hyper::client::connect::dns::Name;
+use hyper::service::Service;
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use crate::error::BoxError;
+
+/// Alias for an `Iterator` trait object over `SocketAddr`.
+pub type Addrs = Box<dyn Iterator<Item = SocketAddr> + Send>;
+
+/// Alias for the `Future` type returned by a DNS resolver.
+pub type Resolving = Pin<Box<dyn Future<Output = Result<Addrs, BoxError>> + Send>>;
+
+/// Trait for customizing DNS resolution in reqwest.
+pub trait Resolve: Send + Sync {
+    /// Performs DNS resolution on a `Name`.
+    /// The return type is a future containing an iterator of `SocketAddr`.
+    ///
+    /// It differs from `tower_service::Service<Name>` in several ways:
+    ///  * It is assumed that `resolve` will always be ready to poll.
+    ///  * It does not need a mutable reference to `self`.
+    ///  * Since trait objects cannot make use of associated types, it requires
+    ///    wrapping the returned `Future` and its contained `Iterator` with `Box`.
+    fn resolve(&self, name: Name) -> Resolving;
+}
+
+#[derive(Clone)]
+pub(crate) struct DynResolver {
+    resolver: Arc<dyn Resolve>,
+}
+
+impl DynResolver {
+    pub(crate) fn new(resolver: Arc<dyn Resolve>) -> Self {
+        Self { resolver }
+    }
+}
+
+impl Service<Name> for DynResolver {
+    type Response = Addrs;
+    type Error = BoxError;
+    type Future = Resolving;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, name: Name) -> Self::Future {
+        self.resolver.resolve(name)
+    }
+}
+
+pub(crate) struct DnsResolverWithOverrides {
+    dns_resolver: Arc<dyn Resolve>,
+    overrides: Arc<HashMap<String, Vec<SocketAddr>>>,
+}
+
+impl DnsResolverWithOverrides {
+    pub(crate) fn new(
+        dns_resolver: Arc<dyn Resolve>,
+        overrides: HashMap<String, Vec<SocketAddr>>,
+    ) -> Self {
+        DnsResolverWithOverrides {
+            dns_resolver,
+            overrides: Arc::new(overrides),
+        }
+    }
+}
+
+impl Resolve for DnsResolverWithOverrides {
+    fn resolve(&self, name: Name) -> Resolving {
+        match self.overrides.get(name.as_str()) {
+            Some(dest) => {
+                let addrs: Addrs = Box::new(dest.clone().into_iter());
+                Box::pin(futures_util::future::ready(Ok(addrs)))
+            }
+            None => self.dns_resolver.resolve(name),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,8 +309,7 @@ if_hyper! {
     mod connect;
     #[cfg(feature = "cookies")]
     pub mod cookie;
-    #[cfg(feature = "trust-dns")]
-    mod dns;
+    pub mod dns;
     mod proxy;
     pub mod redirect;
     #[cfg(feature = "__tls")]


### PR DESCRIPTION
This change refactors DNS resolution, with the goal of supporting custom DNS resolvers. It addresses [#1125](https://github.com/seanmonstar/reqwest/issues/1125).

Previously, reqwest defined its own `HttpConnector`, which dispatched to a different `hyper::client::HttpConnector<R>` instance depending on an enum state. This led to excess complexity in the `Future` type associated with the `Service<Uri>` implementation for the connector, which can be circumvented with a trait object.

This approach exchanges the enum for a trait object, which introduces a dynamic dispatch, but eliminates the enum match inside `HttpConnector`.

One annoyance is that trait objects can't make use of associated types, so the return type of the `resolve` function on the trait needs to be explicitly defined. Let me know what you think - happy to make changes.