### PR TITLE
Fix HTTP/2: retry requests rejected with `REFUSED_STREAM`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ mime_guess = { version = "2.0", default-features = false, optional = true }
 encoding_rs = "0.8"
 http-body = "0.4.0"
 hyper = { version = "0.14.21", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
-h2 = "0.3.10"
+h2 = "0.3.14"
 once_cell = "1"
 log = "0.4"
 mime = "0.3.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ libflate = "1.0"
 brotli_crate = { package = "brotli", version = "3.3.0" }
 doc-comment = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+futures-util = { version = "0.3.0", default-features = false, features = ["std", "alloc"] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.50.0"

--- a/tests/support/delay_server.rs
+++ b/tests/support/delay_server.rs
@@ -1,0 +1,119 @@
+#![cfg(not(target_arch = "wasm32"))]
+use std::convert::Infallible;
+use std::future::Future;
+use std::net;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::FutureExt;
+use http::{Request, Response};
+use hyper::service::service_fn;
+use hyper::Body;
+use tokio::net::TcpListener;
+use tokio::select;
+use tokio::sync::oneshot;
+
+/// This server, unlike [`super::server::Server`], allows for delaying the
+/// specified amount of time after each TCP connection is established. This is
+/// useful for testing the behavior of the client when the server is slow.
+///
+/// For example, in case of HTTP/2, once the TCP/TLS connection is established,
+/// both endpoints are supposed to send a preface and an initial `SETTINGS`
+/// frame (See [RFC9113 3.4] for details). What if these frames are delayed for
+/// whatever reason? This server allows for testing such scenarios.
+///
+/// [RFC9113 3.4]: https://www.rfc-editor.org/rfc/rfc9113.html#name-http-2-connection-preface
+pub struct Server {
+    addr: net::SocketAddr,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    server_terminated_rx: oneshot::Receiver<()>,
+}
+
+impl Server {
+    pub async fn new<F1, Fut, F2>(func: F1, apply_config: F2, delay: Duration) -> Self
+    where
+        F1: Fn(Request<Body>) -> Fut + Clone + Send + 'static,
+        Fut: Future<Output = Response<Body>> + Send + 'static,
+        F2: FnOnce(hyper::server::conn::Http) -> hyper::server::conn::Http + Send + 'static,
+    {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (server_terminated_tx, server_terminated_rx) = oneshot::channel();
+
+        let tcp_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = tcp_listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let http = Arc::new(apply_config(hyper::server::conn::Http::new()));
+
+            tokio::spawn(async move {
+                let (connection_shutdown_tx, connection_shutdown_rx) = oneshot::channel();
+                let connection_shutdown_rx = connection_shutdown_rx.shared();
+                let mut shutdown_rx = std::pin::pin!(shutdown_rx);
+
+                let mut handles = Vec::new();
+                loop {
+                    select! {
+                        _ = shutdown_rx.as_mut() => {
+                            connection_shutdown_tx.send(()).unwrap();
+                            break;
+                        }
+                        res = tcp_listener.accept() => {
+                            let (stream, _) = res.unwrap();
+
+
+                            let handle = tokio::spawn({
+                                let connection_shutdown_rx = connection_shutdown_rx.clone();
+                                let http = http.clone();
+                                let func = func.clone();
+
+                                async move {
+                                    tokio::time::sleep(delay).await;
+
+                                    let mut conn = std::pin::pin!(http.serve_connection(
+                                        stream,
+                                        service_fn(move |req| {
+                                            let fut = func(req);
+                                            async move {
+                                            Ok::<_, Infallible>(fut.await)
+                                        }})
+                                    ));
+
+                                    select! {
+                                        _ = conn.as_mut() => {}
+                                        _ = connection_shutdown_rx => {
+                                            conn.as_mut().graceful_shutdown();
+                                            conn.await.unwrap();
+                                        }
+                                    }
+                                }
+                            });
+
+                            handles.push(handle);
+                        }
+                    }
+                }
+
+                futures_util::future::join_all(handles).await;
+                server_terminated_tx.send(()).unwrap();
+            });
+        });
+
+        Self {
+            addr,
+            shutdown_tx: Some(shutdown_tx),
+            server_terminated_rx,
+        }
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+
+        self.server_terminated_rx.await.unwrap();
+    }
+
+    pub fn addr(&self) -> net::SocketAddr {
+        self.addr
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,4 @@
+pub mod delay_server;
 pub mod server;
 
 // TODO: remove once done converting to new support server?

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -1,15 +1,14 @@
 #![cfg(not(target_arch = "wasm32"))]
-use std::convert::Infallible;
+use std::convert::{identity, Infallible};
 use std::future::Future;
 use std::net;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
 use std::time::Duration;
 
-use tokio::sync::oneshot;
-
-pub use http::Response;
+use hyper::server::conn::AddrIncoming;
 use tokio::runtime;
+use tokio::sync::oneshot;
 
 pub struct Server {
     addr: net::SocketAddr,
@@ -42,51 +41,57 @@ where
     F: Fn(http::Request<hyper::Body>) -> Fut + Clone + Send + 'static,
     Fut: Future<Output = http::Response<hyper::Body>> + Send + 'static,
 {
-    //Spawn new runtime in thread to prevent reactor execution context conflict
-    thread::spawn(move || {
-        let rt = runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("new rt");
-        let srv = rt.block_on(async move {
-            hyper::Server::bind(&([127, 0, 0, 1], 0).into()).serve(hyper::service::make_service_fn(
-                move |_| {
-                    let func = func.clone();
-                    async move {
-                        Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
-                            let fut = func(req);
-                            async move { Ok::<_, Infallible>(fut.await) }
-                        }))
-                    }
-                },
-            ))
-        });
+    http_with_config(func, identity)
+}
 
-        let addr = srv.local_addr();
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let srv = srv.with_graceful_shutdown(async move {
-            let _ = shutdown_rx.await;
-        });
+pub fn http_with_config<F1, Fut, F2>(func: F1, apply_config: F2) -> Server
+where
+    F1: Fn(http::Request<hyper::Body>) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = http::Response<hyper::Body>> + Send + 'static,
+    F2: FnOnce(hyper::server::Builder<AddrIncoming>) -> hyper::server::Builder<AddrIncoming>
+        + Send
+        + 'static,
+{
+    let srv = {
+        let builder = hyper::Server::bind(&([127, 0, 0, 1], 19999).into());
 
-        let (panic_tx, panic_rx) = std_mpsc::channel();
-        let tname = format!(
-            "test({})-support-server",
-            thread::current().name().unwrap_or("<unknown>")
-        );
-        thread::Builder::new()
-            .name(tname)
-            .spawn(move || {
-                rt.block_on(srv).unwrap();
-                let _ = panic_tx.send(());
-            })
-            .expect("thread spawn");
+        apply_config(builder).serve(hyper::service::make_service_fn(move |_| {
+            let func = func.clone();
+            async move {
+                Ok::<_, Infallible>(hyper::service::service_fn(move |req| {
+                    let fut = func(req);
+                    async move { Ok::<_, Infallible>(fut.await) }
+                }))
+            }
+        }))
+    };
 
-        Server {
-            addr,
-            panic_rx,
-            shutdown_tx: Some(shutdown_tx),
-        }
-    })
-    .join()
-    .unwrap()
+    let addr = srv.local_addr();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let srv = srv.with_graceful_shutdown(async move {
+        let _ = shutdown_rx.await;
+    });
+
+    let (panic_tx, panic_rx) = std_mpsc::channel();
+    let tname = format!(
+        "test({})-support-server",
+        thread::current().name().unwrap_or("<unknown>")
+    );
+    thread::Builder::new()
+        .name(tname)
+        .spawn(move || {
+            let rt = runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("new rt");
+            rt.block_on(srv).unwrap();
+            let _ = panic_tx.send(());
+        })
+        .expect("thread spawn");
+
+    Server {
+        addr,
+        panic_rx,
+        shutdown_tx: Some(shutdown_tx),
+    }
 }

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -53,7 +53,7 @@ where
         + 'static,
 {
     let srv = {
-        let builder = hyper::Server::bind(&([127, 0, 0, 1], 19999).into());
+        let builder = hyper::Server::bind(&([127, 0, 0, 1], 0).into());
 
         apply_config(builder).serve(hyper::service::make_service_fn(move |_| {
             let func = func.clone();


### PR DESCRIPTION
This patch gets the client to retry HTTP/2 requests rejected with `REFUSED_STREAM` by inspecting the error detail.

I found the issue with highly concurrent requests in HTTP/2 made to the server that is configured to allow the smaller number of concurrent streams. So for example, a client makes, say, 500 concurrent requests to an HTTP/2 server while the server's `max_concurrent_streams` is set to 100. In this case the client is allowed to initiate 500 concurrent streams _until_ the initial `SETTINGS` frame from the server reaches to the client, though the server will reject 400 streams by responding `REFUSED_STREAM`.
From the standpoint of users of `reqwest` crate, I would expect the crate to deal with this kind of situation behind the scenes. Actually, as far as I searched, Go and libcurl provides the retry logic when they encounter `REFUSED_STREAM`. Considering the "ergonomic, batteries-included" characteristic of `reqwest`, I believe automatic retry would be very nice to have.

Here's a repo containing reproducible code written in a couple different languages. It also has `rust-patched` code which demonstrates that this patch does fix the issue.
https://github.com/magurotuna/deno-fetch-h2-stream-error-repro