### PR TITLE
update wasm-streams dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ js-sys = "0.3.45"
 serde_json = "1.0"
 wasm-bindgen = "0.2.68"
 wasm-bindgen-futures = "0.4.18"
-wasm-streams = { version = "0.3", optional = true }
+wasm-streams = { version = "0.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"


### PR DESCRIPTION
This updates the wasm-streams dependencies from 0.3 to 0.4. I verified that it works.