### PR TITLE
Make wasm requests cancel when the future drops.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,8 @@ wasm-streams = { version = "0.2", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"
 features = [
+    "AbortController",
+    "AbortSignal",
     "Headers",
     "Request",
     "RequestInit",

--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -5,6 +5,8 @@ use http::{HeaderMap, StatusCode};
 use js_sys::Uint8Array;
 use url::Url;
 
+use crate::wasm::AbortGuard;
+
 #[cfg(feature = "stream")]
 use wasm_bindgen::JsCast;
 
@@ -17,16 +19,22 @@ use serde::de::DeserializeOwned;
 /// A Response to a submitted `Request`.
 pub struct Response {
     http: http::Response<web_sys::Response>,
+    _abort: AbortGuard,
     // Boxed to save space (11 words to 1 word), and it's not accessed
     // frequently internally.
     url: Box<Url>,
 }
 
 impl Response {
-    pub(super) fn new(res: http::Response<web_sys::Response>, url: Url) -> Response {
+    pub(super) fn new(
+        res: http::Response<web_sys::Response>,
+        url: Url,
+        abort: AbortGuard,
+    ) -> Response {
         Response {
             http: res,
             url: Box::new(url),
+            _abort: abort,
         }
     }
 


### PR DESCRIPTION
This makes the wasm backend match the behavior of the native one.