### PR TITLE
Bump `wasm-streams` dependency to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ js-sys = "0.3.45"
 serde_json = "1.0"
 wasm-bindgen = "0.2.68"
 wasm-bindgen-futures = "0.4.18"
-wasm-streams = { version = "0.2", optional = true }
+wasm-streams = { version = "0.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"


### PR DESCRIPTION
This PR updates the `wasm-streams` dependency to 0.3. Version 0.2 uses a `wasm-bindgen` feature that prevent bundling for certain targets. See [here](https://rustwasm.github.io/wasm-bindgen/reference/js-snippets.html#caveats) for more details.