### PR TITLE
Remove serde-serialize feature from wasm-bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ features = [
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen = { version = "0.2.68", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.68"}
 wasm-bindgen-test = "0.3"
 
 [[example]]


### PR DESCRIPTION
Using the `serde-serialize` feature can cause dependency cycles due to its usage of serde. This doesn't manifest within reqwest itself, but rather in a workspaces/crates that use reqwests and also depend on crates like `ahash`. For context on the dependency cycle issue please see https://github.com/tkaitchuck/aHash/issues/95