### PR TITLE
Upgrade h2 version as there is a vulnerability in <0.3.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ mime_guess = { version = "2.0", default-features = false, optional = true }
 encoding_rs = "0.8"
 http-body = "0.4.0"
 hyper = { version = "0.14.21", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
-h2 = "0.3.14"
+h2 = "0.3.24"
 once_cell = "1"
 log = "0.4"
 mime = "0.3.16"


### PR DESCRIPTION
Upgrade `h2` version as <0.3.24 has a vulnerability reported: [RUSTSEC-2024-0003](https://rustsec.org/advisories/RUSTSEC-2024-0003)