### PR TITLE
Upgrading env_logger dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ futures-channel = { version="0.3", optional = true}
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-env_logger = "0.8"
+env_logger = "0.10"
 hyper = { version = "0.14", default-features = false, features = ["tcp", "stream", "http1", "http2", "client", "server", "runtime"] }
 serde = { version = "1.0", features = ["derive"] }
 libflate = "1.0"


### PR DESCRIPTION
[`atty`](https://crates.io/crates/atty) is currently unmaintained and has a potential unsoundness vulnerability: https://rustsec.org/advisories/RUSTSEC-2021-0145

`atty` is used by the following dependency tree:
```
Dependency tree:
atty 0.2.14
└── env_logger 0.8.4
    └── reqwest 0.11.23
```

[`env_logger`](https://crates.io/crates/env_logger) removed the `atty` dependency in the following pull request: https://github.com/rust-cli/env_logger/pull/248

This upgrades `env_logger` to version `^0.10` to resolve the issue.