### PR TITLE
Bump webpki-roots to v0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 hyper-rustls = { version = "0.24.0", default-features = false, optional = true }
 rustls = { version = "0.21.0", features = ["dangerous_configuration"], optional = true }
 tokio-rustls = { version = "0.24", optional = true }
-webpki-roots = { version = "0.23", optional = true }
+webpki-roots = { version = "0.24", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
 


### PR DESCRIPTION
`rustls` 0.21.3 bumped `rustls-webpki` to 0.101.1. Bumping `webpki-roots` to v0.24 avoids the duplicate dependency version