### PR TITLE
deps: update rustls v0.20.1 -> v0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,9 +118,9 @@ native-tls-crate = { version = "0.2.10", optional = true, package = "native-tls"
 tokio-native-tls = { version = "0.3.0", optional = true }
 
 # rustls-tls
-hyper-rustls = { version = "0.23", default-features = false, optional = true }
-rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }
-tokio-rustls = { version = "0.23", optional = true }
+hyper-rustls = { version = "0.24.0", default-features = false, optional = true }
+rustls = { version = "0.21.0", features = ["dangerous_configuration"], optional = true }
+tokio-rustls = { version = "0.24", optional = true }
 webpki-roots = { version = "0.22", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
@@ -141,8 +141,8 @@ trust-dns-resolver = { version = "0.22", optional = true }
 
 # HTTP/3 experimental support
 h3 = { version="0.0.2", optional = true }
-h3-quinn = { version="0.0.2", optional = true }
-quinn = { version = "0.9", default-features = false, features = ["tls-rustls", "ring"], optional = true  }
+h3-quinn = { version="0.0.3", optional = true }
+quinn = { version = "0.10", default-features = false, features = ["tls-rustls", "ring"], optional = true  }
 futures-channel = { version="0.3", optional = true}
 
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -14,7 +14,7 @@
 #[cfg(feature = "__rustls")]
 use rustls::{
     client::HandshakeSignatureValid, client::ServerCertVerified, client::ServerCertVerifier,
-    internal::msgs::handshake::DigitallySignedStruct, Error as TLSError, ServerName,
+    DigitallySignedStruct, Error as TLSError, ServerName,
 };
 use std::fmt;
 


### PR DESCRIPTION
## Description

This commit updates reqwest to use rustls 0.21.0, both as a direct dependency and through an update of tokio-rustls to 0.24.0, hyper-rustls to 0.24.0, quinn 0.10.0, and h3-quinn to 0.0.3.

One change is required in the reqwest codebase to adjust the import location of the `DigtallySignedStruct` type.

## Remaining work

- [X] wait for https://github.com/tokio-rs/tls/pull/137 to be merged
- [x] wait for tokio-rustls v0.24.0 to be published to crates.io
- [x] remove Cargo.toml patch for tokio-rustls
- [x] wait for https://github.com/rustls/hyper-rustls/pull/199 to be merged
- [x] wait for hyper-rustls v0.24.0 to be published to crates.io
- [x] remove Cargo.toml patch for hyper-rustls
- [x] wait for https://github.com/quinn-rs/quinn/pull/1515 to be merged
- [x] wait for quinn 0.10 to be published to crates.io https://github.com/quinn-rs/quinn/issues/1528
- [x] remove Cargo.toml patch for quinn
- [x] wait for https://github.com/hyperium/h3/pull/190 to be merged
- [x] wait for an h3 release tag.
- [x] remove Cargo.toml patch for h3
- [x] get PR approved