### PR TITLE
Update version of cookie_store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.56.0]
+        rust: [1.60.0]
 
     steps:
       - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ rustls-pemfile = { version = "1.0", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.16", package = "cookie", optional = true }
-cookie_store = { version = "0.16", optional = true }
+cookie_store = { version = "0.19.0", optional = true }
 proc-macro-hack = { version = "0.5.19", optional = true }
 
 ## compression
@@ -155,6 +155,13 @@ js-sys = "0.3.45"
 serde_json = "1.0"
 wasm-bindgen = "0.2.68"
 wasm-bindgen-futures = "0.4.18"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.cookie_store]
+version = "0.19.0"
+optional = true
+features = [
+    "wasm-bindgen"
+]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"


### PR DESCRIPTION
To avoid duplicate dependency on `idna` in tree:

current cargo tree -d output (trust-dns-proto is already at idna v0.3.0 on main):
```
cargo tree -d --all-features
    Updating crates.io index
  Downloaded cookie_store v0.16.1
  Downloaded 1 crate (29.1 KB) in 1.15s
idna v0.2.3
├── cookie_store v0.16.1
│   └── reqwest v0.11.12 
└── trust-dns-proto v0.22.0
    └── trust-dns-resolver v0.22.0
        └── reqwest v0.11.12

idna v0.3.0
├── publicsuffix v2.2.3
│   └── cookie_store v0.16.1 (*)
└── url v2.3.1
    ├── cookie_store v0.16.1 (*)
    ├── reqwest v0.11.12
    └── trust-dns-proto v0.22.0 (*)
```