### PR TITLE
Load client cert from format *.crt and *.key (native-tls)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ ipnet = "2.3"
 
 ## default-tls
 hyper-tls = { version = "0.5", optional = true }
-native-tls-crate = { version = "0.2.8", optional = true, package = "native-tls" }
+native-tls-crate = { version = "0.2.10", optional = true, package = "native-tls" }
 tokio-native-tls = { version = "0.3.0", optional = true }
 
 # rustls-tls

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -485,7 +485,7 @@ mod tests {
 
     #[cfg(feature = "native-tls")]
     #[test]
-    fn identity_from_pkcs8_der_invalid() {
+    fn identity_from_pkcs8_pem_invalid() {
         Identity::from_pkcs8_pem(b"not pem", b"not key").unwrap_err();
     }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -195,10 +195,10 @@ impl Identity {
     /// # use std::fs::File;
     /// # use std::io::Read;
     /// # fn pkcs8() -> Result<(), Box<std::error::Error>> {
-    /// let mut pem = Vec::new();
-    /// File::open("client.pem")?.read_to_end(&mut buf)?;
+    /// let mut cert = Vec::new();
+    /// File::open("client.pem")?.read_to_end(&mut cert)?;
     /// let mut key = Vec::new();
-    /// File::open("client.key")?.read_to_end(&mut buf)?;
+    /// File::open("client.key")?.read_to_end(&mut key)?;
     /// let pkcs8 = reqwest::Identity::from_pkcs8_pem(&pem, &cert)?;
     /// # drop(pkcs8);
     /// # Ok(())

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -192,13 +192,10 @@ impl Identity {
     /// # Examples
     ///
     /// ```
-    /// # use std::fs::File;
-    /// # use std::io::Read;
+    /// # use std::fs;
     /// # fn pkcs8() -> Result<(), Box<std::error::Error>> {
-    /// let mut cert = Vec::new();
-    /// File::open("client.pem")?.read_to_end(&mut cert)?;
-    /// let mut key = Vec::new();
-    /// File::open("client.key")?.read_to_end(&mut key)?;
+    /// let cert = fs::read("client.pem")?;
+    /// let key = fs::read("key.pem")?;
     /// let pkcs8 = reqwest::Identity::from_pkcs8_pem(&cert, &key)?;
     /// # drop(pkcs8);
     /// # Ok(())

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -179,6 +179,15 @@ impl Identity {
         })
     }
 
+    #[cfg(feature = "native-tls")]
+    pub fn from_pkcs8_pem(pem: &[u8], key: &[u8]) -> crate::Result<Identity> {
+        Ok(Identity {
+            inner: ClientCert::Pkcs12(
+                native_tls_crate::Identity::from_pkcs8(pem, key).map_err(crate::error::builder)?,
+            ),
+        })
+    }
+
     /// Parses PEM encoded private key and certificate.
     ///
     /// The input should contain a PEM encoded private key

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -45,6 +45,8 @@ pub struct Identity {
 enum ClientCert {
     #[cfg(feature = "native-tls")]
     Pkcs12(native_tls_crate::Identity),
+    #[cfg(feature = "native-tls")]
+    Pkcs8(native_tls_crate::Identity),
     #[cfg(feature = "__rustls")]
     Pem {
         key: rustls::PrivateKey,
@@ -179,10 +181,37 @@ impl Identity {
         })
     }
 
+    /// Parses a chain of PEM encoded X509 certificates, with the leaf certificate first.
+    /// `key` is a PEM encoded PKCS #8 formatted private key for the leaf certificate.
+    ///
+    /// The certificate chain should contain any intermediate cerficates that should be sent to
+    /// clients to allow them to build a chain to a trusted root.
+    ///
+    /// A certificate chain here means a series of PEM encoded certificates concatenated together.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::fs::File;
+    /// # use std::io::Read;
+    /// # fn pkcs8() -> Result<(), Box<std::error::Error>> {
+    /// let mut pem = Vec::new();
+    /// File::open("client.pem")?.read_to_end(&mut buf)?;
+    /// let mut key = Vec::new();
+    /// File::open("client.key")?.read_to_end(&mut buf)?;
+    /// let pkcs8 = reqwest::Identity::from_pkcs8_pem(&pem, &cert)?;
+    /// # drop(pkcs8);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Optional
+    ///
+    /// This requires the `native-tls` Cargo feature enabled.
     #[cfg(feature = "native-tls")]
     pub fn from_pkcs8_pem(pem: &[u8], key: &[u8]) -> crate::Result<Identity> {
         Ok(Identity {
-            inner: ClientCert::Pkcs12(
+            inner: ClientCert::Pkcs8(
                 native_tls_crate::Identity::from_pkcs8(pem, key).map_err(crate::error::builder)?,
             ),
         })
@@ -266,6 +295,10 @@ impl Identity {
                 tls.identity(id);
                 Ok(())
             }
+            ClientCert::Pkcs8(id) => {
+                tls.identity(id);
+                Ok(())
+            }
             #[cfg(feature = "__rustls")]
             ClientCert::Pem { .. } => Err(crate::error::builder("incompatible TLS identity type")),
         }
@@ -285,6 +318,7 @@ impl Identity {
                 .map_err(crate::error::builder),
             #[cfg(feature = "native-tls")]
             ClientCert::Pkcs12(..) => Err(crate::error::builder("incompatible TLS identity type")),
+            ClientCert::Pkcs8(..) => Err(crate::error::builder("incompatible TLS identity type")),
         }
     }
 }
@@ -450,6 +484,12 @@ mod tests {
     #[test]
     fn identity_from_pkcs12_der_invalid() {
         Identity::from_pkcs12_der(b"not der", "nope").unwrap_err();
+    }
+
+    #[cfg(feature = "native-tls")]
+    #[test]
+    fn identity_from_pkcs8_der_invalid() {
+        Identity::from_pkcs8_pem(b"not pem", b"not key").unwrap_err();
     }
 
     #[cfg(feature = "__rustls")]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -199,7 +199,7 @@ impl Identity {
     /// File::open("client.pem")?.read_to_end(&mut cert)?;
     /// let mut key = Vec::new();
     /// File::open("client.key")?.read_to_end(&mut key)?;
-    /// let pkcs8 = reqwest::Identity::from_pkcs8_pem(&pem, &cert)?;
+    /// let pkcs8 = reqwest::Identity::from_pkcs8_pem(&cert, &key)?;
     /// # drop(pkcs8);
     /// # Ok(())
     /// # }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -291,11 +291,7 @@ impl Identity {
         tls: &mut native_tls_crate::TlsConnectorBuilder,
     ) -> crate::Result<()> {
         match self.inner {
-            ClientCert::Pkcs12(id) => {
-                tls.identity(id);
-                Ok(())
-            }
-            ClientCert::Pkcs8(id) => {
+            ClientCert::Pkcs12(id) | ClientCert::Pkcs8(id) => {
                 tls.identity(id);
                 Ok(())
             }
@@ -317,8 +313,9 @@ impl Identity {
                 .with_single_cert(certs, key)
                 .map_err(crate::error::builder),
             #[cfg(feature = "native-tls")]
-            ClientCert::Pkcs12(..) => Err(crate::error::builder("incompatible TLS identity type")),
-            ClientCert::Pkcs8(..) => Err(crate::error::builder("incompatible TLS identity type")),
+            ClientCert::Pkcs12(..) | ClientCert::Pkcs8(..) => {
+                Err(crate::error::builder("incompatible TLS identity type"))
+            }
         }
     }
 }


### PR DESCRIPTION
Add new optional fn **from_pkcs8_pem** for easy load client certificate (*.crt and *.key) for feature ``native-tls``.
Example usage:
```rust
use reqwest::blocking::Client;
use reqwest::{Certificate, Identity};
use std::fs;

const URL: &str = "hostname server with mTLS";

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let ca = Certificate::from_pem(&read_file("ca.crt"))?;
    let cert = Identity::from_pkcs8_pem(&read_file("client.crt"), &read_file("client.key"))?;

    let client = Client::builder()
        .add_root_certificate(ca)
        .identity(cert)
        .build()?;

    let status = client.get(URL).send()?.status();

    println!("Status Code: {status}");
    Ok(())
}

fn read_file(path: &str) -> Vec<u8> {
    fs::read(path).unwrap()
}

```