### PR TITLE
Make Result alias gracefully degrade

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,8 @@ use std::io;
 use crate::{StatusCode, Url};
 
 /// A `Result` alias where the `Err` case is `reqwest::Error`.
-pub type Result<T> = std::result::Result<T, Error>;
+// The default error type is used to avoid breaking regular `Result<T, E>` when users glob-import `reqwest::*` 
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The Errors that may occur when processing a `Request`.
 ///


### PR DESCRIPTION
If users glob-import `reqwest::*`, it shadows the standard `Result` type, and [causes very confusing generic type error elsewhere](https://users.rust-lang.org/t/the-true-return-type-of-this-function/96330).

The alias can be made more flexible to still support the 2-arg use, which avoids the problem for end users.
