### PR TITLE
Remove `proc-macro-hack` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rustls-tls-native-roots = ["rustls-native-certs", "__rustls"]
 
 blocking = ["futures-util/io", "tokio/rt-multi-thread", "tokio/sync"]
 
-cookies = ["cookie_crate", "cookie_store", "proc-macro-hack"]
+cookies = ["cookie_crate", "cookie_store"]
 
 gzip = ["async-compression", "async-compression/gzip", "tokio-util"]
 
@@ -124,7 +124,6 @@ rustls-pemfile = { version = "1.0", optional = true }
 ## cookies
 cookie_crate = { version = "0.16", package = "cookie", optional = true }
 cookie_store = { version = "0.16", optional = true }
-proc-macro-hack = { version = "0.5.19", optional = true }
 
 ## compression
 async-compression = { version = "0.3.13", default-features = false, features = ["tokio"], optional = true }


### PR DESCRIPTION
The `proc-macro-hack` crate isn't needed anymore.
Cookie has been updated to `0.16` for a while now, and no other crates depend on it anymore, so no need for reqwest to have this either.

Also, the crate is being deprecated.