### PR TITLE
Add `tls_info` / `TlsInfo` for access to peer's leaf certificate

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -115,7 +115,7 @@ struct Config {
     #[cfg(feature = "__tls")]
     max_tls_version: Option<tls::Version>,
     #[cfg(feature = "__tls")]
-    https_info: bool,
+    tls_info: bool,
     #[cfg(feature = "__tls")]
     tls: TlsBackend,
     http_version_pref: HttpVersionPref,
@@ -200,7 +200,7 @@ impl ClientBuilder {
                 #[cfg(feature = "__tls")]
                 max_tls_version: None,
                 #[cfg(feature = "__tls")]
-                https_info: false,
+                tls_info: false,
                 #[cfg(feature = "__tls")]
                 tls: TlsBackend::default(),
                 http_version_pref: HttpVersionPref::All,
@@ -412,7 +412,7 @@ impl ClientBuilder {
                         user_agent(&config.headers),
                         config.local_address,
                         config.nodelay,
-                        config.https_info,
+                        config.tls_info,
                     )?
                 }
                 #[cfg(feature = "native-tls")]
@@ -423,7 +423,7 @@ impl ClientBuilder {
                     user_agent(&config.headers),
                     config.local_address,
                     config.nodelay,
-                    config.https_info,
+                    config.tls_info,
                 ),
                 #[cfg(feature = "__rustls")]
                 TlsBackend::BuiltRustls(conn) => {
@@ -448,7 +448,7 @@ impl ClientBuilder {
                         user_agent(&config.headers),
                         config.local_address,
                         config.nodelay,
-                        config.https_info,
+                        config.tls_info,
                     )
                 }
                 #[cfg(feature = "__rustls")]
@@ -593,7 +593,7 @@ impl ClientBuilder {
                         user_agent(&config.headers),
                         config.local_address,
                         config.nodelay,
-                        config.https_info,
+                        config.tls_info,
                     )
                 }
                 #[cfg(any(feature = "native-tls", feature = "__rustls",))]
@@ -1491,7 +1491,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Add HTTPS transport information as `HttpsInfo` extension to reponses.
+    /// Add TLS information as `TlsInfo` extension to responses.
     ///
     /// # Optional
     ///
@@ -1506,8 +1506,8 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
-    pub fn https_info(mut self, https_info: bool) -> ClientBuilder {
-        self.config.https_info = https_info;
+    pub fn tls_info(mut self, tls_info: bool) -> ClientBuilder {
+        self.config.tls_info = tls_info;
         self
     }
 
@@ -2016,7 +2016,7 @@ impl Config {
 
             f.field("tls_sni", &self.tls_sni);
 
-            f.field("https_info", &self.https_info);
+            f.field("tls_info", &self.tls_info);
         }
 
         #[cfg(all(feature = "native-tls-crate", feature = "__rustls"))]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -115,6 +115,8 @@ struct Config {
     #[cfg(feature = "__tls")]
     max_tls_version: Option<tls::Version>,
     #[cfg(feature = "__tls")]
+    https_info: bool,
+    #[cfg(feature = "__tls")]
     tls: TlsBackend,
     http_version_pref: HttpVersionPref,
     http09_responses: bool,
@@ -197,6 +199,8 @@ impl ClientBuilder {
                 min_tls_version: None,
                 #[cfg(feature = "__tls")]
                 max_tls_version: None,
+                #[cfg(feature = "__tls")]
+                https_info: false,
                 #[cfg(feature = "__tls")]
                 tls: TlsBackend::default(),
                 http_version_pref: HttpVersionPref::All,
@@ -352,6 +356,7 @@ impl ClientBuilder {
                         user_agent(&config.headers),
                         config.local_address,
                         config.nodelay,
+                        config.https_info,
                     )?
                 }
                 #[cfg(feature = "native-tls")]
@@ -402,6 +407,7 @@ impl ClientBuilder {
                         user_agent(&config.headers),
                         config.local_address,
                         config.nodelay,
+                        config.https_info,
                     )
                 }
                 #[cfg(feature = "__rustls")]
