### PR TITLE
feat(h3): allow multi impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,9 @@ stream = ["tokio/fs", "tokio-util", "wasm-streams"]
 socks = ["tokio-socks"]
 
 # Experimental HTTP/3 client.
-http3 = ["rustls-tls", "h3", "h3-quinn", "quinn", "futures-channel"]
+http3 = ["http3-provider", "h3-quinn", "quinn", "rustls-tls"]
+
+http3-provider = ["h3", "futures-channel"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at anytime.

--- a/examples/h3_provider.rs
+++ b/examples/h3_provider.rs
@@ -1,5 +1,8 @@
 #![deny(warnings)]
 
+use std::net::SocketAddr;
+use futures_core::future::BoxFuture;
+
 // This is using the `tokio` runtime. You'll need the following dependency:
 //
 // `tokio = { version = "1", features = ["full"] }`
@@ -13,6 +16,7 @@ async fn main() -> Result<(), reqwest::Error> {
     async fn get<T: IntoUrl + Clone>(url: T) -> reqwest::Result<Response> {
         Client::builder()
             .http3_prior_knowledge()
+            .http3_connection_provider(Box::new(MyHttp3Provider{}))
             .build()?
             .get(url)
             .version(Version::HTTP_3)
@@ -49,3 +53,20 @@ async fn main() -> Result<(), reqwest::Error> {
 // The two lines below avoid the "'main' function not found" error when building for wasm32 target.
 #[cfg(any(target_arch = "wasm32", not(feature = "http3-provider")))]
 fn main() {}
+
+struct MyHttp3Provider {
+
+}
+
+impl crate::async_impl::h3_client::connect::H3ConnectionProvider for MyHttp3Provider {
+    type C = ();
+    type T = ();
+
+    fn poll_connect(
+        &self,
+        addr: SocketAddr,
+        server_name: &str,
+    ) -> BoxFuture<Result<Self::C, BoxError>> {
+        todo!()
+    }
+}

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -2,46 +2,36 @@ use crate::async_impl::h3_client::dns::resolve;
 use crate::dns::DynResolver;
 use crate::error::BoxError;
 use bytes::Bytes;
+use futures_core::future::BoxFuture;
+use futures_util::{FutureExt, TryFutureExt};
 use h3::client::SendRequest;
-use h3_quinn::{Connection, OpenStreams};
 use http::Uri;
 use hyper::client::connect::dns::Name;
-use quinn::{ClientConfig, Endpoint, TransportConfig};
+use quinn::{ClientConfig, ConnectError, Connecting, Endpoint, TransportConfig};
+use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-type H3Connection = (
-    h3::client::Connection<Connection, Bytes>,
-    SendRequest<OpenStreams, Bytes>,
-);
+pub type H3Connection<C, T> = (h3::client::Connection<C, Bytes>, SendRequest<T, Bytes>);
 
 #[derive(Clone)]
 pub(crate) struct H3Connector {
     resolver: DynResolver,
-    endpoint: Endpoint,
+    connection_provider: Box<dyn H3ConnectionProvider<C = (), T = ()>>,
 }
 
 impl H3Connector {
-    pub fn new(
+    pub fn new<C, T>(
         resolver: DynResolver,
-        tls: rustls::ClientConfig,
-        local_addr: Option<IpAddr>,
-        transport_config: TransportConfig,
+        connection_provider: Box<dyn H3ConnectionProvider<C = C, T = T>>,
     ) -> H3Connector {
-        let mut config = ClientConfig::new(Arc::new(tls));
-        // FIXME: Replace this when there is a setter.
-        config.transport = Arc::new(transport_config);
-
-        let socket_addr = match local_addr {
-            Some(ip) => SocketAddr::new(ip, 0),
-            None => "[::]:0".parse::<SocketAddr>().unwrap(),
-        };
-
-        let mut endpoint = Endpoint::client(socket_addr).expect("unable to create QUIC endpoint");
-        endpoint.set_default_client_config(config);
-
-        Self { resolver, endpoint }
+        Self {
+            resolver,
+            connection_provider,
+        }
     }
 
     pub async fn connect(&mut self, dest: Uri) -> Result<H3Connection, BoxError> {
@@ -67,21 +57,96 @@ impl H3Connector {
         &mut self,
         addrs: Vec<SocketAddr>,
         server_name: &str,
-    ) -> Result<H3Connection, BoxError> {
+    ) -> Result<H3Connection<C, T>, BoxError> {
         let mut err = None;
         for addr in addrs {
-            match self.endpoint.connect(addr, server_name)?.await {
+            match self
+                .connection_provider
+                .poll_connect(addr, server_name)
+                .await
+            {
                 Ok(new_conn) => {
-                    let quinn_conn = Connection::new(new_conn);
-                    return Ok(h3::client::new(quinn_conn).await?);
+                    return Ok(new_conn);
                 }
                 Err(e) => err = Some(e),
             }
         }
 
         match err {
-            Some(e) => Err(Box::new(e) as BoxError),
+            Some(e) => Err(e),
             None => Err("failed to establish connection for HTTP/3 request".into()),
+        }
+    }
+}
+
+pub trait H3ConnectionProvider {
+    type C;
+    type T;
+    fn poll_connect(
+        &self,
+        addr: SocketAddr,
+        server_name: &str,
+    ) -> BoxFuture<Result<H3Connection<Self::C, Self::T>, BoxError>>;
+}
+
+pub struct QuinnH3ConnectionProvider {
+    endpoint: Endpoint,
+}
+
+impl QuinnH3ConnectionProvider {
+    pub fn new(
+        tls: rustls::ClientConfig,
+        local_addr: Option<IpAddr>,
+        transport_config: TransportConfig,
+    ) -> Self {
+        let mut config = ClientConfig::new(Arc::new(tls));
+        // FIXME: Replace this when there is a setter.
+        config.transport = Arc::new(transport_config);
+
+        let socket_addr = match local_addr {
+            Some(ip) => SocketAddr::new(ip, 0),
+            None => "[::]:0".parse::<SocketAddr>().unwrap(),
+        };
+
+        let mut endpoint = Endpoint::client(socket_addr).expect("unable to create QUIC endpoint");
+        endpoint.set_default_client_config(config);
+        QuinnH3ConnectionProvider { endpoint }
+    }
+}
+
+impl H3ConnectionProvider for QuinnH3ConnectionProvider {
+    type C = h3_quinn::Connection;
+    type T = h3_quinn::OpenStreams;
+
+    fn poll_connect(
+        &self,
+        addr: SocketAddr,
+        server_name: &str,
+    ) -> BoxFuture<Result<Self::C, BoxError>> {
+        let connecting = self.endpoint.connect(addr, server_name);
+        Box::pin(H3QuinnConnecting { connecting })
+    }
+}
+
+struct H3QuinnConnecting {
+    connecting: Result<Connecting, ConnectError>,
+}
+
+impl Future for H3QuinnConnecting {
+    type Output = Result<H3Connection<h3_quinn::Connection, h3_quinn::OpenStreams>, BoxError>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.connecting.as_ref() {
+            Ok(mut connecting) => connecting
+                .poll_unpin(cx)
+                .map(|conn_result| match conn_result {
+                    Ok(new_conn) => {
+                        let quinn_conn = h3_quinn::Connection::new(new_conn);
+                        return Ok(quinn_conn);
+                    }
+                    Err(e) => Err(Box::new(e) as BoxError),
+                })
+                .map_ok(|quinn_conn| h3::client::new(quinn_conn)),
+            Err(e) => Poll::Ready(Err(Box::new(e) as BoxError)),
         }
     }
 }

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "http3")]
+#![cfg(feature = "http3-provider")]
 
 pub(crate) mod connect;
 pub(crate) mod dns;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@
 //! [Proxy]: ./struct.Proxy.html
 //! [cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
 
-#[cfg(all(feature = "http3", not(reqwest_unstable)))]
+#[cfg(all(feature = "http3-provider", not(reqwest_unstable)))]
 compile_error!(
     "\
     The `http3` feature is unstable, and requires the \

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -412,14 +412,14 @@ impl fmt::Debug for TlsBackend {
 
 impl Default for TlsBackend {
     fn default() -> TlsBackend {
-        #[cfg(all(feature = "default-tls", not(feature = "http3")))]
+        #[cfg(all(feature = "default-tls", not(feature = "http3-provider")))]
         {
             TlsBackend::Default
         }
 
         #[cfg(any(
             all(feature = "__rustls", not(feature = "default-tls")),
-            feature = "http3"
+            feature = "http3-provider"
         ))]
         {
             TlsBackend::Rustls


### PR DESCRIPTION
Relates to https://github.com/seanmonstar/reqwest/issues/1558

other impls of hyperium/h3 can implement the H3ConnectionProvider trait allowing use of more than one h3 impl and also further customization of the default quinn transport.

I couldn't work out how to let the user provide a dyn trait without exposing the generic h3 types everywhere. maybe someone who knows rust a bit better can help. the trait should be moved to a user facing package too, but I'd like to get the impl sorted first.