### PR TITLE
`fn headers()` for wasm::multipart

### DIFF
--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -7,6 +7,7 @@ use mime_guess::Mime;
 use web_sys::FormData;
 
 use super::Body;
+use crate::header::HeaderMap;
 
 /// An async multipart/form-data request.
 pub struct Form {
@@ -170,6 +171,11 @@ impl Part {
         T: Into<Cow<'static, str>>,
     {
         self.with_inner(move |inner| inner.file_name(filename))
+    }
+
+    /// Sets custom headers for the part.
+    pub fn headers(self, headers: HeaderMap) -> Part {
+        self.with_inner(move |inner| inner.headers(headers))
     }
 
     fn with_inner<F>(self, func: F) -> Self

--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -7,7 +7,6 @@ use mime_guess::Mime;
 use web_sys::FormData;
 
 use super::Body;
-use crate::header::HeaderMap;
 
 /// An async multipart/form-data request.
 pub struct Form {

--- a/src/wasm/multipart.rs
+++ b/src/wasm/multipart.rs
@@ -267,6 +267,14 @@ impl PartMetadata {
         self.file_name = Some(filename.into());
         self
     }
+
+    pub(crate) fn headers<T>(mut self, headers: T) -> Self
+    where
+        T: Into<HeaderMap>,
+    {
+        self.headers = headers.into();
+        self
+    }
 }
 
 impl PartMetadata {


### PR DESCRIPTION
Fixes #2035 by stealing two missing functions from the non-wasm part of the library.