### PR TITLE
Add support for custom connectors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,7 @@ if_hyper! {
     pub use self::async_impl::{
         Body, Client, ClientBuilder, Request, RequestBuilder, Response, Upgraded,
     };
+    pub use self::connect::{GenericConnection, GenericConnector};
     pub use self::proxy::{Proxy,NoProxy};
     #[cfg(feature = "__tls")]
     // Re-exports, to be removed in a future release


### PR DESCRIPTION
Hi @seanmonstar, sorry for the PR without a related GH issue. 

I'm building some stuff with reqwest and added functionality to the library to use arbitrary transport for requests via custom connectors. It's very useful if you want to encapsulate requests created by the library in e.g. ProxyProtocol streams or even other request's CONNECT payload.

So, contributing my changes back to the library 😃 