### PR TITLE
msrv: bump to 1.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Sean McArthur <sean@seanmonstar.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.57.0"
+rust-version = "1.63.0"
 autotests = true
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Tokio requires this.