### PR TITLE
Remove `Sync` bound from `Body::wrap_stream`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ serde_urlencoded = "0.7.1"
 tower-service = "0.3"
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
+sync_wrapper = "0.1.2"
 
 # Optional deps...
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,9 @@ fn _assert_impls() {
 
     assert_send::<Error>();
     assert_sync::<Error>();
+
+    assert_send::<Body>();
+    assert_sync::<Body>();
 }
 
 if_hyper! {


### PR DESCRIPTION
Fixes https://github.com/seanmonstar/reqwest/issues/1969

By using [`SyncWrapper`](https://docs.rs/sync_wrapper/latest/sync_wrapper/struct.SyncWrapper.html) we can avoid requiring `Sync` for the stream passed to `Body::wrap_stream`. This makes it easier to use streams like axum's [`BodyDataStream`](https://docs.rs/axum-core/latest/axum_core/body/struct.BodyDataStream.html).