### PR TITLE
Improve interoperability with http

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -446,6 +446,16 @@ impl<T: Into<Body>> From<http::Response<T>> for Response {
     }
 }
 
+/// A `Response` can be converted into a `http::Response`.
+// It's supposed to be the inverse of the conversion above.
+impl From<Response> for http::Response<Body> {
+    fn from(r: Response) -> http::Response<Body> {
+        let (parts, body) = r.res.into_parts();
+        let body = Body::streaming(body);
+        http::Response::from_parts(parts, body)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Response;


### PR DESCRIPTION
I made a few changes to make reqwest types compatible with `http` types. This will enable a lot of interesting uses (such as a reverse proxy, example code attached in the end).

By interoperability with http I mean the following four components:

- impl `TryFrom` from `http::Request<http::Body>` to `reqwest::Request` (already implemented prior to this PR)
-  impl `TryFrom` from `reqwest::Response` to  `http::Response<reqwest::Body>`
- impl `http::Body` for `reqwest::Body`
- impl `tower::Service<reqwest::Request, Response=reqwest::Response, Error=reqwest::Error>` for `reqwest::Client`  (also already implemented prior to this PR)

In fact, all the implementation logic is already there. I only assembled these together.

Now with all these trait implementations and conversion functions, it becomes easy to play with axum and other `http`-based frameworks. Here's an example reverse proxy written in axum:

```rust
use axum::Router;
use tower::{Layer, ServiceExt};

#[tokio::main(flavor = "current_thread")]
async fn main() {
  let client = reqwest::Client::new();
  let example_proxy = client
    .map_request(|r| reqwest::Request::try_from(r).unwrap())
    .map_response(|r| http::Response::try_from(r).unwrap())
    .map_err(|e| panic!("axum requires this to be infallible {:?}", e));
  let rewrite_req_url = axum::middleware::map_request(rewrite_req_url);

  let example_proxy = rewrite_req_url.layer(example_proxy);

  let app = Router::new().nest_service("/example", example_proxy);
  let service = app.into_make_service();

  axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
    .serve(service)
    .await
    .unwrap();
}

async fn rewrite_req_url<B>(mut req: http::Request<B>) -> http::Request<B> {
  let uri = format!("https://example.com{}", req.uri());
  req.headers_mut().insert(
    http::header::HOST,
    http::header::HeaderValue::from_static("example.com"),
  );
  *req.uri_mut() = uri.parse().unwrap();
  req
}
```

I noticed that the wrapper `ImplStream` is not really used anywhere, so I removed it. In my opinion, it is sensible to interpret a `reqwest::Body` as a `Stream` or a `http::Body` on its own. Please let me know if there are considerations where it's still necessary.