### PR TITLE
Update/Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,21 +32,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
-          profile: minimal
-          override: true
 
       - name: cargo fmt -- --check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt -- --check
 
       - name: temporary workaround - fmt all files under src
         # Workaround for rust-lang/cargo#7732
@@ -155,15 +149,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust || 'stable' }}
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Add mingw32 to path for i686-gnu
         run: |
@@ -185,16 +177,10 @@ jobs:
         run: pacman.exe -Sy --noconfirm mingw-w64-i686-toolchain
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: ${{ matrix.features }}
+        run: cargo build ${{ matrix.features }}
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: ${{ matrix.features }} ${{ matrix.test-features }} -- --test-threads=1
+        run: cargo test ${{ matrix.features }} ${{ matrix.test-features }} -- --test-threads=1
 
   docs:
     name: Docs
@@ -202,22 +188,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --document-private-items --all-features
+        run: cargo doc --no-deps --document-private-items --all-features
 
   # Separate build job for nightly because of the missing feature for allowed failures at
   # job level. See `jobs.build.strategy.matrix`.
@@ -225,29 +204,22 @@ jobs:
     name: linux / nightly
     needs: [style]
 
-    runs-on: ubuntu-latest
+    # Use Ubuntu 20.04 here, because latest (22.04) uses OpenSSL v3.
+    # Currently OpenSSL v3 causes compile issues with openssl-sys
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+      # - name: Build
+      #   run: cargo build
 
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features __internal_proxy_sys_no_cache -- --test-threads=1
+      # - name: Test
+      #   run: cargo test --features __internal_proxy_sys_no_cache -- --test-threads=1
 
       - name: Check minimal versions
         run: |
@@ -264,23 +236,19 @@ jobs:
 
     strategy:
       matrix:
-        rust: [1.56.0]
+        rust: [1.57.0]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
 
       - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   android:
     name: Android
@@ -290,23 +258,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: aarch64-linux-android
-          profile: minimal
-          override: true
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          # disable default-tls feature since cross-compiling openssl is dragons
-          args: --target aarch64-linux-android --no-default-features
+        # disable default-tls feature since cross-compiling openssl is dragons
+        run: cargo build --target aarch64-linux-android --no-default-features
 
   wasm:
     name: WASM
@@ -316,21 +277,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
 
       - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --target wasm32-unknown-unknown
+        run: cargo check --target wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -253,7 +253,8 @@ impl RequestBuilder {
     {
         let mut header_value = b"Basic ".to_vec();
         {
-            let mut encoder = Base64Encoder::from(&mut header_value, &base64::engine::DEFAULT_ENGINE);
+            let mut encoder =
+                Base64Encoder::from(&mut header_value, &base64::engine::DEFAULT_ENGINE);
             // The unwraps here are fine because Vec::write* is infallible.
             write!(encoder, "{}:", username).unwrap();
             if let Some(password) = password {

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -216,7 +216,8 @@ impl RequestBuilder {
     {
         let mut header_value = b"Basic ".to_vec();
         {
-            let mut encoder = Base64Encoder::from(&mut header_value, &base64::engine::DEFAULT_ENGINE);
+            let mut encoder =
+                Base64Encoder::from(&mut header_value, &base64::engine::DEFAULT_ENGINE);
             // The unwraps here are fine because Vec::write* is infallible.
             write!(encoder, "{}:", username).unwrap();
             if let Some(password) = password {


### PR DESCRIPTION
- Fixed cargo fmt
- Updated MSRV to v1.57.0, which is needed for `base64` v0.20
- Updated all actions to the latest versions. (Solves Annotation warnings)
- Replaced actions-rs with dtolnay actions or simple run's. actions-rs is not supported anymore, and also causes warnings.
- Use Ubuntu 20.04 for `linux / nightly`. The reason is that Ubuntu 22.04 uses OpenSSL v3, this currently is not compatible with hyper-tls it looks like. I also tried to update the `openssl-sys` crate but that doesn't solve the compile issue. Using a Ubuntu version that still has OpenSSL v1.1.1 resolves the CI for now.