### PR TITLE
Reject redirects with invalid scheme

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2367,6 +2367,10 @@ impl Future for PendingRequest {
                         redirect::ActionKind::Follow => {
                             debug!("redirecting '{}' to '{}'", self.url, loc);
 
+                            if loc.scheme() != "http" && loc.scheme() != "https" {
+                                return Poll::Ready(Err(error::url_bad_scheme(loc)));
+                            }
+
                             if self.client.https_only && loc.scheme() != "https" {
                                 return Poll::Ready(Err(error::redirect(
                                     error::url_bad_scheme(loc.clone()),

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -286,6 +286,22 @@ async fn test_invalid_location_stops_redirect_gh484() {
     assert_eq!(res.status(), reqwest::StatusCode::FOUND);
 }
 
+#[tokio::test]
+async fn test_invalid_scheme_is_rejected() {
+    let server = server::http(move |_req| async move {
+        http::Response::builder()
+            .status(302)
+            .header("location", "htt://www.yikes.com/")
+            .body(Body::default())
+            .unwrap()
+    });
+
+    let url = format!("http://{}/yikes", server.addr());
+
+    let err = reqwest::get(&url).await.unwrap_err();
+    assert!(err.is_builder());
+}
+
 #[cfg(feature = "cookies")]
 #[tokio::test]
 async fn test_redirect_302_with_set_cookies() {


### PR DESCRIPTION
Reqwest checks the URI scheme to match either `"http"` or `"https"` before it makes the initial request. This check does not exist on redirects, so the request gets executed. It would be better to reject the redirect with the same error as it would reject an initial request.