### PR TITLE
Add response size limit 2

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1396,7 +1396,7 @@ impl Client {
     }
 
     pub(super) fn execute_request(&self, req: Request) -> Pending {
-        let (method, url, mut headers, body, timeout, version) = req.pieces();
+        let (method, url, mut headers, body, response_body_limit, timeout, version) = req.pieces();
         if url.scheme() != "http" && url.scheme() != "https" {
             return Pending::new_err(error::url_bad_scheme(url));
         }
@@ -1474,6 +1474,7 @@ impl Client {
                 client: self.inner.clone(),
 
                 in_flight,
+                response_body_limit,
                 timeout,
             }),
         }
@@ -1705,6 +1706,7 @@ pin_project! {
 
         #[pin]
         in_flight: ResponseFuture,
+        response_body_limit: Option<usize>,
         #[pin]
         timeout: Option<Pin<Box<Sleep>>>,
     }
@@ -1957,6 +1959,7 @@ impl Future for PendingRequest {
                 res,
                 self.url.clone(),
                 self.client.accepts,
+                self.response_body_limit,
                 self.timeout.take(),
             );
             return Poll::Ready(Ok(res));

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1831,7 +1831,7 @@ pin_project! {
 
         #[pin]
         in_flight: ResponseFuture,
-        response_body_limit: Option<usize>,
+        response_body_limit: Option<u64>,
         #[pin]
         timeout: Option<Pin<Box<Sleep>>>,
     }

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -25,7 +25,7 @@ pub struct Request {
     headers: HeaderMap,
     body: Option<Body>,
     timeout: Option<Duration>,
-    response_body_limit: Option<usize>,
+    response_body_limit: Option<u64>,
     version: Version,
 }
 
