### PR TITLE
Add default 'wasmbind' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 ]
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "wasmbind"]
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.
@@ -42,6 +42,14 @@ rustls-tls = ["rustls-tls-webpki-roots"]
 rustls-tls-manual-roots = ["__rustls"]
 rustls-tls-webpki-roots = ["webpki-roots", "__rustls"]
 rustls-tls-native-roots = ["rustls-native-certs", "__rustls"]
+
+wasmbind = [
+    "js-sys",
+    "serde_json",
+    "wasm-bindgen",
+    "wasm-bindgen-futures",
+    "web-sys",
+]
 
 blocking = ["futures-util/io", "tokio/rt-multi-thread", "tokio/sync"]
 
@@ -161,14 +169,15 @@ winreg = "0.50.0"
 # wasm
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.45"
-serde_json = "1.0"
-wasm-bindgen = "0.2.68"
-wasm-bindgen-futures = "0.4.18"
+js-sys = { version = "0.3.45", optional = true }
+serde_json = { version = "1.0", optional = true }
+wasm-bindgen = { version = "0.2.68", optional = true }
+wasm-bindgen-futures = { version = "0.4.18", optional = true }
 wasm-streams = { version = "0.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"
+optional = true
 features = [
     "AbortController",
     "AbortSignal",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,14 +229,14 @@ compile_error!(
 
 macro_rules! if_wasm {
     ($($item:item)*) => {$(
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(all(target_arch = "wasm32", feature = "wasmbind"))]
         $item
     )*}
 }
 
 macro_rules! if_hyper {
     ($($item:item)*) => {$(
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(all(target_arch = "wasm32", feature = "wasmbind")))]
         $item
     )*}
 }


### PR DESCRIPTION
Similiar to the `chrono` crate from crates.io, the feature `wasmbind` is included by default, which indicates that the `wasm32` architecture is treated as the browser environment.

If a developer needs `reqwest` to work always using `hyper`, they'll just need to use `default-features = false`...

https://github.com/seanmonstar/reqwest/issues/1917