### PR TITLE
Respect MacOS proxy settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,9 @@ tokio = { version = "1.0", default-features = false, features = ["macros", "rt-m
 [target.'cfg(windows)'.dependencies]
 winreg = "0.50.0"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+system-configuration = "0.5.1"
+
 # wasm
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
This PR adds support to `reqwest` for respecting the system proxy settings for MacOS. It follows many of the same code paths as #547, which added support for system proxies on Windows. This does add a dependency on a new crate, `system-configuration`, for communicating with MacOS.

I did a little bit of renaming, mostly changing the word "registry" to "platform" to better communicate that the non-environment-variable proxy settings can come from different locations, depending on your target platform.

I tested this locally via a Rust app I work on (on Ventura 13.5.1), and verified that with these changes (and a local proxy server like Charles active), any requests are forwarded through the proxy. The no proxy case works as well.