### PR TITLE
docs: Add note regarding possible Client::execute panic

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1497,6 +1497,11 @@ impl Client {
     ///
     /// This method fails if there was an error while sending request,
     /// redirect loop was detected or redirect limit was exhausted.
+    ///
+    /// # Panics
+    ///
+    /// When using with Hyper, this method panics if a serialized `url::Url`
+    /// cannot be parsed as a valid `http::Uri`.
     pub fn execute(
         &self,
         request: Request,


### PR DESCRIPTION
Happens here https://github.com/seanmonstar/reqwest/blob/cdbf84feb1d86b8288796631f2120de5363b3ba9/src/async_impl/client.rs#L1544 due to `expect` call in https://github.com/seanmonstar/reqwest/blob/cdbf84feb1d86b8288796631f2120de5363b3ba9/src/into_url.rs#L67-L71

It would be nice to get an error that one could recover from, but before it happens, a simple doc change should be sufficient.

ref: https://github.com/denoland/deno/pull/17164