### PR TITLE
Solve issue #1462

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ gzip = ["async-compression", "async-compression/gzip", "tokio-util"]
 
 brotli = ["async-compression", "async-compression/brotli", "tokio-util"]
 
-deflate = ["async-compression", "async-compression/zlib", "tokio-util"]
+deflate = ["async-compression", "async-compression/deflate", "tokio-util"]
 
 json = ["serde_json"]
 

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -10,7 +10,7 @@ use async_compression::tokio::bufread::GzipDecoder;
 use async_compression::tokio::bufread::BrotliDecoder;
 
 #[cfg(feature = "deflate")]
-use async_compression::tokio::bufread::ZlibDecoder;
+use async_compression::tokio::bufread::DeflateDecoder;
 
 use bytes::Bytes;
 use futures_core::Stream;
@@ -62,7 +62,7 @@ enum Inner {
 
     /// A `Deflate` decoder will uncompress the deflated response content before returning it.
     #[cfg(feature = "deflate")]
-    Deflate(Pin<Box<FramedRead<ZlibDecoder<PeekableIoStreamReader>, BytesCodec>>>),
+    Deflate(Pin<Box<FramedRead<DeflateDecoder<PeekableIoStreamReader>, BytesCodec>>>),
 
     /// A decoder that doesn't have a value yet.
     #[cfg(any(feature = "brotli", feature = "gzip", feature = "deflate"))]


### PR DESCRIPTION
This solve issue 1462 by using 'deflate' algo instead of 'zlib' algo to decompress responses with the 'deflate' Content-Encoding.

The full series of tests (cargo test) still works after this.

My code (see isseu #1462) now works, where I was getting " deflate decompression error" before my patch.