### PR TITLE
Update README advice regarding OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 On Linux:
 
-- OpenSSL 1.0.1, 1.0.2, 1.1.0, or 1.1.1 with headers (see https://github.com/sfackler/rust-openssl)
+- OpenSSL with headers. See https://docs.rs/openssl for supported versions
+  and more details. Alternatively you can enable the `native-tls-vendored`
+  feature to compile a copy of OpenSSL.
 
 On Windows and macOS:
 
@@ -75,7 +77,8 @@ On Windows and macOS:
 
 Reqwest uses [rust-native-tls](https://github.com/sfackler/rust-native-tls),
 which will use the operating system TLS framework if available, meaning Windows
-and macOS. On Linux, it will use OpenSSL 1.1.
+and macOS. On Linux, it will use the available OpenSSL or fail to build if
+not found.
 
 
 ## License


### PR DESCRIPTION
Previously, the README suggested that only certain older versions of OpenSSL are supported. This is no longer accurate (e.g. OpenSSL 3 works), the better source of truth for supported versions is https://docs.rs/openssl.

Also adds clarity that OpenSSL can be vendored, useful if not installed on the host.