### PR TITLE
Optimize `TrustDnsResolver`

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -266,7 +266,7 @@ impl ClientBuilder {
             let mut resolver: Arc<dyn Resolve> = match config.trust_dns {
                 false => Arc::new(GaiResolver::new()),
                 #[cfg(feature = "trust-dns")]
-                true => Arc::new(TrustDnsResolver::new().map_err(crate::error::builder)?),
+                true => Arc::new(TrustDnsResolver::default()),
                 #[cfg(not(feature = "trust-dns"))]
                 true => unreachable!("trust-dns shouldn't be enabled unless the feature is"),
             };

--- a/src/dns/trust_dns.rs
+++ b/src/dns/trust_dns.rs
@@ -1,7 +1,7 @@
 //! DNS resolution via the [trust_dns_resolver](https://github.com/bluejekyll/trust-dns) crate
 
 use hyper::client::connect::dns::Name;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 pub use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 use trust_dns_resolver::{lookup_ip::LookupIpIntoIter, system_conf, TokioAsyncResolver};
 
@@ -12,9 +12,6 @@ use std::sync::Arc;
 use super::{Addrs, Resolve, Resolving};
 
 type SharedResolver = Arc<TokioAsyncResolver>;
-
-static SYSTEM_CONF: Lazy<io::Result<(ResolverConfig, ResolverOpts)>> =
-    Lazy::new(|| system_conf::read_system_conf().map_err(io::Error::from));
 
 /// Wrapper around an `AsyncResolver`, which implements the `Resolve` trait.
 #[derive(Debug, Clone)]
@@ -30,10 +27,6 @@ impl TrustDnsResolver {
     /// Create a new resolver with the default configuration,
     /// which reads from `/etc/resolve.conf`.
     pub fn new() -> io::Result<Self> {
-        SYSTEM_CONF.as_ref().map_err(|e| {
-            io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e))
-        })?;
-
         // At this stage, we might not have been called in the context of a
         // Tokio Runtime, so we must delay the actual construction of the
         // resolver.
@@ -47,7 +40,7 @@ impl Resolve for TrustDnsResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let resolver = self.clone();
         Box::pin(async move {
-            let resolver = resolver.state.get_or_init(new_resolver);
+            let resolver = resolver.state.get_or_try_init(new_resolver)?;
 
             let lookup = resolver.lookup_ip(name.as_str()).await?;
             let addrs: Addrs = Box::new(SocketAddrs {
@@ -66,12 +59,10 @@ impl Iterator for SocketAddrs {
     }
 }
 
-fn new_resolver() -> SharedResolver {
-    let (config, opts) = SYSTEM_CONF
-        .as_ref()
-        .expect("can't construct TrustDnsResolver if SYSTEM_CONF is error")
-        .clone();
-    new_resolver_with_config(config, opts)
+fn new_resolver() -> io::Result<SharedResolver> {
+    let (config, opts) = system_conf::read_system_conf()
+        .map_err(|e| io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e)))?;
+    Ok(new_resolver_with_config(config, opts))
 }
 
 fn new_resolver_with_config(config: ResolverConfig, opts: ResolverOpts) -> SharedResolver {

--- a/src/dns/trust_dns.rs
+++ b/src/dns/trust_dns.rs
@@ -11,12 +11,10 @@ use std::sync::Arc;
 
 use super::{Addrs, Resolve, Resolving};
 
-type SharedResolver = Arc<TokioAsyncResolver>;
-
 /// Wrapper around an `AsyncResolver`, which implements the `Resolve` trait.
 #[derive(Debug, Clone)]
 pub(crate) struct TrustDnsResolver {
-    state: Arc<OnceCell<SharedResolver>>,
+    state: Arc<OnceCell<TokioAsyncResolver>>,
 }
 
 struct SocketAddrs {
@@ -59,12 +57,8 @@ impl Iterator for SocketAddrs {
     }
 }
 
-fn new_resolver() -> io::Result<SharedResolver> {
+fn new_resolver() -> io::Result<TokioAsyncResolver> {
     let (config, opts) = system_conf::read_system_conf()
         .map_err(|e| io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e)))?;
-    Ok(new_resolver_with_config(config, opts))
-}
-
-fn new_resolver_with_config(config: ResolverConfig, opts: ResolverOpts) -> SharedResolver {
-    Arc::new(TokioAsyncResolver::tokio(config, opts))
+    Ok(TokioAsyncResolver::tokio(config, opts))
 }


### PR DESCRIPTION
 - Replace use of `tokio::sync::Mutex` with `once_cell::sync::OnceCell`
   since there's no need for it to be `async` and thus it can just use
   `OnceCell` instead of `Mutex`.
 - Optimize `TrustDnsResolver`: Rm use of `Lazy`
 - Optimize `TrustDnsResolver`: Rm unnecessary `Arc`
 - Derive `Default` on `TrustDnsResolver`