### PR TITLE
chore: A few simple cleanups/lints

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,12 +7,11 @@
 #[tokio::main]
 async fn main() -> Result<(), reqwest::Error> {
     // Some simple CLI args requirements...
-    let url = match std::env::args().nth(1) {
-        Some(url) => url,
-        None => {
-            println!("No CLI URL provided, using default.");
-            "https://hyper.rs".into()
-        }
+    let url = if let Some(url) = std::env::args().nth(1) {
+        url
+    } else {
+        println!("No CLI URL provided, using default.");
+        "https://hyper.rs".into()
     };
 
     eprintln!("Fetching {:?}...", url);

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -132,7 +132,7 @@ impl Request {
             None => None,
         };
         let mut req = Request::new(self.method().clone(), self.url().clone());
-        *req.timeout_mut() = self.timeout().cloned();
+        *req.timeout_mut() = self.timeout().copied();
         *req.headers_mut() = self.headers().clone();
         *req.version_mut() = self.version();
         req.body = body;
@@ -196,7 +196,7 @@ impl RequestBuilder {
         self.header_sensitive(key, value, false)
     }
 
-    /// Add a `Header` to this Request with ability to define if header_value is sensitive.
+    /// Add a `Header` to this Request with ability to define if `header_value` is sensitive.
     fn header_sensitive<K, V>(mut self, key: K, value: V, sensitive: bool) -> RequestBuilder
     where
         HeaderName: TryFrom<K>,

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -3,7 +3,7 @@ mod support;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
 use std::collections::HashMap;
-use support::*;
+use support::server;
 
 #[test]
 fn test_response_text() {

--- a/tests/brotli.rs
+++ b/tests/brotli.rs
@@ -1,6 +1,6 @@
 mod support;
 use std::io::Read;
-use support::*;
+use support::server;
 
 #[tokio::test]
 async fn brotli_response() {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2,10 +2,12 @@
 mod support;
 
 use futures_util::stream::StreamExt;
+use support::server;
+
+#[cfg(feature = "json")]
 use http::header::CONTENT_TYPE;
-use http::HeaderValue;
+#[cfg(feature = "json")]
 use std::collections::HashMap;
-use support::*;
 
 use reqwest::Client;
 
@@ -382,7 +384,7 @@ async fn test_allowed_methods() {
 fn add_json_default_content_type_if_not_set_manually() {
     let mut map = HashMap::new();
     map.insert("body", "json");
-    let content_type = HeaderValue::from_static("application/vnd.api+json");
+    let content_type = http::HeaderValue::from_static("application/vnd.api+json");
     let req = Client::new()
         .post("https://google.com/")
         .header(CONTENT_TYPE, &content_type)

--- a/tests/cookie.rs
+++ b/tests/cookie.rs
@@ -1,5 +1,5 @@
 mod support;
-use support::*;
+use support::server;
 
 #[tokio::test]
 async fn cookie_response_accessor() {
@@ -36,7 +36,7 @@ async fn cookie_response_accessor() {
     assert_eq!(cookies[1].name(), "expires");
     assert_eq!(
         cookies[1].expires().unwrap(),
-        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1445412480)
+        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_445_412_480)
     );
 
     // path

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -1,6 +1,6 @@
 mod support;
 use std::io::Write;
-use support::*;
+use support::server;
 
 #[tokio::test]
 async fn deflate_response() {

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -1,5 +1,5 @@
 mod support;
-use support::*;
+use support::server;
 
 use std::io::Write;
 

--- a/tests/multipart.rs
+++ b/tests/multipart.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 mod support;
 use futures_util::stream::StreamExt;
-use support::*;
+use support::server;
 
 #[tokio::test]
 async fn text_part() {

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 mod support;
-use support::*;
+use support::server;
 
 use std::env;
 

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -1,14 +1,15 @@
 #![cfg(not(target_arch = "wasm32"))]
 mod support;
 use futures_util::stream::StreamExt;
-use support::*;
+use hyper::Body;
+use support::server;
 
 #[tokio::test]
 async fn test_redirect_301_and_302_and_303_changes_post_to_get() {
     let client = reqwest::Client::new();
     let codes = [301u16, 302, 303];
 
-    for &code in codes.iter() {
+    for &code in &codes {
         let redirect = server::http(move |req| async move {
             if req.method() == "POST" {
                 assert_eq!(req.uri(), &*format!("/{}", code));
@@ -16,14 +17,14 @@ async fn test_redirect_301_and_302_and_303_changes_post_to_get() {
                     .status(code)
                     .header("location", "/dst")
                     .header("server", "test-redirect")
-                    .body(Default::default())
+                    .body(Body::default())
                     .unwrap()
             } else {
                 assert_eq!(req.method(), "GET");
 
                 http::Response::builder()
                     .header("server", "test-dst")
-                    .body(Default::default())
+                    .body(Body::default())
                     .unwrap()
             }
         });
@@ -44,7 +45,7 @@ async fn test_redirect_301_and_302_and_303_changes_post_to_get() {
 async fn test_redirect_307_and_308_tries_to_get_again() {
     let client = reqwest::Client::new();
     let codes = [307u16, 308];
-    for &code in codes.iter() {
+    for &code in &codes {
         let redirect = server::http(move |req| async move {
             assert_eq!(req.method(), "GET");
             if req.uri() == &*format!("/{}", code) {
@@ -52,14 +53,14 @@ async fn test_redirect_307_and_308_tries_to_get_again() {
                     .status(code)
                     .header("location", "/dst")
                     .header("server", "test-redirect")
-                    .body(Default::default())
+                    .body(Body::default())
                     .unwrap()
             } else {
                 assert_eq!(req.uri(), "/dst");
 
                 http::Response::builder()
                     .header("server", "test-dst")
-                    .body(Default::default())
+                    .body(Body::default())
                     .unwrap()
             }
         });
@@ -81,7 +82,7 @@ async fn test_redirect_307_and_308_tries_to_post_again() {
     let _ = env_logger::try_init();
     let client = reqwest::Client::new();
     let codes = [307u16, 308];
-    for &code in codes.iter() {
+    for &code in &codes {
         let redirect = server::http(move |mut req| async move {
             assert_eq!(req.method(), "POST");
             assert_eq!(req.headers()["content-length"], "5");
@@ -94,14 +95,14 @@ async fn test_redirect_307_and_308_tries_to_post_again() {
                     .status(code)
                     .header("location", "/dst")
                     .header("server", "test-redirect")
-                    .body(Default::default())
+                    .body(Body::default())
                     .unwrap()
             } else {
                 assert_eq!(req.uri(), "/dst");
 
                 http::Response::builder()
                     .header("server", "test-dst")
-                    .body(Default::default())
+                    .body(Body::default())
                     .unwrap()
             }
         });
@@ -123,7 +124,7 @@ async fn test_redirect_307_and_308_tries_to_post_again() {
 fn test_redirect_307_does_not_try_if_reader_cannot_reset() {
     let client = reqwest::blocking::Client::new();
     let codes = [307u16, 308];
-    for &code in codes.iter() {
+    for &code in &codes {
         let redirect = server::http(move |mut req| async move {
             assert_eq!(req.method(), "POST");
             assert_eq!(req.uri(), &*format!("/{}", code));
@@ -136,7 +137,7 @@ fn test_redirect_307_does_not_try_if_reader_cannot_reset() {
                 .status(code)
                 .header("location", "/dst")
                 .header("server", "test-redirect")
-                .body(Default::default())
+                .body(Body::default())
                 .unwrap()
         });
 
@@ -179,7 +180,7 @@ async fn test_redirect_removes_sensitive_headers() {
         http::Response::builder()
             .status(302)
             .header("location", format!("http://{}/end", end_addr))
-            .body(Default::default())
+            .body(Body::default())
             .unwrap()
     });
 
@@ -205,7 +206,7 @@ async fn test_redirect_policy_can_return_errors() {
         http::Response::builder()
             .status(302)
             .header("location", "/loop")
-            .body(Default::default())
+            .body(Body::default())
             .unwrap()
     });
 
@@ -221,7 +222,7 @@ async fn test_redirect_policy_can_stop_redirects_without_an_error() {
         http::Response::builder()
             .status(302)
             .header("location", "/dont")
-            .body(Default::default())
+            .body(Body::default())
             .unwrap()
     });
 
@@ -247,7 +248,7 @@ async fn test_referer_is_not_set_if_disabled() {
             http::Response::builder()
                 .status(302)
                 .header("location", "/dst")
-                .body(Default::default())
+                .body(Body::default())
                 .unwrap()
         } else {
             assert_eq!(req.uri(), "/dst");
@@ -273,7 +274,7 @@ async fn test_invalid_location_stops_redirect_gh484() {
         http::Response::builder()
             .status(302)
             .header("location", "http://www.yikes{KABOOM}")
-            .body(Default::default())
+            .body(Body::default())
             .unwrap()
     });
 
@@ -295,7 +296,7 @@ async fn test_redirect_302_with_set_cookies() {
                 .status(302)
                 .header("location", "/dst")
                 .header("set-cookie", "key=value")
-                .body(Default::default())
+                .body(Body::default())
                 .unwrap()
         } else {
             assert_eq!(req.uri(), "/dst");
@@ -325,7 +326,7 @@ async fn test_redirect_https_only_enforced_gh1312() {
         http::Response::builder()
             .status(302)
             .header("location", "http://insecure")
-            .body(Default::default())
+            .body(Body::default())
             .unwrap()
     });
 

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 mod support;
-use support::*;
+use support::server;
 
 use std::time::Duration;
 

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 mod support;
-use support::*;
+use support::server;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[tokio::test]


### PR DESCRIPTION
I asked clippy to help out, to see if any simple improvements are available. I ignored most of the pedantic ones, but a few of them seemed reasonable.

* in a few places, the match with `_` is used, even though there is only one other option. I think it is better to explicitly list them all - so that if another enum value is added in the future, it won't compile until someone looks at each case and decides what should the proper value be. This way there won't be any surprising breakages due to changes in the enums.
* a few `use wildcard` inlinings
* some big numbers are easier to read with underscores
* `for` iterating without `.iter()`