### PR TITLE
Added into_owned() to Cookie.

### DIFF
--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -97,6 +97,11 @@ impl<'a> Cookie<'a> {
             None | Some(cookie_crate::Expiration::Session) => None,
         }
     }
+
+    /// Creates Cookie with a static lifetime.
+    pub fn into_owned(&self) -> Cookie<'static> {
+        Cookie(self.0.clone().into_owned())
+    }
 }
 
 impl<'a> fmt::Debug for Cookie<'a> {
@@ -187,5 +192,21 @@ impl CookieStore for Jar {
         }
 
         HeaderValue::from_maybe_shared(Bytes::from(s)).ok()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cookie_can_become_owned_type() {
+        let cookie = {
+            let header_value = HeaderValue::from_static("sessionId=e8bb43229de9;");
+            Cookie::parse(&header_value).unwrap().into_owned()
+        };
+        assert_eq!("sessionId", cookie.name());
+        assert_eq!("e8bb43229de9", cookie.value());
     }
 }


### PR DESCRIPTION
There are some scenarios when it might be desirable to make cookies outlive response object. Currently there is no (or I failed to find out) easy way to have a copy of cookes, while underlying cookie library has `into_owned` to make cookie outlive response.
As an alternative solution (or maybe additional) it seems like `cookies()` method could be part of `HeaderMap`, which is already easily to have an owned copy.
Please let me know if anything like this could be landed into library, thanks a lot in advance.