### PR TITLE
refactor: Migrate trust-dns to hickory-dns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           - "feat.: stream"
           - "feat.: socks/default-tls"
           - "feat.: socks/rustls-tls"
-          - "feat.: trust-dns"
+          - "feat.: hickory-dns"
 
         include:
           - name: linux / stable
@@ -151,8 +151,8 @@ jobs:
             features: "--features socks"
           - name: "feat.: socks/rustls-tls"
             features: "--features socks,rustls-tls"
-          - name: "feat.: trust-dns"
-            features: "--features trust-dns"
+          - name: "feat.: hickory-dns"
+            features: "--features hickory-dns"
 
     steps:
       - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,9 @@ json = ["serde_json"]
 
 multipart = ["mime_guess"]
 
-trust-dns = ["trust-dns-resolver"]
+# Deprecated, remove this feature while bumping minor versions.
+trust-dns = ["hickory-dns"]
+hickory-dns = ["hickory-resolver"]
 
 stream = ["tokio/fs", "tokio-util", "wasm-streams"]
 
@@ -136,8 +138,8 @@ tokio-util = { version = "0.7.1", default-features = false, features = ["codec",
 ## socks
 tokio-socks = { version = "0.5.1", optional = true }
 
-## trust-dns
-trust-dns-resolver = { version = "0.23", optional = true, features = ["tokio-runtime"] }
+## hickory-dns
+hickory-resolver = { version = "0.24", optional = true, features = ["tokio-runtime"] }
 
 # HTTP/3 experimental support
 h3 = { version="0.0.2", optional = true }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -781,26 +781,50 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))
     }
 
-    /// Enables the [trust-dns](trust_dns_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
+    /// Enables the [hickory-dns](hickory_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
     ///
-    /// If the `trust-dns` feature is turned on, the default option is enabled.
+    /// If the `hickory-dns` feature is turned on, the default option is enabled.
     ///
     /// # Optional
     ///
-    /// This requires the optional `trust-dns` feature to be enabled
-    #[cfg(feature = "trust-dns")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "trust-dns")))]
+    /// This requires the optional `hickory-dns` feature to be enabled
+    #[cfg(feature = "hickory-dns")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "hickory-dns")))]
+    #[deprecated(note = "use `hickory_dns` instead", since = "0.12.0")]
     pub fn trust_dns(self, enable: bool) -> ClientBuilder {
-        self.with_inner(|inner| inner.trust_dns(enable))
+        self.with_inner(|inner| inner.hickory_dns(enable))
     }
 
-    /// Disables the trust-dns async resolver.
+    /// Enables the [hickory-dns](hickory_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
     ///
-    /// This method exists even if the optional `trust-dns` feature is not enabled.
-    /// This can be used to ensure a `Client` doesn't use the trust-dns async resolver
-    /// even if another dependency were to enable the optional `trust-dns` feature.
+    /// If the `hickory-dns` feature is turned on, the default option is enabled.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `hickory-dns` feature to be enabled
+    #[cfg(feature = "hickory-dns")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "hickory-dns")))]
+    pub fn hickory_dns(self, enable: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.hickory_dns(enable))
+    }
+
+    /// Disables the hickory-dns async resolver.
+    ///
+    /// This method exists even if the optional `hickory-dns` feature is not enabled.
+    /// This can be used to ensure a `Client` doesn't use the hickory-dns async resolver
+    /// even if another dependency were to enable the optional `hickory-dns` feature.
+    #[deprecated(note = "use `no_hickory_dns` instead", since = "0.12.0")]
     pub fn no_trust_dns(self) -> ClientBuilder {
-        self.with_inner(|inner| inner.no_trust_dns())
+        self.with_inner(|inner| inner.no_hickory_dns())
+    }
+
+    /// Disables the hickory-dns async resolver.
+    ///
+    /// This method exists even if the optional `hickory-dns` feature is not enabled.
+    /// This can be used to ensure a `Client` doesn't use the hickory-dns async resolver
+    /// even if another dependency were to enable the optional `hickory-dns` feature.
+    pub fn no_hickory_dns(self) -> ClientBuilder {
+        self.with_inner(|inner| inner.no_hickory_dns())
     }
 
     /// Restrict the Client to be used with HTTPS only requests.