@@ -562,6 +568,7 @@ impl ClientBuilder {
                         user_agent(&config.headers),
                         config.local_address,
                         config.nodelay,
+                        config.https_info,
                     )
                 }
                 #[cfg(any(feature = "native-tls", feature = "__rustls",))]
@@ -1455,6 +1462,26 @@ impl ClientBuilder {
         self
     }
 
+    /// Add HTTPS transport information as `HttpsInfo` extension to reponses.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "default-tls",
+            feature = "native-tls",
+            feature = "rustls-tls"
+        )))
+    )]
+    pub fn https_info(mut self, https_info: bool) -> ClientBuilder {
+        self.config.https_info = https_info;
+        self
+    }
+
     /// Enables the [trust-dns](trust_dns_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
     ///
     /// If the `trust-dns` feature is turned on, the default option is enabled.
@@ -1959,6 +1986,8 @@ impl Config {
             }
 
             f.field("tls_sni", &self.tls_sni);
+
+            f.field("https_info", &self.https_info);
         }
 
         #[cfg(all(feature = "native-tls-crate", feature = "__rustls"))]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -367,6 +367,7 @@ impl ClientBuilder {
                     user_agent(&config.headers),
                     config.local_address,
                     config.nodelay,
+                    config.https_info,
                 ),
                 #[cfg(feature = "__rustls")]
                 TlsBackend::BuiltRustls(conn) => {

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -738,7 +738,7 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.use_rustls_tls())
     }
 
-    /// Add HTTPS transport information as `HttpsInfo` extension to reponses.
+    /// Add TLS information as `TlsInfo` extension to responses.
     ///
     /// # Optional
     ///
@@ -753,8 +753,8 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
-    pub fn https_info(self, https_info: bool) -> ClientBuilder {
-        self.with_inner(|inner| inner.https_info(https_info))
+    pub fn tls_info(self, tls_info: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.tls_info(tls_info))
     }
 
     /// Use a preconfigured TLS backend.

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -738,6 +738,25 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.use_rustls_tls())
     }
 
