### PR TITLE
Add redirect::Policy::none to wasm client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,7 +206,8 @@ features = [
     "ServiceWorkerGlobalScope",
     "RequestCredentials",
     "File",
-    "ReadableStream"
+    "ReadableStream",
+    "RequestRedirect"
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,7 @@ if_wasm! {
     mod wasm;
     mod util;
 
-    pub use self::wasm::{Body, Client, ClientBuilder, Request, RequestBuilder, Response};
+    pub use self::wasm::{Body, Client, ClientBuilder, Request, RequestBuilder, Response, redirect};
     #[cfg(feature = "multipart")]
     pub use self::wasm::multipart;
 }

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -6,6 +6,7 @@ mod client;
 /// TODO
 #[cfg(feature = "multipart")]
 pub mod multipart;
+pub mod redirect;
 mod request;
 mod response;
 

--- a/src/wasm/redirect.rs
+++ b/src/wasm/redirect.rs
@@ -1,0 +1,41 @@
+//! Redirect Handling
+//!
+//! By default, a `Client` will automatically follow HTTP redirects. To customize this behavior, a
+//! `redirect::Policy` can be used with a `ClientBuilder`.
+
+/// A type that controls the policy on how to handle the following of redirects.
+///
+/// The default value follow redirects https://developer.mozilla.org/en-US/docs/Web/API/Request/redirect
+///
+/// - `none` can be used to disable all redirect behavior. This sets the redirect value to "manual".
+#[derive(Debug, PartialEq, Clone)]
+pub struct Policy {
+    inner: PolicyKind,
+}
+
+impl Policy {
+    /// Create a `Policy` that does not follow any redirect.
+    pub fn none() -> Self {
+        Self {
+            inner: PolicyKind::None,
+        }
+    }
+
+    fn not_set() -> Self {
+        Self {
+            inner: PolicyKind::NotSet,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+enum PolicyKind {
+    None,
+    NotSet,
+}
+
+impl Default for Policy {
+    fn default() -> Policy {
+        Policy::not_set()
+    }
+}


### PR DESCRIPTION
Solves https://github.com/seanmonstar/reqwest/issues/2071

https://developer.mozilla.org/en-US/docs/Web/API/Request/redirect

This PR keeps the default fetch redirect functionality as-is (it doesn't set anything, and therefore "follow" is used).

In order to support "manual", we use the `Policy::none()` interface that does the same thing as the other clients "disables all redirect behaviour".

I deliberately omitted the `error` kind, since no `error` interface existed in the current `redirect::Policy` struct.

Let me know if there's anything else to be improved, thanks!