### PR TITLE
Add public interface to Multipart's Part `headers`

### DIFF
--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -607,7 +607,9 @@ mod tests {
     #[test]
     fn stream_to_end_with_header() {
         let mut part = Part::text("value2").mime(mime::IMAGE_BMP);
-        part.meta.headers.insert("Hdr3", "/a/b/c".parse().unwrap());
+        let mut headers = HeaderMap::new();
+        headers.insert("Hdr3", "/a/b/c".parse().unwrap());
+        part = part.headers(headers);
         let mut form = Form::new().part("key2", part);
         form.inner.boundary = "boundary".to_string();
         let expected = "--boundary\r\n\

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::pin::Pin;
 
 use bytes::Bytes;
-use http::HeaderMap;
 use mime_guess::Mime;
 use percent_encoding::{self, AsciiSet, NON_ALPHANUMERIC};
 
@@ -12,6 +11,7 @@ use futures_core::Stream;
 use futures_util::{future, stream, StreamExt};
 
 use super::Body;
+use crate::header::HeaderMap;
 
 /// An async multipart/form-data request.
 pub struct Form {
@@ -245,10 +245,7 @@ impl Part {
     }
 
     /// Sets custom headers for the part.
-    pub fn headers<T>(self, headers: T) -> Part
-    where
-        T: Into<HeaderMap>,
-    {
+    pub fn headers(self, headers: HeaderMap) -> Part {
         self.with_inner(move |inner| inner.headers(headers))
     }
 

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -244,6 +244,14 @@ impl Part {
         self.with_inner(move |inner| inner.file_name(filename))
     }
 
+    /// Sets custom headers for the part.
+    pub fn headers<T>(self, headers: T) -> Part
+    where
+        T: Into<HeaderMap>,
+    {
+        self.with_inner(move |inner| inner.headers(headers))
+    }
+
     fn with_inner<F>(self, func: F) -> Self
     where
         F: FnOnce(PartMetadata) -> PartMetadata,
@@ -392,6 +400,14 @@ impl PartMetadata {
         T: Into<Cow<'static, str>>,
     {
         self.file_name = Some(filename.into());
+        self
+    }
+
+    pub(crate) fn headers<T>(mut self, headers: T) -> Self
+    where
+        T: Into<HeaderMap>,
+    {
+        self.headers = headers.into();
         self
     }
 }

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -256,6 +256,14 @@ impl Part {
         self.with_inner(move |inner| inner.file_name(filename))
     }
 
+    /// Sets custom headers for the part.
+    pub fn headers<T>(self, headers: T) -> Part
+    where
+        T: Into<HeaderMap>,
+    {
+        self.with_inner(move |inner| inner.headers(headers))
+    }
+
     fn with_inner<F>(self, func: F) -> Self
     where
         F: FnOnce(PartMetadata) -> PartMetadata,

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -42,11 +42,11 @@ use std::fs::File;
 use std::io::{self, Cursor, Read};
 use std::path::Path;
 
-use http::HeaderMap;
 use mime_guess::{self, Mime};
 
 use super::Body;
 use crate::async_impl::multipart::{FormParts, PartMetadata, PartProps};
+use crate::header::HeaderMap;
 
 /// A multipart/form-data request.
 pub struct Form {
@@ -258,10 +258,7 @@ impl Part {
     }
 
     /// Sets custom headers for the part.
-    pub fn headers<T>(self, headers: T) -> Part
-    where
-        T: Into<HeaderMap>,
-    {
+    pub fn headers(self, headers: HeaderMap) -> Part {
         self.with_inner(move |inner| inner.headers(headers))
     }
 

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -42,6 +42,7 @@ use std::fs::File;
 use std::io::{self, Cursor, Read};
 use std::path::Path;
 
+use http::HeaderMap;
 use mime_guess::{self, Mime};
 
 use super::Body;

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -461,7 +461,9 @@ mod tests {
     fn read_to_end_with_header() {
         let mut output = Vec::new();
         let mut part = Part::text("value2").mime(mime::IMAGE_BMP);
-        part.meta.headers.insert("Hdr3", "/a/b/c".parse().unwrap());
+        let mut headers = HeaderMap::new();
+        headers.insert("Hdr3", "/a/b/c".parse().unwrap());
+        part = part.headers(headers);
         let mut form = Form::new().part("key2", part);
         form.inner.boundary = "boundary".to_string();
         let expected = "--boundary\r\n\


### PR DESCRIPTION
I have an application where I'd like to add compressed files to a multipart form request, and would like to set the `content-encoding` header for said files in the request. However, the current implementation doesn't allow editing the metadata on `multipart::Part`s. I added the necessary public setters to be able to to add custom headers to the multipart items.