@@ -103,13 +103,13 @@ impl Request {
 
     /// Get the response body limit.
     #[inline]
-    pub fn response_body_limit(&self) -> Option<&usize> {
-        self.response_body_limit.as_ref()
+    pub fn response_body_limit(&self) -> Option<u64> {
+        self.response_body_limit
     }
 
     /// Get a mutable reference to the response body limit.
     #[inline]
-    pub fn response_body_limit_mut(&mut self) -> &mut Option<usize> {
+    pub fn response_body_limit_mut(&mut self) -> &mut Option<u64> {
         &mut self.response_body_limit
     }
 
@@ -146,7 +146,7 @@ impl Request {
             None => None,
         };
         let mut req = Request::new(self.method().clone(), self.url().clone());
-        *req.response_body_limit_mut() = self.response_body_limit().cloned();
+        *req.response_body_limit_mut() = self.response_body_limit();
         *req.timeout_mut() = self.timeout().cloned();
         *req.headers_mut() = self.headers().clone();
         *req.version_mut() = self.version();
@@ -161,7 +161,7 @@ impl Request {
         Url,
         HeaderMap,
         Option<Body>,
-        Option<usize>,
+        Option<u64>,
         Option<Duration>,
         Version,
     ) {
@@ -291,7 +291,7 @@ impl RequestBuilder {
     ///
     /// The response body limits the size of the response. Responses larger than
     /// the limit will be rejected. Only this request is affected. The limit is specified in bytes.
-    pub fn response_body_limit(mut self, response_body_limit: usize) -> RequestBuilder {
+    pub fn response_body_limit(mut self, response_body_limit: u64) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             *req.response_body_limit_mut() = Some(response_body_limit);
         }

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -27,6 +27,7 @@ pub struct Request {
     headers: HeaderMap,
     body: Option<Body>,
     timeout: Option<Duration>,
+    response_body_limit: Option<usize>,
     version: Version,
 }
 
@@ -49,6 +50,7 @@ impl Request {
             headers: HeaderMap::new(),
             body: None,
             timeout: None,
+            response_body_limit: None,
             version: Version::default(),
         }
     }
@@ -101,6 +103,18 @@ impl Request {
         &mut self.body
     }
 
+    /// Get the response body limit.
+    #[inline]
+    pub fn response_body_limit(&self) -> Option<&usize> {
+        self.response_body_limit.as_ref()
+    }
+
+    /// Get a mutable reference to the response body limit.
+    #[inline]
+    pub fn response_body_limit_mut(&mut self) -> &mut Option<usize> {
+        &mut self.response_body_limit
+    }
+
     /// Get the timeout.
     #[inline]
     pub fn timeout(&self) -> Option<&Duration> {
@@ -134,6 +148,7 @@ impl Request {
             None => None,
         };
         let mut req = Request::new(self.method().clone(), self.url().clone());
+        *req.response_body_limit_mut() = self.response_body_limit().cloned();
         *req.timeout_mut() = self.timeout().cloned();
         *req.headers_mut() = self.headers().clone();
         *req.version_mut() = self.version();
@@ -148,6 +163,7 @@ impl Request {
         Url,
         HeaderMap,
         Option<Body>,
+        Option<usize>,
         Option<Duration>,
         Version,
     ) {
@@ -156,6 +172,7 @@ impl Request {
             self.url,
             self.headers,
             self.body,
+            self.response_body_limit,
             self.timeout,
             self.version,
         )
@@ -272,6 +289,17 @@ impl RequestBuilder {
     pub fn body<T: Into<Body>>(mut self, body: T) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             *req.body_mut() = Some(body.into());
+        }
+        self
+    }
+
+    /// Enables a response body limit.
+    ///
+    /// The response body limits the size of the response. Responses larger than
+    /// the limit will be rejected. Only this request is affected. The limit is specified in bytes.
+    pub fn response_body_limit(mut self, response_body_limit: usize) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            *req.response_body_limit_mut() = Some(response_body_limit);
         }
         self
     }
@@ -603,6 +631,7 @@ where
             url,
             headers,
             body: Some(body.into()),
+            response_body_limit: None,
             timeout: None,
             version,
         })

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -28,7 +28,7 @@ pub struct Response {
     // Boxed to save space (11 words to 1 word), and it's not accessed
     // frequently internally.
     url: Box<Url>,
-    body_limit: Option<usize>,
+    body_limit: Option<u64>,
 }
 
 impl Response {
@@ -36,7 +36,7 @@ impl Response {
         res: hyper::Response<hyper::Body>,
         url: Url,
         accepts: Accepts,
-        body_limit: Option<usize>,
+        body_limit: Option<u64>,
         timeout: Option<Pin<Box<Sleep>>>,
     ) -> Response {
         let (mut parts, body) = res.into_parts();
@@ -279,7 +279,7 @@ impl Response {
                     match buf {
                         Err(e) => return Err(e),
                         Ok(buf) => {
-                            if vec.len() + buf.len() > body_limit {
+                            if vec.len() + buf.len() > body_limit as usize {
                                 Err(crate::error::body(
                                     "Content length exceeds response body limit",
                                 ))?

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -281,7 +281,7 @@ impl Response {
                         Ok(buf) => {
                             if vec.len() + buf.len() > body_limit as usize {
                                 Err(crate::error::body(
-                                    "Content length exceeds response body limit",
+                                    "Received body exceeds response body limit.",
                                 ))?
                             }
                             vec.put(buf);

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -102,6 +102,18 @@ impl Request {
         &mut self.body
     }
 
+    /// Get the response body limit.
+    #[inline]
+    pub fn response_body_limit(&self) -> Option<&usize> {
+        self.inner.response_body_limit()
+    }
+
+    /// Get a mutable reference to the response body limit.
+    #[inline]
+    pub fn response_body_limit_mut(&mut self) -> &mut Option<usize> {
+        self.inner.response_body_limit_mut()
+    }
+
     /// Get the timeout.
     #[inline]
     pub fn timeout(&self) -> Option<&Duration> {
@@ -339,6 +351,17 @@ impl RequestBuilder {
     pub fn body<T: Into<Body>>(mut self, body: T) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             *req.body_mut() = Some(body.into());
+        }
+        self
+    }
+
+    /// Enables a response body limit.
+    ///
+    /// The response body limits the size of the response. Responses larger than
+    /// the limit will be rejected. Only this request is affected. The limit is specified in bytes.
+    pub fn response_body_limit(mut self, response_body_limit: usize) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            *req.response_body_limit() = Some(response_body_limit);
         }
         self
     }

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -103,13 +103,13 @@ impl Request {
 
     /// Get the response body limit.
     #[inline]
-    pub fn response_body_limit(&self) -> Option<&usize> {
+    pub fn response_body_limit(&self) -> Option<u64> {
         self.inner.response_body_limit()
     }
 
     /// Get a mutable reference to the response body limit.
     #[inline]
-    pub fn response_body_limit_mut(&mut self) -> &mut Option<usize> {
+    pub fn response_body_limit_mut(&mut self) -> &mut Option<u64> {
         self.inner.response_body_limit_mut()
     }
 
@@ -354,9 +354,9 @@ impl RequestBuilder {
     ///
     /// The response body limits the size of the response. Responses larger than
     /// the limit will be rejected. Only this request is affected. The limit is specified in bytes.
-    pub fn response_body_limit(mut self, response_body_limit: usize) -> RequestBuilder {
+    pub fn response_body_limit(mut self, response_body_limit: u64) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            *req.response_body_limit() = Some(response_body_limit);
+            *req.response_body_limit_mut() = Some(response_body_limit);
         }
         self
     }


### PR DESCRIPTION
## Motivation

Allowing the server to send an arbitrarily large body creates a security vulnerability, namely memory exhaustion DoS.

### Changes

- Adds `reponse_body_limit` knob to requests
- Enforces it at the `Decoder` level such that it applies to both all-at-once and streaming APIs
- Adds a test case

## Related

Fixes #1234 

This PR is intended to supersede @tthebst's excellent PR #1532 by addressing the [concern](https://github.com/seanmonstar/reqwest/pull/1532#discussion_r1089572481) that the limit doesn't apply to streaming API's.