### PR TITLE
chore: Inline format args

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?
         .json::<HashMap<String, String>>()
         .await?;
-    println!("{:#?}", resp);
+    println!("{resp:#?}");
     Ok(())
 }
 ```
@@ -58,7 +58,7 @@ use std::collections::HashMap;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let resp = reqwest::blocking::get("https://httpbin.org/ip")?
         .json::<HashMap<String, String>>()?;
-    println!("{:#?}", resp);
+    println!("{resp:#?}");
     Ok(())
 }
 ```

--- a/examples/blocking.rs
+++ b/examples/blocking.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    eprintln!("Fetching {:?}...", url);
+    eprintln!("Fetching {url:?}...");
 
     // reqwest::blocking::get() is a convenience function.
     //

--- a/examples/h3_simple.rs
+++ b/examples/h3_simple.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), reqwest::Error> {
         }
     };
 
-    eprintln!("Fetching {:?}...", url);
+    eprintln!("Fetching {url:?}...");
 
     let res = get(url).await?;
 
@@ -38,7 +38,7 @@ async fn main() -> Result<(), reqwest::Error> {
 
     let body = res.text().await?;
 
-    println!("{}", body);
+    println!("{body}");
 
     Ok(())
 }

--- a/examples/json_dynamic.rs
+++ b/examples/json_dynamic.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), reqwest::Error> {
         .json()
         .await?;
 
-    println!("{:#?}", echo_json);
+    println!("{echo_json:#?}");
     // Object(
     //     {
     //         "body": String(

--- a/examples/json_typed.rs
+++ b/examples/json_typed.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), reqwest::Error> {
         .json()
         .await?;
 
-    println!("{:#?}", new_post);
+    println!("{new_post:#?}");
     // Post {
     //     id: Some(
     //         101

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), reqwest::Error> {
         "https://hyper.rs".into()
     };
 
-    eprintln!("Fetching {:?}...", url);
+    eprintln!("Fetching {url:?}...");
 
     // reqwest::get() is a convenience function.
     //
@@ -27,7 +27,7 @@ async fn main() -> Result<(), reqwest::Error> {
 
     let body = res.text().await?;
 
-    println!("{}", body);
+    println!("{body}");
 
     Ok(())
 }

