### PR TITLE
All dependencies updated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,13 +78,13 @@ __internal_proxy_sys_no_cache = []
 [dependencies]
 base64 = "0.21"
 http = "0.2"
-url = "2.2"
-bytes = "1.0"
+url = "2.3"
+bytes = "1.3"
 serde = "1.0"
 serde_urlencoded = "0.7.1"
 tower-service = "0.3"
-futures-core = { version = "0.3.0", default-features = false }
-futures-util = { version = "0.3.0", default-features = false }
+futures-core = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 
 # Optional deps...
 
@@ -95,16 +95,16 @@ mime_guess = { version = "2.0", default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 encoding_rs = "0.8"
-http-body = "0.4.0"
-hyper = { version = "0.14.18", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
-h2 = "0.3.10"
+http-body = "0.4"
+hyper = { version = "0.14", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
+h2 = "0.3"
 once_cell = "1"
 log = "0.4"
 mime = "0.3.16"
-percent-encoding = "2.1"
-tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
-pin-project-lite = "0.2.0"
-ipnet = "2.3"
+percent-encoding = "2.2"
+tokio = { version = "1.24", default-features = false, features = ["net", "time"] }
+pin-project-lite = "0.2"
+ipnet = "2.7"
 
 # Optional deps...
 
@@ -126,23 +126,23 @@ cookie_crate = { version = "0.16", package = "cookie", optional = true }
 cookie_store = { version = "0.16", optional = true }
 
 ## compression
-async-compression = { version = "0.3.13", default-features = false, features = ["tokio"], optional = true }
-tokio-util = { version = "0.7.1", default-features = false, features = ["codec", "io"], optional = true }
+async-compression = { version = "0.3", default-features = false, features = ["tokio"], optional = true }
+tokio-util = { version = "0.7", default-features = false, features = ["codec", "io"], optional = true }
 
 ## socks
-tokio-socks = { version = "0.5.1", optional = true }
+tokio-socks = { version = "0.5", optional = true }
 
 ## trust-dns
 trust-dns-resolver = { version = "0.22", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-env_logger = "0.8"
+env_logger = "0.10"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "http1", "http2", "client", "server", "runtime"] }
 serde = { version = "1.0", features = ["derive"] }
-libflate = "1.0"
+libflate = "1.2"
 brotli_crate = { package = "brotli", version = "3.3.0" }
 doc-comment = "0.3"
-tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.24", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10"
@@ -150,14 +150,14 @@ winreg = "0.10"
 # wasm
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.45"
+js-sys = "0.3"
 serde_json = "1.0"
-wasm-bindgen = "0.2.68"
-wasm-bindgen-futures = "0.4.18"
-wasm-streams = { version = "0.2", optional = true }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+wasm-streams = { version = "0.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-version = "0.3.25"
+version = "0.3"
 features = [
     "Headers",
     "Request",
@@ -175,7 +175,7 @@ features = [
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen = { version = "0.2.68", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3"
 
 [[example]]


### PR DESCRIPTION
> **Note**
> `brotli_crate`, `cookie_crate` and `native-tls-crate` could no longer be found on https://crates.io/

First of all I want to thank you and all the people working on `reqwest` for his great work.

I tested this version of the updated dependencies with my own projects and everything worked fine for me.

Some of these dependencies have had newer versions for months or years and I removed some patches "Major.Minor.Patch" to allow the dependencies to get all bugfixes.

Cargo test result:
```shell
running 116 tests
test async_impl::body::tests::test_as_bytes ... ok
test async_impl::multipart::tests::header_percent_encoding ... ok
test async_impl::multipart::tests::correct_content_length ... ok
test async_impl::request::tests::convert_from_http_request ... ok
test async_impl::request::tests::add_query_append_same ... ok
test async_impl::request::tests::add_query_struct ... ok
test async_impl::request::tests::normalize_empty_query ... ok
test async_impl::request::tests::add_query_append ... ok
test async_impl::request::tests::add_query_map ... ok
test async_impl::request::tests::set_http_request_version ... ok
test async_impl::request::tests::convert_url_authority_into_basic_auth ... ok
test async_impl::multipart::tests::form_empty ... ok
test async_impl::client::tests::execute_request_rejects_invald_urls ... ok
test async_impl::request::tests::test_basic_auth_sensitive_header ... ok
test async_impl::multipart::tests::stream_to_end_with_header ... ok
test async_impl::multipart::tests::stream_to_end ... ok
test async_impl::request::tests::test_bearer_auth_sensitive_header ... ok
test async_impl::request::tests::test_explicit_sensitive_header ... ok
test async_impl::request::tests::test_replace_headers ... ok
test async_impl::request::tests::try_clone_no_body ... ok
test async_impl::request::tests::try_clone_reusable ... ok
test async_impl::response::tests::test_from_http_response ... ok
test blocking::multipart::tests::form_empty ... ok
test blocking::multipart::tests::read_to_end ... ok
test blocking::multipart::tests::read_to_end_with_header ... ok
test blocking::multipart::tests::read_to_end_with_length ... ok
test blocking::request::tests::add_body ... ok
test blocking::request::tests::add_form ... ok
test blocking::request::tests::add_header ... ok
test blocking::request::tests::add_headers ... ok
test blocking::request::tests::add_headers_multi ... ok
test blocking::request::tests::add_query_append ... ok
test blocking::request::tests::add_query_append_same ... ok
test blocking::request::tests::add_query_map ... ok
test blocking::request::tests::add_query_struct ... ok
test blocking::request::tests::basic_delete_request ... ok
test blocking::request::tests::basic_get_request ... ok
test blocking::request::tests::basic_head_request ... ok
test blocking::request::tests::basic_patch_request ... ok
test blocking::request::tests::basic_post_request ... ok
test blocking::request::tests::convert_from_http_request ... ok
test blocking::request::tests::basic_put_request ... ok
test blocking::request::tests::convert_url_authority_into_basic_auth ... ok
test blocking::request::tests::set_http_request_version ... ok
test blocking::request::tests::normalize_empty_query ... ok
test blocking::request::tests::test_basic_auth_sensitive_header ... ok
test blocking::request::tests::test_bearer_auth_sensitive_header ... ok
test blocking::request::tests::test_replace_headers ... ok
test error::tests::from_unknown_io_error ... ok
test error::tests::is_timeout ... ok
test error::tests::mem_size_of ... ok
test error::tests::roundtrip_io_error ... ok
test error::tests::test_source_chain ... ok
test connect::tests::test_tunnel ... ok
test connect::tests::test_tunnel_eof ... ok
test connect::tests::test_tunnel_non_http_response ... ok
test connect::tests::test_tunnel_basic_auth ... ok
test connect::tests::test_tunnel_proxy_unauthorized ... ok
test into_url::tests::into_url_file_scheme ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_has_bad::host ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_has_bad::idna_encoding ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_has_bad::invalid_domain_character ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_has_bad::ip_v4_address ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_has_bad::ip_v6_address ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_has_bad::port ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::domain_port_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::domain_username_password_port_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::domain_username_password_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::domain_username_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::domain_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::lookback_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::loopback_port_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::loopback_username_password_port_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::loopback_username_password_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_missing::and_url_is_valid::loopback_username_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_has_bad::host ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_has_bad::idna_encoding ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_has_bad::invalid_domain_character ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_has_bad::ip_v4_address ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_has_bad::ip_v6_address ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_has_bad::port ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::domain_port_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::domain_username_password_port_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::domain_username_password_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::domain_username_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::domain_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::loopback_port_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::loopback_username_password_port_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::loopback_username_password_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::loopback_username_works ... ok
test proxy::test::into_proxy_scheme::when_scheme_present::and_url_is_valid::loopback_works ... ok
test proxy::tests::test_all ... ok
test proxy::tests::test_custom ... ok
test proxy::tests::test_domain_matcher ... ok
test proxy::tests::test_empty_sys_no_proxy ... ok
test proxy::tests::test_get_sys_proxies_in_cgi ... ok
test proxy::tests::test_get_sys_proxies_parsing ... ok
test proxy::tests::test_get_sys_proxies_registry_parsing ... ok
test proxy::tests::test_has_http_auth ... ok
test proxy::tests::test_http ... ok
test proxy::tests::test_https ... ok
test proxy::tests::test_no_proxy_load ... ok
test proxy::tests::test_proxy_no_proxy_interception_for_proxy_types ... ok
test proxy::tests::test_proxy_scheme_ip_address_default_http ... ok
test proxy::tests::test_proxy_scheme_parse ... ok
test proxy::tests::test_proxy_scheme_parse_default_http_with_auth ... ok
test proxy::tests::test_type_prefix_extraction ... ok
test proxy::tests::test_sys_no_proxy ... ok
test proxy::tests::test_wildcard_sys_no_proxy ... ok
test redirect::test_redirect_policy_custom ... ok
test redirect::test_redirect_policy_limit ... ok
test redirect::test_redirect_policy_limit_to_0 ... ok
test redirect::test_remove_sensitive_headers ... ok
test response::tests::test_response_builder_ext ... ok
test tls::tests::certificate_from_pem_invalid ... ok
test tls::tests::certificate_from_der_invalid ... ok

test result: ok. 116 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running tests\badssl.rs (target\debug\deps\badssl-c75850b35cfa0422.exe)

running 3 tests
test test_badssl_no_built_in_roots ... ok
test test_badssl_modern ... ok
test test_badssl_self_signed ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.60s

     Running tests/blocking.rs (target\debug\deps\blocking-0b363480e0f11f56.exe)

running 14 tests
test test_body_from_bytes ... ok
test test_blocking_inside_a_runtime - should panic ... ok
test test_post ... ok
test test_post_form ... ok
test test_error_for_status_5xx ... ok
test test_error_for_status_4xx ... ok
test test_default_headers ... ok
test test_get ... ok
test test_response_copy_to ... ok
test test_override_default_headers ... ok
test test_response_non_utf_8_text ... ok
test test_response_text ... ok
test test_appended_headers_not_overwritten ... ok
test test_allowed_methods_blocking ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.41s

     Running tests/brotli.rs (target\debug\deps\brotli-91dc39fde9b7b931.exe)

running 5 tests
test test_accept_header_is_not_changed_if_set ... ok
test test_accept_encoding_header_is_not_changed_if_set ... ok
test test_brotli_empty_body ... ok
test brotli_single_byte_chunks ... ok
test brotli_response ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running tests\client.rs (target\debug\deps\client-9df482eec80d2f24.exe)

running 8 tests
test response_bytes ... ok
test overridden_dns_resolution_with_gai ... ok
test response_text ... ok
test auto_headers ... ok
test user_agent ... ok
test body_pipe_response ... ok
test overridden_dns_resolution_with_gai_multiple ... ok
test test_allowed_methods ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s

     Running tests/cookie.rs (target\debug\deps\cookie-cc6786cb45c3bfa7.exe)

running 6 tests
test cookie_response_accessor ... ok
test cookie_store_max_age ... ok
test cookie_store_expires ... ok
test cookie_store_simple ... ok
test cookie_store_path ... ok
test cookie_store_overwrite_existing ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests/deflate.rs (target\debug\deps\deflate-b7a946a06f410dab.exe)

running 5 tests
test test_deflate_empty_body ... ok
test test_accept_header_is_not_changed_if_set ... ok
test test_accept_encoding_header_is_not_changed_if_set ... ok
test deflate_single_byte_chunks ... ok
test deflate_response ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running tests/gzip.rs (target\debug\deps\gzip-7d2b5d4acf41b5a0.exe)

running 5 tests
test test_accept_header_is_not_changed_if_set ... ok
test test_accept_encoding_header_is_not_changed_if_set ... ok
test test_gzip_empty_body ... ok
test gzip_single_byte_chunks ... ok
test gzip_response ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

     Running tests/multipart.rs (target\debug\deps\multipart-7d08532e2caa7502.exe)

running 2 tests
test text_part ... ok
test blocking_file_part ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests\proxy.rs (target\debug\deps\proxy-4422d20e882fb429.exe)

running 7 tests
test test_using_system_proxy ... ignored
test http_proxy_basic_auth ... ok
test http_proxy ... ok
test test_no_proxy ... ok
test system_http_proxy_basic_auth_parsed ... ok
test http_over_http ... ok
test http_proxy_basic_auth_parsed ... ok

test result: ok. 6 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests\redirect.rs (target\debug\deps\redirect-5170f8743c3d1391.exe)

running 10 tests
test test_invalid_location_stops_redirect_gh484 ... ok
test test_referer_is_not_set_if_disabled ... ok
test test_redirect_policy_can_stop_redirects_without_an_error ... ok
test test_redirect_302_with_set_cookies ... ok
test test_redirect_removes_sensitive_headers ... ok
test test_redirect_307_does_not_try_if_reader_cannot_reset ... ok
test test_redirect_307_and_308_tries_to_get_again ... ok
test test_redirect_307_and_308_tries_to_post_again ... ok
test test_redirect_policy_can_return_errors ... ok
test test_redirect_301_and_302_and_303_changes_post_to_get ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests\timeouts.rs (target\debug\deps\timeouts-96726b5606aab99d.exe)

running 8 tests
test connect_timeout ... ok
test timeout_blocking_request ... ok
test timeout_closes_connection ... ok
test blocking_request_timeout_body ... ok
test response_timeout ... ok
test client_timeout ... ok
test request_timeout ... ok
test write_timeout_large_body ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.02s

     Running tests\upgrade.rs (target\debug\deps\upgrade-078fb4caa1d247f4.exe)

running 1 test
test http_upgrade ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests\wasm_simple.rs (target\debug\deps\wasm_simple-f758ea51fc603871.exe)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests reqwest

running 75 tests
test src\async_impl\request.rs - async_impl::request::RequestBuilder::send (line 477) - compile ... ok
test src\async_impl\response.rs - async_impl::response::Response::error_for_status (line 324) ... ok
test src\async_impl\client.rs - async_impl::client::ClientBuilder::default_headers (line 584) ... ok
test src\async_impl\client.rs - async_impl::client::ClientBuilder::user_agent (line 549) ... ok
test src\async_impl\request.rs - async_impl::request::RequestBuilder::try_clone (line 502) ... ok
test src\async_impl\request.rs - async_impl::request::RequestBuilder::basic_auth (line 235) ... ok
test src\async_impl\request.rs - async_impl::request::RequestBuilder::form (line 377) ... ok
test src\async_impl\response.rs - async_impl::response::Response::bytes (line 251) ... ok
test src\async_impl\response.rs - async_impl::response::Response::chunk (line 272) ... ok
test src\async_impl\client.rs - async_impl::client::ClientBuilder::default_headers (line 606) ... ok
test src\async_impl\request.rs - async_impl::request::RequestBuilder::multipart (line 287) ... ok
test src\async_impl\multipart.rs - async_impl::multipart::Form::text (line 72) ... ok
test src\async_impl\client.rs - async_impl::client::ClientBuilder::local_address (line 1015) ... ok
test src\blocking\body.rs - blocking::body::Body::new (line 52) ... ok
test src\blocking\client.rs - blocking::client::ClientBuilder (line 58) ... ok
test src\blocking\body.rs - blocking::body::Body::sized (line 70) ... ok
test src\blocking\body.rs - blocking::body::Body::new (line 38) ... ok
test src\blocking\client.rs - blocking::client::ClientBuilder::default_headers (line 163) ... ok
test src\async_impl\response.rs - async_impl::response::Response::text (line 135) ... ok
test src\async_impl\response.rs - async_impl::response::Response::text_with_charset (line 162) ... ok
test src\async_impl\response.rs - async_impl::response::Response::error_for_status_ref (line 354) ... ok
test src\blocking\client.rs - blocking::client::Client (line 38) ... ok
test src\blocking\client.rs - blocking::client::ClientBuilder::add_root_certificate (line 514) ... ok
test src\blocking\client.rs - blocking::client::ClientBuilder::default_headers (line 140) ... ok
test src\blocking\client.rs - blocking::client::ClientBuilder::local_address (line 480) ... ok
test src\blocking\multipart.rs - blocking::multipart::Form::file (line 105) - compile ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::body (line 297) ... ok
test src\blocking\mod.rs - blocking (line 50) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::bearer_auth (line 274) ... ok
test src\blocking\client.rs - blocking::client::ClientBuilder::user_agent (line 112) ... ok
test src\blocking\multipart.rs - blocking::multipart (line 9) ... ok
test src\blocking\mod.rs - blocking::get (line 88) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::body (line 322) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::basic_auth (line 254) ... ok
test src\blocking\mod.rs - blocking (line 21) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::body (line 309) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::form (line 419) ... ok
test src\blocking\multipart.rs - blocking::multipart::Form::text (line 86) ... ok
test src\blocking\response.rs - blocking::response::Response::error_for_status_ref (line 377) - compile ... ok
test src\blocking\response.rs - blocking::response::Response::error_for_status (line 346) - compile ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::multipart (line 512) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::header (line 172) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::headers (line 224) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::query (line 362) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::try_clone (line 583) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::try_clone (line 595) ... ok
test src\blocking\request.rs - blocking::request::RequestBuilder::try_clone (line 570) ... ok
test src\blocking\response.rs - blocking::response::Response::bytes (line 251) ... ok
test src\blocking\response.rs - blocking::response::Response::copy_to (line 326) ... ok
test src\blocking\response.rs - blocking::response::Response::headers (line 102) ... ok
test src\blocking\response.rs - blocking::response::Response::remote_addr (line 170) ... ok
test src\blocking\response.rs - blocking::response::Response::status (line 54) ... ok
test src\blocking\response.rs - blocking::response::Response::text (line 275) ... ok
test src\blocking\response.rs - blocking::response::Response::url (line 154) ... ok
test src\blocking\response.rs - blocking::response::Response::text_with_charset (line 298) ... ok
test src\blocking\response.rs - blocking::response::Response::status (line 71) ... ok
test src\lib.rs - get (line 246) ... ok
test src\lib.rs - (line 80) ... ok
test src\lib.rs - (line 59) ... ok
test src\lib.rs - (line 101) ... ok
test src\lib.rs - (line 35) ... ok
test src\proxy.rs - proxy::Proxy (line 30) ... ok
test src\error.rs - error::Error::url (line 46) ... ok
test src\cookie.rs - cookie::Jar::add_cookie_str (line 147) ... ok
test src\proxy.rs - proxy::Proxy::no_proxy (line 310) ... ok
test src\proxy.rs - proxy::Proxy::http (line 182) ... ok
test src\proxy.rs - proxy::Proxy::basic_auth (line 292) ... ok
test src\proxy.rs - proxy::Proxy::all (line 222) ... ok
test src\redirect.rs - redirect::Policy::redirect (line 116) ... ok
test src\redirect.rs - redirect::Policy::custom (line 76) ... ok
test src\proxy.rs - proxy::Proxy (line 47) ... ok
test src\proxy.rs - proxy::Proxy::https (line 202) ... ok
test src\tls.rs - tls::Certificate::from_der (line 62) ... ok
test src\proxy.rs - proxy::Proxy::custom (line 242) ... ok
test src\tls.rs - tls::Certificate::from_pem (line 87) ... ok

test result: ok. 75 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.73s
```