### PR TITLE
chore: migrate edition 2018 to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/reqwest"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.63.0"
 autotests = true
 
@@ -141,10 +141,10 @@ tokio-socks = { version = "0.5.1", optional = true }
 trust-dns-resolver = { version = "0.23", optional = true, features = ["tokio-runtime"] }
 
 # HTTP/3 experimental support
-h3 = { version="0.0.3", optional = true }
-h3-quinn = { version="0.0.4", optional = true }
-quinn = { version = "0.10", default-features = false, features = ["tls-rustls", "ring", "runtime-tokio"], optional = true  }
-futures-channel = { version="0.3", optional = true}
+h3 = { version = "0.0.3", optional = true }
+h3-quinn = { version = "0.0.4", optional = true }
+quinn = { version = "0.10", default-features = false, features = ["tls-rustls", "ring", "runtime-tokio"], optional = true }
+futures-channel = { version = "0.3", optional = true }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/examples/wasm_github_fetch/Cargo.toml
+++ b/examples/wasm_github_fetch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm"
 version = "0.1.0"
 authors = ["John Gallagher <john.willis.gallagher@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # Config mostly pulled from: https://github.com/rustwasm/wasm-bindgen/blob/master/examples/fetch/Cargo.toml
 

--- a/src/blocking/body.rs
+++ b/src/blocking/body.rs
@@ -38,7 +38,7 @@ impl Body {
     /// ```rust
     /// # use std::fs::File;
     /// # use reqwest::blocking::Body;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let file = File::open("national_secrets.txt")?;
     /// let body = Body::new(file);
     /// # Ok(())
@@ -51,7 +51,7 @@ impl Body {
     ///
     /// ```rust
     /// # use reqwest::blocking::Body;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let s = "A stringy body";
     /// let body = Body::from(s);
     /// # Ok(())
@@ -70,7 +70,7 @@ impl Body {
     /// ```rust
     /// # use std::fs::File;
     /// # use reqwest::blocking::Body;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let file = File::open("a_large_file.txt")?;
     /// let file_size = file.metadata()?.len();
     /// let body = Body::sized(file, file_size);

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -172,7 +172,7 @@ impl RequestBuilder {
     /// ```rust
     /// use reqwest::header::USER_AGENT;
     ///
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::blocking::Client::new();
     /// let res = client.get("https://www.rust-lang.org")
     ///     .header(USER_AGENT, "foo")
@@ -232,7 +232,7 @@ impl RequestBuilder {
     ///     headers
     /// }
     ///
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let file = fs::File::open("much_beauty.png")?;
     /// let client = reqwest::blocking::Client::new();
     /// let res = client.post("http://httpbin.org/post")
@@ -252,7 +252,7 @@ impl RequestBuilder {
     /// Enable HTTP basic authentication.
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::blocking::Client::new();
     /// let resp = client.delete("http://httpbin.org/delete")
     ///     .basic_auth("admin", Some("good password"))
@@ -272,7 +272,7 @@ impl RequestBuilder {
     /// Enable HTTP bearer authentication.
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::blocking::Client::new();
     /// let resp = client.delete("http://httpbin.org/delete")
     ///     .bearer_auth("token")
@@ -295,7 +295,7 @@ impl RequestBuilder {
     /// Using a string:
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::blocking::Client::new();
     /// let res = client.post("http://httpbin.org/post")
     ///     .body("from a &str!")
@@ -307,7 +307,7 @@ impl RequestBuilder {
     /// Using a `File`:
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let file = std::fs::File::open("from_a_file.txt")?;
     /// let client = reqwest::blocking::Client::new();
     /// let res = client.post("http://httpbin.org/post")
@@ -321,7 +321,7 @@ impl RequestBuilder {
     ///
     /// ```rust
     /// # use std::fs;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// // from bytes!
     /// let bytes: Vec<u8> = vec![1, 10, 100];
     /// let client = reqwest::blocking::Client::new();
@@ -514,7 +514,7 @@ impl RequestBuilder {
     /// ```
     /// # use reqwest::Error;
     ///
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::blocking::Client::new();
     /// let form = reqwest::blocking::multipart::Form::new()
     ///     .text("key3", "value3")
@@ -570,7 +570,7 @@ impl RequestBuilder {
     /// With a static body
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::blocking::Client::new();
     /// let builder = client.post("http://httpbin.org/post")
     ///     .body("from a &str!");
@@ -583,7 +583,7 @@ impl RequestBuilder {
     /// Without a body
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::blocking::Client::new();
     /// let builder = client.get("http://httpbin.org/get");
     /// let clone = builder.try_clone();
@@ -595,7 +595,7 @@ impl RequestBuilder {
     /// With a non-clonable body
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::blocking::Client::new();
     /// let builder = client.get("http://httpbin.org/get")
     ///     .body(reqwest::blocking::Body::new(std::io::empty()));

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -53,7 +53,7 @@ impl Response {
     ///
     /// ```rust
     /// # #[cfg(feature = "json")]
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let resp = reqwest::blocking::get("http://httpbin.org/get")?;
     /// if resp.status().is_success() {
     ///     println!("success!");
@@ -71,7 +71,7 @@ impl Response {
     /// ```rust
     /// use reqwest::blocking::Client;
     /// use reqwest::StatusCode;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new();
     ///
     /// let resp = client.post("http://httpbin.org/post")
@@ -103,7 +103,7 @@ impl Response {
     /// use reqwest::blocking::Client;
     /// use reqwest::header::ETAG;
     ///
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new();
     ///
     /// let mut resp = client.get("http://httpbin.org/cache").send()?;
@@ -152,7 +152,7 @@ impl Response {
     /// # Example
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let resp = reqwest::blocking::get("http://httpbin.org/redirect/1")?;
     /// assert_eq!(resp.url().as_str(), "http://httpbin.org/get");
     /// # Ok(())
@@ -168,7 +168,7 @@ impl Response {
     /// # Example
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let resp = reqwest::blocking::get("http://httpbin.org/redirect/1")?;
     /// println!("httpbin.org address: {:?}", resp.remote_addr());
     /// # Ok(())
@@ -274,7 +274,7 @@ impl Response {
     ///
     /// ```rust
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let content = reqwest::blocking::get("http://httpbin.org/range/26")?.text()?;
     /// # Ok(())
     /// # }
@@ -297,7 +297,7 @@ impl Response {
     ///
     /// ```rust
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let content = reqwest::blocking::get("http://httpbin.org/range/26")?
     ///     .text_with_charset("utf-8")?;
     /// # Ok(())
@@ -324,7 +324,7 @@ impl Response {
     /// # Example
     ///
     /// ```rust
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut resp = reqwest::blocking::get("http://httpbin.org/range/5")?;
     /// let mut buf: Vec<u8> = vec![];
     /// resp.copy_to(&mut buf)?;
@@ -345,7 +345,7 @@ impl Response {
     ///
     /// ```rust,no_run
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let res = reqwest::blocking::get("http://httpbin.org/status/400")?
     ///     .error_for_status();
     /// if let Err(err) = res {
@@ -376,7 +376,7 @@ impl Response {
     ///
     /// ```rust,no_run
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let res = reqwest::blocking::get("http://httpbin.org/status/400")?;
     /// let res = res.error_for_status_ref();
     /// if let Err(err) = res {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -44,7 +44,7 @@ use winreg::RegKey;
 /// For instance, let's look at `Proxy::http`:
 ///
 /// ```rust
-/// # fn run() -> Result<(), Box<std::error::Error>> {
+/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// let proxy = reqwest::Proxy::http("https://secure.example")?;
 /// # Ok(())
 /// # }
@@ -61,7 +61,7 @@ use winreg::RegKey;
 ///
 /// By enabling the `"socks"` feature it is possible to use a socks proxy:
 /// ```rust
-/// # fn run() -> Result<(), Box<std::error::Error>> {
+/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// let proxy = reqwest::Proxy::http("socks5://192.168.1.1:9000")?;
 /// # Ok(())
 /// # }
@@ -196,7 +196,7 @@ impl Proxy {
     ///
     /// ```
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::Client::builder()
     ///     .proxy(reqwest::Proxy::http("https://my.prox")?)
     ///     .build()?;
@@ -216,7 +216,7 @@ impl Proxy {
     ///
     /// ```
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::Client::builder()
     ///     .proxy(reqwest::Proxy::https("https://example.prox:4545")?)
     ///     .build()?;
@@ -236,7 +236,7 @@ impl Proxy {
     ///
     /// ```
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = reqwest::Client::builder()
     ///     .proxy(reqwest::Proxy::all("http://pro.xy")?)
     ///     .build()?;
@@ -256,7 +256,7 @@ impl Proxy {
     ///
     /// ```
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let target = reqwest::Url::parse("https://my.prox")?;
     /// let client = reqwest::Client::builder()
     ///     .proxy(reqwest::Proxy::custom(move |url| {
@@ -306,7 +306,7 @@ impl Proxy {
     ///
     /// ```
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let proxy = reqwest::Proxy::https("http://localhost:1234")?
     ///     .basic_auth("Aladdin", "open sesame");
     /// # Ok(())
@@ -325,7 +325,7 @@ impl Proxy {
     /// ```
     /// # extern crate reqwest;
     /// # use reqwest::header::*;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let proxy = reqwest::Proxy::https("http://localhost:1234")?
     ///     .custom_http_auth(HeaderValue::from_static("justletmeinalreadyplease"));
     /// # Ok(())
@@ -343,7 +343,7 @@ impl Proxy {
     ///
     /// ```
     /// # extern crate reqwest;
-    /// # fn run() -> Result<(), Box<std::error::Error>> {
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let proxy = reqwest::Proxy::https("http://localhost:1234")?
     ///     .no_proxy(reqwest::NoProxy::from_string("direct.tld, sub.direct2.tld"));
     /// # Ok(())

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -98,7 +98,7 @@ impl Certificate {
     /// ```
     /// # use std::fs::File;
     /// # use std::io::Read;
-    /// # fn cert() -> Result<(), Box<std::error::Error>> {
+    /// # fn cert() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut buf = Vec::new();
     /// File::open("my_cert.der")?
     ///     .read_to_end(&mut buf)?;
@@ -123,7 +123,7 @@ impl Certificate {
     /// ```
     /// # use std::fs::File;
     /// # use std::io::Read;
-    /// # fn cert() -> Result<(), Box<std::error::Error>> {
+    /// # fn cert() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut buf = Vec::new();
     /// File::open("my_cert.pem")?
     ///     .read_to_end(&mut buf)?;
@@ -149,7 +149,7 @@ impl Certificate {
     /// ```
     /// # use std::fs::File;
     /// # use std::io::Read;
-    /// # fn cert() -> Result<(), Box<std::error::Error>> {
+    /// # fn cert() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut buf = Vec::new();
     /// File::open("ca-bundle.crt")?
     ///     .read_to_end(&mut buf)?;
@@ -221,7 +221,7 @@ impl Identity {
     /// ```
     /// # use std::fs::File;
     /// # use std::io::Read;
-    /// # fn pkcs12() -> Result<(), Box<std::error::Error>> {
+    /// # fn pkcs12() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut buf = Vec::new();
     /// File::open("my-ident.pfx")?
     ///     .read_to_end(&mut buf)?;
@@ -256,7 +256,7 @@ impl Identity {
     ///
     /// ```
     /// # use std::fs;
-    /// # fn pkcs8() -> Result<(), Box<std::error::Error>> {
+    /// # fn pkcs8() -> Result<(), Box<dyn std::error::Error>> {
     /// let cert = fs::read("client.pem")?;
     /// let key = fs::read("key.pem")?;
     /// let pkcs8 = reqwest::Identity::from_pkcs8_pem(&cert, &key)?;
@@ -289,7 +289,7 @@ impl Identity {
     /// ```
     /// # use std::fs::File;
     /// # use std::io::Read;
-    /// # fn pem() -> Result<(), Box<std::error::Error>> {
+    /// # fn pem() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut buf = Vec::new();
     /// File::open("my-ident.pem")?
     ///     .read_to_end(&mut buf)?;


### PR DESCRIPTION
* Bump edition to 2021 on both crates
* Fix docs to use `Box<dyn ...>` (required)

P.S. So sad I missed the PR 2021 - would be symbolic to have edition 2021 migration as PR number 2021 :)