--- a/src/dns/hickory.rs
+++ b/src/dns/hickory.rs
@@ -1,9 +1,9 @@
-//! DNS resolution via the [trust_dns_resolver](https://github.com/bluejekyll/trust-dns) crate
+//! DNS resolution via the [hickory-resolver](https://github.com/hickory-dns/hickory-dns) crate
 
 use hyper::client::connect::dns::Name;
 use once_cell::sync::OnceCell;
-pub use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use trust_dns_resolver::{lookup_ip::LookupIpIntoIter, system_conf, TokioAsyncResolver};
+pub use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::{lookup_ip::LookupIpIntoIter, system_conf, TokioAsyncResolver};
 
 use std::io;
 use std::net::SocketAddr;
@@ -13,7 +13,7 @@ use super::{Addrs, Resolve, Resolving};
 
 /// Wrapper around an `AsyncResolver`, which implements the `Resolve` trait.
 #[derive(Debug, Default, Clone)]
-pub(crate) struct TrustDnsResolver {
+pub(crate) struct HickoryDnsResolver {
     /// Since we might not have been called in the context of a
     /// Tokio Runtime in initialization, so we must delay the actual
     /// construction of the resolver.
@@ -24,7 +24,7 @@ struct SocketAddrs {
     iter: LookupIpIntoIter,
 }
 
-impl Resolve for TrustDnsResolver {
+impl Resolve for HickoryDnsResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let resolver = self.clone();
         Box::pin(async move {

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -5,5 +5,5 @@ pub(crate) use resolve::{DnsResolverWithOverrides, DynResolver};
 
 pub(crate) mod gai;
 pub(crate) mod resolve;
-#[cfg(feature = "trust-dns")]
-pub(crate) mod trust_dns;
+#[cfg(feature = "hickory-dns")]
+pub(crate) mod hickory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@
 //! - **multipart**: Provides functionality for multipart forms.
 //! - **stream**: Adds support for `futures::Stream`.
 //! - **socks**: Provides SOCKS5 proxy support.
-//! - **trust-dns**: Enables a trust-dns async resolver instead of default
+//! - **hickory-dns**: Enables a hickory-dns async resolver instead of default
 //!   threadpool using `getaddrinfo`.
 //!
 //! ## Unstable Features

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -230,9 +230,9 @@ async fn overridden_dns_resolution_with_gai_multiple() {
     assert_eq!("Hello", text);
 }
 
-#[cfg(feature = "trust-dns")]
+#[cfg(feature = "hickory-dns")]
 #[tokio::test]
-async fn overridden_dns_resolution_with_trust_dns() {
+async fn overridden_dns_resolution_with_hickory_dns() {
     let _ = env_logger::builder().is_test(true).try_init();
     let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
 
@@ -244,7 +244,7 @@ async fn overridden_dns_resolution_with_trust_dns() {
     );
     let client = reqwest::Client::builder()
         .resolve(overridden_domain, server.addr())
-        .trust_dns(true)
+        .hickory_dns(true)
         .build()
         .expect("client builder");
     let req = client.get(&url);
@@ -255,9 +255,9 @@ async fn overridden_dns_resolution_with_trust_dns() {
     assert_eq!("Hello", text);
 }
 
-#[cfg(feature = "trust-dns")]
+#[cfg(feature = "hickory-dns")]
 #[tokio::test]
-async fn overridden_dns_resolution_with_trust_dns_multiple() {
+async fn overridden_dns_resolution_with_hickory_dns_multiple() {
     let _ = env_logger::builder().is_test(true).try_init();
     let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
 
@@ -280,7 +280,7 @@ async fn overridden_dns_resolution_with_trust_dns_multiple() {
                 server.addr(),
             ],
         )
-        .trust_dns(true)
+        .hickory_dns(true)
         .build()
         .expect("client builder");
     let req = client.get(&url);


### PR DESCRIPTION
In response to https://bluejekyll.github.io/blog/posts/announcing-hickory-dns/