### PR TITLE
Adds support for `ALL_PROXY`

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -846,6 +846,11 @@ fn get_from_environment() -> SystemProxyMap {
         insert_from_env(&mut proxies, "https", "https_proxy");
     }
 
+    if !(insert_from_env(&mut proxies, "http", "ALL_PROXY") && insert_from_env(&mut proxies, "http", "ALL_PROXY")) {
+        insert_from_env(&mut proxies, "http", "all_proxy");
+        insert_from_env(&mut proxies, "https", "all_proxy");
+    }
+
     proxies
 }
 
@@ -1134,6 +1139,7 @@ mod tests {
         // save system setting first.
         let _g1 = env_guard("HTTP_PROXY");
         let _g2 = env_guard("http_proxy");
+        let _g3 = env_guard("all_proxy");
 
         // Mock ENV, get the results, before doing assertions
         // to avoid assert! -> panic! -> Mutex Poisoned.
@@ -1143,7 +1149,10 @@ mod tests {
         let invalid_proxies = get_sys_proxies(None);
         // set valid proxy
         env::set_var("http_proxy", "127.0.0.1/");
-        let valid_proxies = get_sys_proxies(None);
+        let valid_proxies = get_sys_proxies(None); 
+        // set valid all_proxy
+        env::set_var("all_proxy", "127.0.0.2/");
+        let all_proxies = get_sys_proxies(None);  
 
         // reset user setting when guards drop
         drop(_g1);
@@ -1157,6 +1166,9 @@ mod tests {
         let p = &valid_proxies["http"];
         assert_eq!(p.scheme(), "http");
         assert_eq!(p.host(), "127.0.0.1");
+
+        assert_eq!(all_proxies.len(), 2);
+        assert!(all_proxies.values().all(|p| p.host() == "127.0.0.2"));
     }
 
     #[cfg(target_os = "windows")]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -846,7 +846,7 @@ fn get_from_environment() -> SystemProxyMap {
         insert_from_env(&mut proxies, "https", "https_proxy");
     }
 
-    if !(insert_from_env(&mut proxies, "http", "ALL_PROXY") && insert_from_env(&mut proxies, "http", "ALL_PROXY")) {
+    if !(insert_from_env(&mut proxies, "http", "ALL_PROXY") && insert_from_env(&mut proxies, "https", "ALL_PROXY")) {
         insert_from_env(&mut proxies, "http", "all_proxy");
         insert_from_env(&mut proxies, "https", "all_proxy");
     }
@@ -1139,7 +1139,7 @@ mod tests {
         // save system setting first.
         let _g1 = env_guard("HTTP_PROXY");
         let _g2 = env_guard("http_proxy");
-        let _g3 = env_guard("all_proxy");
+        let _g3 = env_guard("ALL_PROXY");
 
         // Mock ENV, get the results, before doing assertions
         // to avoid assert! -> panic! -> Mutex Poisoned.
@@ -1150,8 +1150,8 @@ mod tests {
         // set valid proxy
         env::set_var("http_proxy", "127.0.0.1/");
         let valid_proxies = get_sys_proxies(None); 
-        // set valid all_proxy
-        env::set_var("all_proxy", "127.0.0.2/");
+        // set valid ALL_PROXY
+        env::set_var("ALL_PROXY", "127.0.0.2/");
         let all_proxies = get_sys_proxies(None);  
 
         // reset user setting when guards drop

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -846,7 +846,9 @@ fn get_from_environment() -> SystemProxyMap {
         insert_from_env(&mut proxies, "https", "https_proxy");
     }
 
-    if !(insert_from_env(&mut proxies, "http", "ALL_PROXY") && insert_from_env(&mut proxies, "https", "ALL_PROXY")) {
+    if !(insert_from_env(&mut proxies, "http", "ALL_PROXY")
+        && insert_from_env(&mut proxies, "https", "ALL_PROXY"))
+    {
         insert_from_env(&mut proxies, "http", "all_proxy");
         insert_from_env(&mut proxies, "https", "all_proxy");
     }
@@ -1149,10 +1151,10 @@ mod tests {
         let invalid_proxies = get_sys_proxies(None);
         // set valid proxy
         env::set_var("http_proxy", "127.0.0.1/");
-        let valid_proxies = get_sys_proxies(None); 
+        let valid_proxies = get_sys_proxies(None);
         // set valid ALL_PROXY
         env::set_var("ALL_PROXY", "127.0.0.2/");
-        let all_proxies = get_sys_proxies(None);  
+        let all_proxies = get_sys_proxies(None);
 
         // reset user setting when guards drop
         drop(_g1);


### PR DESCRIPTION
This was mentioned a long time ago in #1414.
`ALL_PROXY` is commonly used instead of using multiple env vars. In this code if `ALL_PROXY` is set, it sets/overrides the proxy for HTTP and HTTPS.