+    /// Add HTTPS transport information as `HttpsInfo` extension to reponses.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "default-tls",
+            feature = "native-tls",
+            feature = "rustls-tls"
+        )))
+    )]
+    pub fn https_info(self, https_info) -> ClientBuilder {
+        self.with_inner(|inner| inner.https_info(https_info))
+    }
+
     /// Use a preconfigured TLS backend.
     ///
     /// If the passed `Any` argument is not a TLS backend that reqwest

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -753,7 +753,7 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
-    pub fn https_info(self, https_info) -> ClientBuilder {
+    pub fn https_info(self, https_info: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.https_info(https_info))
     }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -463,19 +463,19 @@ impl Service<Uri> for Connector {
 
 #[cfg(feature = "__tls")]
 trait TlsInfoFactory {
-    fn tls_info(&self) -> Option<crate::TlsInfo>;
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo>;
 }
 
 #[cfg(feature = "__tls")]
 impl TlsInfoFactory for tokio::net::TcpStream {
-    fn tls_info(&self) -> Option<crate::TlsInfo> {
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         None
     }
 }
 
 #[cfg(feature = "default-tls")]
 impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<tokio::net::TcpStream> {
-    fn tls_info(&self) -> Option<crate::TlsInfo> {
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         match self {
             hyper_tls::MaybeHttpsStream::Https(tls) => tls.tls_info(),
             hyper_tls::MaybeHttpsStream::Http(_) => None,
@@ -485,33 +485,33 @@ impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<tokio::net::TcpStream> {
 
 #[cfg(feature = "default-tls")]
 impl TlsInfoFactory for hyper_tls::TlsStream<hyper_tls::MaybeHttpsStream<tokio::net::TcpStream>> {
-    fn tls_info(&self) -> Option<crate::TlsInfo> {
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
             .get_ref()
             .peer_certificate()
             .ok()
             .flatten()
             .and_then(|c| c.to_der().ok());
-        Some(crate::TlsInfo { peer_certificate })
+        Some(crate::tls::TlsInfo { peer_certificate })
     }
 }
 
 #[cfg(feature = "default-tls")]
 impl TlsInfoFactory for tokio_native_tls::TlsStream<tokio::net::TcpStream> {
-    fn tls_info(&self) -> Option<crate::TlsInfo> {
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
             .get_ref()
             .peer_certificate()
             .ok()
             .flatten()
             .and_then(|c| c.to_der().ok());
-        Some(crate::TlsInfo { peer_certificate })
+        Some(crate::tls::TlsInfo { peer_certificate })
     }
 }
 
 #[cfg(feature = "__rustls")]
 impl TlsInfoFactory for hyper_rustls::MaybeHttpsStream<tokio::net::TcpStream> {
-    fn tls_info(&self) -> Option<crate::TlsInfo> {
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         match self {
             hyper_rustls::MaybeHttpsStream::Https(tls) => tls.tls_info(),
             hyper_rustls::MaybeHttpsStream::Http(_) => None,
@@ -521,14 +521,14 @@ impl TlsInfoFactory for hyper_rustls::MaybeHttpsStream<tokio::net::TcpStream> {
 
 #[cfg(feature = "__rustls")]
 impl TlsInfoFactory for tokio_rustls::TlsStream<tokio::net::TcpStream> {
-    fn tls_info(&self) -> Option<crate::TlsInfo> {
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
             .get_ref()
             .1
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.0.clone());
-        Some(crate::TlsInfo { peer_certificate })
+        Some(crate::tls::TlsInfo { peer_certificate })
     }
 }
 
@@ -536,27 +536,27 @@ impl TlsInfoFactory for tokio_rustls::TlsStream<tokio::net::TcpStream> {
 impl TlsInfoFactory
     for tokio_rustls::client::TlsStream<hyper_rustls::MaybeHttpsStream<tokio::net::TcpStream>>
 {
-    fn tls_info(&self) -> Option<crate::TlsInfo> {
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
             .get_ref()
             .1
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.0.clone());
-        Some(crate::TlsInfo { peer_certificate })
+        Some(crate::tls::TlsInfo { peer_certificate })
     }
 }
 
 #[cfg(feature = "__rustls")]
 impl TlsInfoFactory for tokio_rustls::client::TlsStream<tokio::net::TcpStream> {
-    fn tls_info(&self) -> Option<crate::TlsInfo> {
+    fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
             .get_ref()
             .1
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.0.clone());
-        Some(crate::TlsInfo { peer_certificate })
+        Some(crate::tls::TlsInfo { peer_certificate })
     }
 }
 
@@ -825,13 +825,13 @@ mod native_tls_conn {
     }
 
     impl TlsInfoFactory for NativeTlsConn<tokio::net::TcpStream> {
-        fn tls_info(&self) -> Option<crate::TlsInfo> {
+        fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
             self.inner.tls_info()
         }
     }
 
     impl TlsInfoFactory for NativeTlsConn<hyper_tls::MaybeHttpsStream<tokio::net::TcpStream>> {
-        fn tls_info(&self) -> Option<crate::TlsInfo> {
+        fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
             self.inner.tls_info()
         }
     }
@@ -918,13 +918,13 @@ mod rustls_tls_conn {
     }
 
     impl TlsInfoFactory for RustlsTlsConn<tokio::net::TcpStream> {
-        fn tls_info(&self) -> Option<crate::TlsInfo> {
+        fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
             self.inner.tls_info()
         }
     }
 
     impl TlsInfoFactory for RustlsTlsConn<hyper_rustls::MaybeHttpsStream<tokio::net::TcpStream>> {
-        fn tls_info(&self) -> Option<crate::TlsInfo> {
+        fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
             self.inner.tls_info()
         }
     }
@@ -1107,7 +1107,7 @@ mod verbose {
 
     #[cfg(feature = "__tls")]
     impl<T: super::TlsInfoFactory> super::TlsInfoFactory for Verbose<T> {
-        fn tls_info(&self) -> Option<crate::TlsInfo> {
+        fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
             self.inner.tls_info()
         }
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -577,7 +577,6 @@ impl<T: AsyncConn + TlsInfoFactory> AsyncConnWithInfo for T {}
 #[cfg(not(feature = "__tls"))]
 impl<T: AsyncConn> AsyncConnWithInfo for T {}
 
-
 type BoxConn = Box<dyn AsyncConnWithInfo>;
 
 pin_project! {
@@ -1011,10 +1010,7 @@ mod verbose {
     pub(super) struct Wrapper(pub(super) bool);
 
     impl Wrapper {
-        pub(super) fn wrap<T: super::AsyncConnWithInfo>(
-            &self,
-            conn: T,
-        ) -> super::BoxConn {
+        pub(super) fn wrap<T: super::AsyncConnWithInfo>(&self, conn: T) -> super::BoxConn {
             if self.0 && log::log_enabled!(log::Level::Trace) {
                 Box::new(Verbose {
                     // truncate is fine

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,8 +326,6 @@ if_hyper! {
     #[cfg(feature = "multipart")]
     pub use self::async_impl::multipart;
 
-    #[cfg(feature = "__tls")]
-    pub use self::tls::TlsInfo;
 
     mod async_impl;
     #[cfg(feature = "blocking")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,7 @@ if_hyper! {
     #[cfg(feature = "multipart")]
     pub use self::async_impl::multipart;
 
+    pub use self::connect::HttpsInfo;
 
     mod async_impl;
     #[cfg(feature = "blocking")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,8 @@ if_hyper! {
     #[cfg(feature = "multipart")]
     pub use self::async_impl::multipart;
 
-    pub use self::connect::HttpsInfo;
+    #[cfg(feature = "__tls")]
+    pub use self::tls::TlsInfo;
 
     mod async_impl;
     #[cfg(feature = "blocking")]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -463,6 +463,26 @@ impl ServerCertVerifier for NoVerifier {
     }
 }
 
+/// Hyper extension carrying extra TLS layer information.
+/// Made available to clients on responses when `tls_info` is set.
+#[derive(Clone)]
+pub struct TlsInfo {
+    pub(crate) peer_certificate: Option<Vec<u8>>,
+}
+
+impl TlsInfo {
+    /// Get the DER encoded leaf certificate of the peer.
+    pub fn peer_certificate(&self) -> Option<&[u8]> {
+        self.peer_certificate.as_ref().map(|der| &der[..])
+    }
+}
+
+impl std::fmt::Debug for TlsInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("TlsInfo").finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -378,7 +378,7 @@ fn test_response_no_tls_info_for_http() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.content_length(), Some(5));
-    let tls_info = res.extensions().get::<reqwest::TlsInfo>();
+    let tls_info = res.extensions().get::<reqwest::tls::TlsInfo>();
     assert_eq!(tls_info.is_none(), true);
 
     let body = res.text().unwrap();

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -362,3 +362,25 @@ fn blocking_update_json_content_type_if_set_manually() {
 
     assert_eq!("application/json", req.headers().get(CONTENT_TYPE).unwrap());
 }
+
+#[test]
+fn test_response_no_https_info_for_http() {
+    let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
+
+    let url = format!("http://{}/text", server.addr());
+
+    let client = reqwest::blocking::Client::builder()
+        .https_info(true)
+        .build()
+        .unwrap();
+
+    let res = client.get(&url).send().unwrap();
+    assert_eq!(res.url().as_str(), &url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    assert_eq!(res.content_length(), Some(5));
+    let https_info = res.extensions().get::<reqwest::HttpsInfo>();
+    assert_eq!(https_info.is_none(), true);
+
+    let body = res.text().unwrap();
+    assert_eq!(b"Hello", body.as_bytes());
+}

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -364,13 +364,13 @@ fn blocking_update_json_content_type_if_set_manually() {
 }
 
 #[test]
-fn test_response_no_https_info_for_http() {
+fn test_response_no_tls_info_for_http() {
     let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
 
     let url = format!("http://{}/text", server.addr());
 
     let client = reqwest::blocking::Client::builder()
-        .https_info(true)
+        .tls_info(true)
         .build()
         .unwrap();
 
@@ -378,8 +378,8 @@ fn test_response_no_https_info_for_http() {
     assert_eq!(res.url().as_str(), &url);
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     assert_eq!(res.content_length(), Some(5));
-    let https_info = res.extensions().get::<reqwest::HttpsInfo>();
-    assert_eq!(https_info.is_none(), true);
+    let tls_info = res.extensions().get::<reqwest::TlsInfo>();
+    assert_eq!(tls_info.is_none(), true);
 
     let body = res.text().unwrap();
     assert_eq!(b"Hello", body.as_bytes());

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -409,7 +409,7 @@ fn update_json_content_type_if_set_manually() {
     assert_eq!("application/json", req.headers().get(CONTENT_TYPE).unwrap());
 }
 
-#[cfg(feature = "__tls")]
+#[cfg(all(feature = "__tls", not(feature = "rustls-tls-manual-roots")))]
 #[tokio::test]
 async fn test_https_info() {
     let resp = reqwest::Client::builder()

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -420,7 +420,7 @@ async fn test_tls_info() {
         .send()
         .await
         .expect("response");
-    let tls_info = resp.extensions().get::<reqwest::TlsInfo>();
+    let tls_info = resp.extensions().get::<reqwest::tls::TlsInfo>();
     assert!(tls_info.is_some());
     let tls_info = tls_info.unwrap();
     let peer_certificate = tls_info.peer_certificate();
@@ -435,6 +435,6 @@ async fn test_tls_info() {
         .send()
         .await
         .expect("response");
-    let tls_info = resp.extensions().get::<reqwest::TlsInfo>();
+    let tls_info = resp.extensions().get::<reqwest::tls::TlsInfo>();
     assert!(tls_info.is_none());
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -411,19 +411,19 @@ fn update_json_content_type_if_set_manually() {
 
 #[cfg(all(feature = "__tls", not(feature = "rustls-tls-manual-roots")))]
 #[tokio::test]
-async fn test_https_info() {
+async fn test_tls_info() {
     let resp = reqwest::Client::builder()
-        .https_info(true)
+        .tls_info(true)
         .build()
         .expect("client builder")
         .get("https://google.com")
         .send()
         .await
         .expect("response");
-    let https_info = resp.extensions().get::<reqwest::HttpsInfo>();
-    assert!(https_info.is_some());
-    let https_info = https_info.unwrap();
-    let peer_certificate = https_info.peer_certificate();
+    let tls_info = resp.extensions().get::<reqwest::TlsInfo>();
+    assert!(tls_info.is_some());
+    let tls_info = tls_info.unwrap();
+    let peer_certificate = tls_info.peer_certificate();
     assert!(peer_certificate.is_some());
     let der = peer_certificate.unwrap();
     assert_eq!(der[0], 0x30); // ASN.1 SEQUENCE
@@ -435,6 +435,6 @@ async fn test_https_info() {
         .send()
         .await
         .expect("response");
-    let https_info = resp.extensions().get::<reqwest::HttpsInfo>();
-    assert!(https_info.is_none());
+    let tls_info = resp.extensions().get::<reqwest::TlsInfo>();
+    assert!(tls_info.is_none());
 }


### PR DESCRIPTION
This adds a `HttpsInfo` extension into responses when configuring a client with `https_info(true)`.  The extension can be obtained by callers to get access to the peer's leaf certificate.  Works with both native and rustls TLS.  Fixes #1428.

Not sure if this is the best way to solve it, but it works, doesn't expose TLS connector specific types, and should not cause overhead unless enabled.  Happy to refactor and clean up as much as needed for this to go in.