### PR TITLE
Allow user to reinitialize SYSTEM_CONF

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ percent-encoding = "2.1"
 tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
 pin-project-lite = "0.2.0"
 ipnet = "2.3"
+lazy_static = "1.4"
 
 # Optional deps...
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ tokio = { version = "1.0", default-features = false, features = ["net", "time"] 
 pin-project-lite = "0.2.0"
 ipnet = "2.3"
 lazy_static = "1.4"
+futures = "0.3"
 
 # Optional deps...
 

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -6,4 +6,4 @@ pub(crate) use resolve::{DnsResolverWithOverrides, DynResolver};
 pub(crate) mod gai;
 pub(crate) mod resolve;
 #[cfg(feature = "trust-dns")]
-pub(crate) mod trust_dns;
+pub mod trust_dns;

--- a/src/dns/trust_dns.rs
+++ b/src/dns/trust_dns.rs
@@ -1,5 +1,6 @@
 //! DNS resolution via the [trust_dns_resolver](https://github.com/bluejekyll/trust-dns) crate
 
+use futures::executor::block_on;
 use hyper::client::connect::dns::Name;
 use once_cell::sync::Lazy;
 use tokio::sync::Mutex;

--- a/src/dns/trust_dns.rs
+++ b/src/dns/trust_dns.rs
@@ -108,7 +108,7 @@ async fn new_resolver() -> Result<SharedResolver, BoxError> {
         .lock()
         .await
         .as_ref()
-        .expect("Failed to get reference of SYSTEM_CONF")
+        .unwrap()
         .clone();
     new_resolver_with_config(config, opts)
 }

--- a/src/dns/trust_dns.rs
+++ b/src/dns/trust_dns.rs
@@ -54,7 +54,6 @@ impl TrustDnsResolver {
     pub fn new() -> io::Result<Self> {
         SYSTEM_CONF
             .lock()
-            .await
             .as_ref()
             .map_err(|e| io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e)))?;
 

--- a/src/dns/trust_dns.rs
+++ b/src/dns/trust_dns.rs
@@ -52,11 +52,14 @@ impl TrustDnsResolver {
     /// Create a new resolver with the default configuration,
     /// which reads from `/etc/resolve.conf`.
     pub fn new() -> io::Result<Self> {
-        SYSTEM_CONF
-            .lock()
-            .as_ref()
-            .map_err(|e| io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e)))?;
-
+        block_on(async {
+            SYSTEM_CONF
+                .lock()
+                .await
+                .as_ref()
+                .map_err(|e| io::Error::new(e.kind(), format!("error reading DNS system conf: {}", e)))
+                .unwrap();
+        });
         // At this stage, we might not have been called in the context of a
         // Tokio Runtime, so we must delay the actual construction of the
         // resolver.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,9 @@ if_hyper! {
     #[macro_use]
     extern crate doc_comment;
 
+    #[macro_use]
+    extern crate lazy_static;
+
     #[cfg(test)]
     doctest!("../README.md");
 


### PR DESCRIPTION
Hi,

I'm new to Rust programming, but I've encountered an issue with the reqwest crate. Specifically, when my device switches from one network to another, the reqwest crate fails to handle the network change properly because of the statically cached SYSTEM_CONFIG. I believe that implementing a pull request to allow users to reinitialize SYSTEM_CONFIG would help resolve this issue.

You can find a more detailed description of the issue I'm facing in the following GitHub comment: [https://github.com/seanmonstar/reqwest/issues/1407#issuecomment-1699085369].

I hope this clarifies the problem I've encountered and the proposed solution.
