### PR TITLE
Fix 1.63.0 MSRV

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -943,7 +943,9 @@ fn parse_setting_from_dynamic_store(
 fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     let store = SCDynamicStoreBuilder::new("reqwest").build();
 
-    let Some(proxies_map) = store.get_proxies() else {
+    let proxies_map = if let Some(proxies_map) = store.get_proxies() {
+        proxies_map
+    } else {
         return Ok(None);
     };
 


### PR DESCRIPTION
Unfortunately, #1955 broke MSRV 1.63.0 as the `let Some` syntax wasn't stabilized until 1.65.0.

This fixes the MSRV breakage on macOS.

As this had previously slipped the CI `msrv` test, the second commit now ensures we check MSRV on `macos-latest` and `windows-latest`, too.