### PR TITLE
Add lower speed limit to full async body retrievals.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ libflate = "1.0"
 brotli_crate = { package = "brotli", version = "3.3.0" }
 doc-comment = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+futures-util = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.50.0"

--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -1,7 +1,7 @@
 pub use self::body::Body;
 pub use self::client::{Client, ClientBuilder};
 pub use self::request::{Request, RequestBuilder};
-pub use self::response::Response;
+pub use self::response::{Response, ResponseConfig, SpeedLimitConfig};
 pub use self::upgrade::Upgraded;
 
 #[cfg(feature = "blocking")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ if_hyper! {
     doctest!("../README.md");
 
     pub use self::async_impl::{
-        Body, Client, ClientBuilder, Request, RequestBuilder, Response, Upgraded,
+        Body, Client, ClientBuilder, Request, RequestBuilder, Response, ResponseConfig , SpeedLimitConfig, Upgraded,
     };
     pub use self::proxy::{Proxy,NoProxy};
     #[cfg(feature = "__tls")]


### PR DESCRIPTION
Background: https://github.com/hyperium/hyper/issues/3402

No breaking changes were added and this time I made sure to not touch changelog.md :3

(Note: added dependency is only a dev-dependency.)