### PR TITLE
fail Client build if Identity + default backend + !cfg(native-tls)

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -319,7 +319,7 @@ impl ClientBuilder {
                             id.add_to_native_tls(&mut tls)?;
                         }
                     }
-                    #[cfg(feature = "__rustls")]
+                    #[cfg(all(feature = "__rustls", not(feature = "native-tls")))]
                     {
                         // Default backend + rustls Identity doesn't work.
                         if let Some(_id) = config.identity {

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -319,6 +319,13 @@ impl ClientBuilder {
                             id.add_to_native_tls(&mut tls)?;
                         }
                     }
+                    #[cfg(feature = "__rustls")]
+                    {
+                        // Default backend + rustls Identity doesn't work.
+                        if let Some(_id) = config.identity {
+                            return Err(crate::error::builder("incompatible TLS identity type"));
+                        }
+                    }
 
                     if let Some(min_tls_version) = config.min_tls_version {
                         let protocol = min_tls_version.to_native_tls().ok_or_else(|| {


### PR DESCRIPTION
If `ClientBuilder::build` encounters a `TlsBackend::Default`, and `cfg(native-tls)` is not enabled, it doesn't know how to load the client certificate. Rather than silently ignore the attempt to use a client `Identity`, return an error.

This fix feels a little unsatisfying, for a couple of reasons:
1. The problem might come back. It's not obvious which `cfg` gates should be applied at the various places `Identity` gets touched, so the code seems fragile in this area.
Perhaps there should be a way to indicate that the `Identity` was successfully consumed? Then if we reach the end of `build()` and we still have an unused identity, we know there's a problem and should return an error.
2. There's no test coverage. I'm looking into how to do this, but I'm not there yet. So far all I can offer is a flimsy "works for me."

I think this fixes #903, though it contains a few different reports over the years and it's hard to tell if they're all the same thing. 