### PR TITLE
support for arbitrary proxy

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -544,11 +544,11 @@ impl Service<Uri> for Connector {
 }
 
 pub trait AsyncConn:
-    AsyncRead + AsyncWrite + Connection + Send + Sync + Unpin + 'static
+    AsyncRead + AsyncWrite + Connection + Send + Unpin + 'static
 {
 }
 
-impl<T: AsyncRead + AsyncWrite + Connection + Send + Sync + Unpin + 'static> AsyncConn for T {}
+impl<T: AsyncRead + AsyncWrite + Connection + Send + Unpin + 'static> AsyncConn for T {}
 
 type BoxConn = Box<dyn AsyncConn>;
 


### PR DESCRIPTION
this is my proposal to fix #1321 

It's functional, I used it to implement reqwest over arti (in-process Tor) in [this gist](https://gist.github.com/trinity-1686a/9286c8dd41b533810940fa36e0f83975)

I don't think it is ready to be merged as is, without some documentation/example and renaming `custom2` to something more meaningful. But I believe it's a good base for a discussion on whether Reqwest wants this feature, and what the public interface could be