### PR TITLE
fix RUSTSEC-2023-0034 by updating h2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ mime_guess = { version = "2.0", default-features = false, optional = true }
 encoding_rs = "0.8"
 http-body = "0.4.0"
 hyper = { version = "0.14.18", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
-h2 = "0.3.10"
+h2 = "0.3.17"
 once_cell = "1"
 log = "0.4"
 mime = "0.3.16"


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2023-0034 by updating h2