--- a/examples/tor_socks.rs
+++ b/examples/tor_socks.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), reqwest::Error> {
 
     let text = res.text().await?;
     let is_tor = text.contains("Congratulations. This browser is configured to use Tor.");
-    println!("Is Tor: {}", is_tor);
+    println!("Is Tor: {is_tor}");
     assert!(is_tor);
 
     Ok(())

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -494,9 +494,7 @@ impl ClientBuilder {
                                 Err(err) => {
                                     invalid_count += 1;
                                     log::warn!(
-                                        "rustls failed to parse DER certificate {:?} {:?}",
-                                        &err,
-                                        &cert
+                                        "rustls failed to parse DER certificate {err:?} {cert:?}"
                                     );
                                 }
                             }
@@ -2164,7 +2162,7 @@ impl PendingRequest {
             return false;
         }
 
-        trace!("can retry {:?}", err);
+        trace!("can retry {err:?}");
 
         let body = match self.body {
             Some(Some(ref body)) => Body::reusable(body.clone()),
@@ -2220,7 +2218,7 @@ fn is_retryable_error(err: &(dyn std::error::Error + 'static)) -> bool {
     #[cfg(feature = "http3")]
     if let Some(cause) = err.source() {
         if let Some(err) = cause.downcast_ref::<h3::Error>() {
-            debug!("determining if HTTP/3 error {} can be retried", err);
+            debug!("determining if HTTP/3 error {err} can be retried");
             // TODO: Does h3 provide an API for checking the error?
             return err.to_string().as_str() == "timeout";
         }
@@ -2370,7 +2368,7 @@ impl Future for PendingRequest {
                     });
 
                     if loc.is_none() {
-                        debug!("Location header had invalid URI: {:?}", val);
+                        debug!("Location header had invalid URI: {val:?}");
                     }
                     loc
                 });
@@ -2452,7 +2450,7 @@ impl Future for PendingRequest {
                             continue;
                         }
                         redirect::ActionKind::Stop => {
-                            debug!("redirect policy disallowed redirection to '{}'", loc);
+                            debug!("redirect policy disallowed redirection to '{loc}'");
                         }
                         redirect::ActionKind::Error(err) => {
                             return Poll::Ready(Err(crate::error::redirect(err, self.url.clone())));

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -169,7 +169,7 @@ impl Decoder {
         if is_content_encoded {
             if let Some(content_length) = headers.get(CONTENT_LENGTH) {
                 if content_length == "0" {
-                    warn!("{} response with content-length of 0", encoding_str);
+                    warn!("{encoding_str} response with content-length of 0");
                     is_content_encoded = false;
                 }
             }

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -33,11 +33,11 @@ impl H3Client {
 
     async fn get_pooled_client(&mut self, key: Key) -> Result<PoolClient, BoxError> {
         if let Some(client) = self.pool.try_pool(&key) {
-            trace!("getting client from pool with key {:?}", key);
+            trace!("getting client from pool with key {key:?}");
             return Ok(client);
         }
 
-        trace!("did not find connection {:?} in pool so connecting...", key);
+        trace!("did not find connection {key:?} in pool so connecting...");
 
         let dest = pool::domain_as_uri(key.clone());
         self.pool.connecting(key.clone())?;

--- a/src/async_impl/h3_client/pool.rs
+++ b/src/async_impl/h3_client/pool.rs
@@ -37,7 +37,7 @@ impl Pool {
     pub fn connecting(&self, key: Key) -> Result<(), BoxError> {
         let mut inner = self.inner.lock().unwrap();
         if !inner.connecting.insert(key.clone()) {
-            return Err(format!("HTTP/3 connecting already in progress for {:?}", key).into());
+            return Err(format!("HTTP/3 connecting already in progress for {key:?}").into());
         }
         return Ok(());
     }
@@ -77,7 +77,7 @@ impl Pool {
         let (close_tx, close_rx) = std::sync::mpsc::channel();
         tokio::spawn(async move {
             if let Err(e) = future::poll_fn(|cx| driver.poll_close(cx)).await {
-                trace!("poll_close returned error {:?}", e);
+                trace!("poll_close returned error {e:?}");
                 close_tx.send(e).ok();
             }
         });
@@ -105,7 +105,7 @@ struct PoolInner {
 impl PoolInner {
     fn insert(&mut self, key: Key, conn: PoolConnection) {
         if self.idle_conns.contains_key(&key) {
-            trace!("connection already exists for key {:?}", key);
+            trace!("connection already exists for key {key:?}");
         }
 
         self.idle_conns.insert(key, conn);

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -520,7 +520,7 @@ fn gen_boundary() -> String {
     let c = random();
     let d = random();
 
-    format!("{:016x}-{:016x}-{:016x}-{:016x}", a, b, c, d)
+    format!("{a:016x}-{b:016x}-{c:016x}-{d:016x}")
 }
 
 #[cfg(test)]
@@ -597,7 +597,7 @@ mod tests {
             "START REAL\n{}\nEND REAL",
             std::str::from_utf8(&out).unwrap()
         );
-        println!("START EXPECTED\n{}\nEND EXPECTED", expected);
+        println!("START EXPECTED\n{expected}\nEND EXPECTED");
         assert_eq!(std::str::from_utf8(&out).unwrap(), expected);
     }
 
@@ -629,7 +629,7 @@ mod tests {
             "START REAL\n{}\nEND REAL",
             std::str::from_utf8(&out).unwrap()
         );
-        println!("START EXPECTED\n{}\nEND EXPECTED", expected);
+        println!("START EXPECTED\n{expected}\nEND EXPECTED");
         assert_eq!(std::str::from_utf8(&out).unwrap(), expected);
     }
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -266,7 +266,7 @@ impl RequestBuilder {
     where
         T: fmt::Display,
     {
-        let header_value = format!("Bearer {}", token);
+        let header_value = format!("Bearer {token}");
         self.header_sensitive(crate::header::AUTHORIZATION, header_value, true)
     }
 

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -140,7 +140,7 @@ impl Response {
     ///     .text()
     ///     .await?;
     ///
-    /// println!("text: {:?}", content);
+    /// println!("text: {content:?}");
     /// # Ok(())
     /// # }
     /// ```
@@ -169,7 +169,7 @@ impl Response {
     ///     .text_with_charset("utf-8")
     ///     .await?;
     ///
-    /// println!("text: {:?}", content);
+    /// println!("text: {content:?}");
     /// # Ok(())
     /// # }
     /// ```
@@ -251,7 +251,7 @@ impl Response {
     ///     .bytes()
     ///     .await?;
     ///
-    /// println!("bytes: {:?}", bytes);
+    /// println!("bytes: {bytes:?}");
     /// # Ok(())
     /// # }
     /// ```
@@ -270,7 +270,7 @@ impl Response {
     /// let mut res = reqwest::get("https://hyper.rs").await?;
     ///
     /// while let Some(chunk) = res.chunk().await? {
-    ///     println!("Chunk: {:?}", chunk);
+    ///     println!("Chunk: {chunk:?}");
     /// }
     /// # Ok(())
     /// # }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1014,11 +1014,11 @@ impl Drop for InnerClientHandle {
             .map(|h| h.thread().id())
             .expect("thread not dropped yet");
 
-        trace!("closing runtime thread ({:?})", id);
+        trace!("closing runtime thread ({id:?})");
         self.tx.take();
-        trace!("signaled close for runtime thread ({:?})", id);
+        trace!("signaled close for runtime thread ({id:?})");
         self.thread.take().map(|h| h.join());
-        trace!("closed runtime thread ({:?})", id);
+        trace!("closed runtime thread ({id:?})");
     }
 }
 
@@ -1039,7 +1039,7 @@ impl ClientHandle {
                 {
                     Err(e) => {
                         if let Err(e) = spawn_tx.send(Err(e)) {
-                            error!("Failed to communicate runtime creation failure: {:?}", e);
+                            error!("Failed to communicate runtime creation failure: {e:?}");
                         }
                         return;
                     }
@@ -1050,14 +1050,14 @@ impl ClientHandle {
                     let client = match builder.build() {
                         Err(e) => {
                             if let Err(e) = spawn_tx.send(Err(e)) {
-                                error!("Failed to communicate client creation failure: {:?}", e);
+                                error!("Failed to communicate client creation failure: {e:?}");
                             }
                             return;
                         }
                         Ok(v) => v,
                     };
                     if let Err(e) = spawn_tx.send(Ok(())) {
-                        error!("Failed to communicate successful startup: {:?}", e);
+                        error!("Failed to communicate successful startup: {e:?}");
                         return;
                     }
 

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -25,7 +25,7 @@
 //! let body = reqwest::blocking::get("https://www.rust-lang.org")?
 //!     .text()?;
 //!
-//! println!("body = {:?}", body);
+//! println!("body = {body:?}");
 //! # Ok(())
 //! # }
 //! ```

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -420,7 +420,7 @@ mod tests {
             "START REAL\n{}\nEND REAL",
             std::str::from_utf8(&output).unwrap()
         );
-        println!("START EXPECTED\n{}\nEND EXPECTED", expected);
+        println!("START EXPECTED\n{expected}\nEND EXPECTED");
         assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
         assert!(length.is_none());
     }
@@ -450,7 +450,7 @@ mod tests {
             "START REAL\n{}\nEND REAL",
             std::str::from_utf8(&output).unwrap()
         );
-        println!("START EXPECTED\n{}\nEND EXPECTED", expected);
+        println!("START EXPECTED\n{expected}\nEND EXPECTED");
         assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
         assert_eq!(length.unwrap(), expected.len() as u64);
     }
@@ -477,7 +477,7 @@ mod tests {
             "START REAL\n{}\nEND REAL",
             std::str::from_utf8(&output).unwrap()
         );
-        println!("START EXPECTED\n{}\nEND EXPECTED", expected);
+        println!("START EXPECTED\n{expected}\nEND EXPECTED");
         assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
     }
 }

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -284,7 +284,7 @@ impl RequestBuilder {
     where
         T: fmt::Display,
     {
-        let header_value = format!("Bearer {}", token);
+        let header_value = format!("Bearer {token}");
         self.header_sensitive(crate::header::AUTHORIZATION, &*header_value, true)
     }
 

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -83,7 +83,7 @@ impl Response {
     ///     StatusCode::PAYLOAD_TOO_LARGE => {
     ///         println!("Request payload is too large!");
     ///     }
-    ///     s => println!("Received response status: {:?}", s),
+    ///     s => println!("Received response status: {s:?}"),
     /// };
     /// # Ok(())
     /// # }
@@ -252,7 +252,7 @@ impl Response {
     /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let bytes = reqwest::blocking::get("http://httpbin.org/ip")?.bytes()?;
     ///
-    /// println!("bytes: {:?}", bytes);
+    /// println!("bytes: {bytes:?}");
     /// # Ok(())
     /// # }
     /// ```

--- a/src/blocking/wait.rs
+++ b/src/blocking/wait.rs
@@ -13,7 +13,7 @@ where
     enter();
 
     let deadline = timeout.map(|d| {
-        log::trace!("wait at most {:?}", d);
+        log::trace!("wait at most {d:?}");
         Instant::now() + d
     });
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -317,7 +317,7 @@ impl Connector {
         dst: Uri,
         proxy_scheme: ProxyScheme,
     ) -> Result<Conn, BoxError> {
-        log::debug!("proxy({:?}) intercepts '{:?}'", proxy_scheme, dst);
+        log::debug!("proxy({proxy_scheme:?}) intercepts '{dst:?}'");
 
         let (proxy_dst, _auth) = match proxy_scheme {
             ProxyScheme::Http { host, auth } => (into_uri(Scheme::HTTP, host), auth),
@@ -446,7 +446,7 @@ impl Service<Uri> for Connector {
     }
 
     fn call(&mut self, dst: Uri) -> Self::Future {
-        log::debug!("starting new connection: {:?}", dst);
+        log::debug!("starting new connection: {dst:?}");
         let timeout = self.timeout;
         for prox in self.proxies.iter() {
             if let Some(proxy_scheme) = prox.intercept(&dst) {
@@ -676,10 +676,9 @@ where
 
     let mut buf = format!(
         "\
-         CONNECT {0}:{1} HTTP/1.1\r\n\
-         Host: {0}:{1}\r\n\
-         ",
-        host, port
+         CONNECT {host}:{port} HTTP/1.1\r\n\
+         Host: {host}:{port}\r\n\
+         "
     )
     .into_bytes();
 
@@ -692,7 +691,7 @@ where
 
     // proxy-authorization
     if let Some(value) = auth {
-        log::debug!("tunnel to {}:{} using basic auth", host, port);
+        log::debug!("tunnel to {host}:{port} using basic auth");
         buf.extend_from_slice(b"Proxy-Authorization: ");
         buf.extend_from_slice(value.as_bytes());
         buf.extend_from_slice(b"\r\n");
@@ -987,11 +986,11 @@ mod socks {
                 &password,
             )
             .await
-            .map_err(|e| format!("socks connect error: {}", e))?
+            .map_err(|e| format!("socks connect error: {e}"))?
         } else {
             Socks5Stream::connect(socket_addr, (host.as_str(), port))
                 .await
-                .map_err(|e| format!("socks connect error: {}", e))?
+                .map_err(|e| format!("socks connect error: {e}"))?
         };
 
         Ok(stream.into_inner())
@@ -1136,7 +1135,7 @@ mod verbose {
                 } else if c >= 0x20 && c < 0x7f {
                     write!(f, "{}", c as char)?;
                 } else {
-                    write!(f, "\\x{:02x}", c)?;
+                    write!(f, "\\x{c:02x}")?;
                 }
             }
             write!(f, "\"")?;

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -178,7 +178,7 @@ impl CookieStore for Jar {
             .read()
             .unwrap()
             .get_request_values(url)
-            .map(|(name, value)| format!("{}={}", name, value))
+            .map(|(name, value)| format!("{name}={value}"))
             .collect::<Vec<_>>()
             .join("; ");
 

--- a/src/dns/trust_dns.rs
+++ b/src/dns/trust_dns.rs
@@ -52,7 +52,7 @@ fn new_resolver() -> io::Result<TokioAsyncResolver> {
     let (config, opts) = system_conf::read_system_conf().map_err(|e| {
         io::Error::new(
             io::ErrorKind::Other,
-            format!("error reading DNS system conf: {}", e),
+            format!("error reading DNS system conf: {e}"),
         )
     })?;
     Ok(TokioAsyncResolver::tokio(config, opts))

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,7 @@ impl Error {
     /// if let Err(e) = response {
     ///     if e.is_redirect() {
     ///         if let Some(final_stop) = e.url() {
-    ///             println!("redirect loop at {}", final_stop);
+    ///             println!("redirect loop at {final_stop}");
     ///         }
     ///     }
     /// }
@@ -198,16 +198,16 @@ impl fmt::Display for Error {
                     debug_assert!(code.is_server_error());
                     "HTTP status server error"
                 };
-                write!(f, "{} ({})", prefix, code)?;
+                write!(f, "{prefix} ({code})")?;
             }
         };
 
         if let Some(url) = &self.inner.url {
-            write!(f, " for url ({})", url.as_str())?;
+            write!(f, " for url ({url})")?;
         }
 
         if let Some(e) = &self.inner.source {
-            write!(f, ": {}", e)?;
+            write!(f, ": {e}")?;
         }
 
         Ok(())
@@ -230,7 +230,7 @@ impl From<crate::error::Error> for wasm_bindgen::JsValue {
 #[cfg(target_arch = "wasm32")]
 impl From<crate::error::Error> for js_sys::Error {
     fn from(err: Error) -> js_sys::Error {
-        js_sys::Error::new(&format!("{}", err))
+        js_sys::Error::new(&format!("{err}"))
     }
 }
 
@@ -281,7 +281,7 @@ pub(crate) fn url_invalid_uri(url: Url) -> Error {
 
 if_wasm! {
     pub(crate) fn wasm(js_val: wasm_bindgen::JsValue) -> BoxError {
-        format!("{:?}", js_val).into()
+        format!("{js_val:?}").into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //!     .text()
 //!     .await?;
 //!
-//! println!("body = {:?}", body);
+//! println!("body = {body:?}");
 //! # Ok(())
 //! # }
 //! ```

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -737,8 +737,8 @@ impl ProxyScheme {
 impl fmt::Debug for ProxyScheme {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ProxyScheme::Http { auth: _auth, host } => write!(f, "http://{}", host),
-            ProxyScheme::Https { auth: _auth, host } => write!(f, "https://{}", host),
+            ProxyScheme::Http { auth: _auth, host } => write!(f, "http://{host}"),
+            ProxyScheme::Https { auth: _auth, host } => write!(f, "https://{host}"),
             #[cfg(feature = "socks")]
             ProxyScheme::Socks5 {
                 addr,
@@ -746,7 +746,7 @@ impl fmt::Debug for ProxyScheme {
                 remote_dns,
             } => {
                 let h = if *remote_dns { "h" } else { "" };
-                write!(f, "socks5{}://{}", h, addr)
+                write!(f, "socks5{h}://{addr}")
             }
         }
     }
@@ -1040,7 +1040,7 @@ fn parse_platform_values_impl(platform_values: String) -> SystemProxyMap {
                     let address = if extract_type_prefix(*address).is_some() {
                         String::from(*address)
                     } else {
-                        format!("http://{}", address)
+                        format!("http://{address}")
                     };
 
                     insert_proxy(&mut proxies, *protocol, address);
@@ -1059,8 +1059,8 @@ fn parse_platform_values_impl(platform_values: String) -> SystemProxyMap {
             insert_proxy(&mut proxies, scheme, platform_values.to_owned());
         } else {
             // No explicit protocol has been specified, default to HTTP
-            insert_proxy(&mut proxies, "http", format!("http://{}", platform_values));
-            insert_proxy(&mut proxies, "https", format!("http://{}", platform_values));
+            insert_proxy(&mut proxies, "http", format!("http://{platform_values}"));
+            insert_proxy(&mut proxies, "https", format!("http://{platform_values}"));
         }
     }
     proxies

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -261,7 +261,7 @@ fn test_redirect_policy_limit() {
     let policy = Policy::default();
     let next = Url::parse("http://x.y/z").unwrap();
     let mut previous = (0..9)
-        .map(|i| Url::parse(&format!("http://a.b/c/{}", i)).unwrap())
+        .map(|i| Url::parse(&format!("http://a.b/c/{i}")).unwrap())
         .collect::<Vec<_>>();
 
     match policy.check(StatusCode::FOUND, &next, &previous) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,9 +12,9 @@ where
     let mut buf = b"Basic ".to_vec();
     {
         let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
-        let _ = write!(encoder, "{}:", username);
+        let _ = write!(encoder, "{username}:");
         if let Some(password) = password {
-            let _ = write!(encoder, "{}", password);
+            let _ = write!(encoder, "{password}");
         }
     }
     let mut header = HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -221,7 +221,7 @@ impl RequestBuilder {
     where
         T: fmt::Display,
     {
-        let header_value = format!("Bearer {}", token);
+        let header_value = format!("Bearer {token}");
         self.header(crate::header::AUTHORIZATION, header_value)
     }
 

--- a/tests/brotli.rs
+++ b/tests/brotli.rs
@@ -90,7 +90,7 @@ async fn brotli_case(response_size: usize, chunk_size: usize) {
 
     let content: String = (0..response_size)
         .into_iter()
-        .map(|i| format!("test {}", i))
+        .map(|i| format!("test {i}"))
         .collect();
 
     let mut encoder = brotli_crate::CompressorReader::new(content.as_bytes(), 4096, 5, 20);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -181,8 +181,7 @@ async fn overridden_dns_resolution_with_gai() {
 
     let overridden_domain = "rust-lang.org";
     let url = format!(
-        "http://{}:{}/domain_override",
-        overridden_domain,
+        "http://{overridden_domain}:{}/domain_override",
         server.addr().port()
     );
     let client = reqwest::Client::builder()
@@ -204,8 +203,7 @@ async fn overridden_dns_resolution_with_gai_multiple() {
 
     let overridden_domain = "rust-lang.org";
     let url = format!(
-        "http://{}:{}/domain_override",
-        overridden_domain,
+        "http://{overridden_domain}:{}/domain_override",
         server.addr().port()
     );
     // the server runs on IPv4 localhost, so provide both IPv4 and IPv6 and let the happy eyeballs
@@ -239,8 +237,7 @@ async fn overridden_dns_resolution_with_trust_dns() {
 
     let overridden_domain = "rust-lang.org";
     let url = format!(
-        "http://{}:{}/domain_override",
-        overridden_domain,
+        "http://{overridden_domain}:{}/domain_override",
         server.addr().port()
     );
     let client = reqwest::Client::builder()
@@ -264,8 +261,7 @@ async fn overridden_dns_resolution_with_trust_dns_multiple() {
 
     let overridden_domain = "rust-lang.org";
     let url = format!(
-        "http://{}:{}/domain_override",
-        overridden_domain,
+        "http://{overridden_domain}:{}/domain_override",
         server.addr().port()
     );
     // the server runs on IPv4 localhost, so provide both IPv4 and IPv6 and let the happy eyeballs

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -90,7 +90,7 @@ async fn deflate_case(response_size: usize, chunk_size: usize) {
 
     let content: String = (0..response_size)
         .into_iter()
-        .map(|i| format!("test {}", i))
+        .map(|i| format!("test {i}"))
         .collect();
     let mut encoder = libflate::zlib::Encoder::new(Vec::new()).unwrap();
     match encoder.write(content.as_bytes()) {

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -91,7 +91,7 @@ async fn gzip_case(response_size: usize, chunk_size: usize) {
 
     let content: String = (0..response_size)
         .into_iter()
-        .map(|i| format!("test {}", i))
+        .map(|i| format!("test {i}"))
         .collect();
     let mut encoder = libflate::gzip::Encoder::new(Vec::new()).unwrap();
     match encoder.write(content.as_bytes()) {

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -12,7 +12,7 @@ async fn test_redirect_301_and_302_and_303_changes_post_to_get() {
     for &code in &codes {
         let redirect = server::http(move |req| async move {
             if req.method() == "POST" {
-                assert_eq!(req.uri(), &*format!("/{}", code));
+                assert_eq!(req.uri(), &*format!("/{code}"));
                 http::Response::builder()
                     .status(code)
                     .header("location", "/dst")
@@ -48,7 +48,7 @@ async fn test_redirect_307_and_308_tries_to_get_again() {
     for &code in &codes {
         let redirect = server::http(move |req| async move {
             assert_eq!(req.method(), "GET");
-            if req.uri() == &*format!("/{}", code) {
+            if req.uri() == &*format!("/{code}") {
                 http::Response::builder()
                     .status(code)
                     .header("location", "/dst")
@@ -90,7 +90,7 @@ async fn test_redirect_307_and_308_tries_to_post_again() {
             let data = req.body_mut().next().await.unwrap().unwrap();
             assert_eq!(&*data, b"Hello");
 
-            if req.uri() == &*format!("/{}", code) {
+            if req.uri() == &*format!("/{code}") {
                 http::Response::builder()
                     .status(code)
                     .header("location", "/dst")
@@ -127,7 +127,7 @@ fn test_redirect_307_does_not_try_if_reader_cannot_reset() {
     for &code in &codes {
         let redirect = server::http(move |mut req| async move {
             assert_eq!(req.method(), "POST");
-            assert_eq!(req.uri(), &*format!("/{}", code));
+            assert_eq!(req.uri(), &*format!("/{code}"));
             assert_eq!(req.headers()["transfer-encoding"], "chunked");
 
             let data = req.body_mut().next().await.unwrap().unwrap();
@@ -167,7 +167,7 @@ async fn test_redirect_removes_sensitive_headers() {
             let mid_addr = rx.borrow().unwrap();
             assert_eq!(
                 req.headers()["referer"],
-                format!("http://{}/sensitive", mid_addr)
+                format!("http://{mid_addr}/sensitive")
             );
             http::Response::default()
         }
@@ -179,7 +179,7 @@ async fn test_redirect_removes_sensitive_headers() {
         assert_eq!(req.headers()["cookie"], "foo=bar");
         http::Response::builder()
             .status(302)
-            .header("location", format!("http://{}/end", end_addr))
+            .header("location", format!("http://{end_addr}/end"))
             .body(Body::default())
             .unwrap()
     });

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -130,7 +130,7 @@ async fn connect_many_timeout() {
         .build()
         .unwrap();
 
-    let url = format!("http://many_addrs:81/slow");
+    let url = "http://many_addrs:81/slow".to_string();
 
     let res = client
         .get(url)

--- a/tests/wasm_simple.rs
+++ b/tests/wasm_simple.rs
@@ -20,5 +20,5 @@ async fn simple_example() {
     log(&format!("Status: {}", res.status()));
 
     let body = res.text().await.expect("response to utf-8 text");
-    log(&format!("Body:\n\n{}", body));
+    log(&format!("Body:\n\n{body}"));
 }


### PR DESCRIPTION
This makes the code a bit easier to read, and might result in a few minor perf optimizations (e.g. if Display trait is implemented, it might be better to make it part of the formatting). Also, i eliminated a few cases of using refs as format args - i.e. converted double-ref two single-ref, which is a 6% perf improvement (rustc cannot inline those for various reasons) - e.g. `format!("{}", &foo)` is more expensive than `format!("{}", foo)`.

All these changes are safe for both 2018 and 2021 editions.  The panic changes were moved to #2122