### PR TITLE
Bump webpki-roots to v0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 hyper-rustls = { version = "0.24.0", default-features = false, optional = true }
 rustls = { version = "0.21.0", features = ["dangerous_configuration"], optional = true }
 tokio-rustls = { version = "0.24", optional = true }
-webpki-roots = { version = "0.24", optional = true }
+webpki-roots = { version = "0.25", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -415,7 +415,7 @@ impl ClientBuilder {
                         use rustls::OwnedTrustAnchor;
 
                         let trust_anchors =
-                            webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|trust_anchor| {
+                            webpki_roots::TLS_SERVER_ROOTS.iter().map(|trust_anchor| {
                                 OwnedTrustAnchor::from_subject_spki_name_constraints(
                                     trust_anchor.subject,
                                     trust_anchor.spki,
@@ -423,7 +423,7 @@ impl ClientBuilder {
                                 )
                             });
 
-                        root_cert_store.add_server_trust_anchors(trust_anchors);
+                        root_cert_store.add_trust_anchors(trust_anchors);
                     }
 
                     #[cfg(feature = "rustls-tls-native-roots")]


### PR DESCRIPTION
https://github.com/rustls/webpki-roots/compare/v/0.24.0...5bc18e3fcf4299be2b88ca83c594e5eb85edcfc2