### PR TITLE
Use proper SPDX license identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/seanmonstar/reqwest"
 documentation = "https://docs.rs/reqwest"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 autotests = true
 


### PR DESCRIPTION
Tools that parse license identifiers fail with the current identifier of the csv crate. E.g. `cargo-cyclonedx`:

```
[2023-01-17T14:43:55Z ERROR cargo_cyclonedx::generator] Package reqwest has an invalid license expression, trying lax parsing (MIT/Apache-2.0): Invalid SPDX expression: invalid character(s)
```

This PR fixes it.