### PR TITLE
Add `macos-system-configuration` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 ]
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "macos-system-configuration"]
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.
@@ -62,6 +62,9 @@ trust-dns = ["trust-dns-resolver"]
 stream = ["tokio/fs", "tokio-util", "wasm-streams"]
 
 socks = ["tokio-socks"]
+
+# Use the system's proxy configuration.
+macos-system-configuration = ["system-configuration"]
 
 # Experimental HTTP/3 client.
 http3 = ["rustls-tls-manual-roots", "h3", "h3-quinn", "quinn", "futures-channel"]
@@ -161,7 +164,7 @@ futures-util = { version = "0.3.0", default-features = false, features = ["std",
 winreg = "0.50.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-system-configuration = "0.5.1"
+system-configuration = { version = "0.5.1", optional = true }
 
 # wasm
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::env;
 use std::error::Error;
 use std::net::IpAddr;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 use system_configuration::{
     core_foundation::{
         base::CFType,
@@ -947,7 +947,7 @@ fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     Ok((proxy_enable == 1).then_some(proxy_server))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 fn parse_setting_from_dynamic_store(
     proxies_map: &CFDictionary<CFString, CFType>,
     enabled_key: CFStringRef,
@@ -985,7 +985,7 @@ fn parse_setting_from_dynamic_store(
     None
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos-system-configuration"))]
 fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     let store = SCDynamicStoreBuilder::new("reqwest").build();
 
@@ -1016,12 +1016,12 @@ fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", all(target_os = "macos", feature = "macos-system-configuration")))]
 fn get_from_platform() -> Option<String> {
     get_from_platform_impl().ok().flatten()
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", all(target_os = "macos", feature = "macos-system-configuration"))))]
 fn get_from_platform() -> Option<String> {
     None
 }


### PR DESCRIPTION
The `system-configuration` crate was added in https://github.com/seanmonstar/reqwest/pull/1955 to support macOS system proxy settings. However, it forces users to link to the SystemConfiguration framework.

This PR makes macOS system proxy a default feature in reqwest. Users can disable the feature and avoid the `dyld` startup cost of loading the framework.