### PR TITLE
chore: Use edition 2021 panics

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -366,7 +366,7 @@ mod tests {
         // It should have pulled out the original, not nested it...
         match err.inner.kind {
             Kind::Request => (),
-            _ => panic!("{:?}", err),
+            _ => panic!("{err:?}"),
         }
     }
 
@@ -376,7 +376,7 @@ mod tests {
         let err = super::decode_io(orig);
         match err.inner.kind {
             Kind::Decode => (),
-            _ => panic!("{:?}", err),
+            _ => panic!("{err:?}"),
         }
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1202,7 +1202,7 @@ mod tests {
                 assert_eq!(auth.unwrap(), encode_basic_auth("foo", "bar"));
                 assert_eq!(host, "localhost:1239");
             }
-            other => panic!("unexpected: {:?}", other),
+            other => panic!("unexpected: {other:?}"),
         }
     }
 
@@ -1215,7 +1215,7 @@ mod tests {
                 assert!(auth.is_none());
                 assert_eq!(host, "192.168.1.1:8888");
             }
-            other => panic!("unexpected: {:?}", other),
+            other => panic!("unexpected: {other:?}"),
         }
     }
 
@@ -1229,7 +1229,7 @@ mod tests {
                 assert_eq!(auth.unwrap(), encode_basic_auth("foo", "bar"));
                 assert_eq!(host, "localhost:1239");
             }
-            other => panic!("unexpected: {:?}", other),
+            other => panic!("unexpected: {other:?}"),
         }
     }
 
@@ -1791,7 +1791,7 @@ mod test {
         fn check_parse_error(url: &str, needle: url::ParseError) {
             let error = Proxy::http(url).unwrap_err();
             if !includes(&error, needle) {
-                panic!("{:?} expected; {:?}, {} found", needle, error, error);
+                panic!("{needle:?} expected; {error:?}, {error} found");
             }
         }
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -266,14 +266,14 @@ fn test_redirect_policy_limit() {
 
     match policy.check(StatusCode::FOUND, &next, &previous) {
         ActionKind::Follow => (),
-        other => panic!("unexpected {:?}", other),
+        other => panic!("unexpected {other:?}"),
     }
 
     previous.push(Url::parse("http://a.b.d/e/33").unwrap());
 
     match policy.check(StatusCode::FOUND, &next, &previous) {
         ActionKind::Error(err) if err.is::<TooManyRedirects>() => (),
-        other => panic!("unexpected {:?}", other),
+        other => panic!("unexpected {other:?}"),
     }
 }
 
@@ -285,7 +285,7 @@ fn test_redirect_policy_limit_to_0() {
 
     match policy.check(StatusCode::FOUND, &next, &previous) {
         ActionKind::Error(err) if err.is::<TooManyRedirects>() => (),
-        other => panic!("unexpected {:?}", other),
+        other => panic!("unexpected {other:?}"),
     }
 }
 
@@ -302,13 +302,13 @@ fn test_redirect_policy_custom() {
     let next = Url::parse("http://bar/baz").unwrap();
     match policy.check(StatusCode::FOUND, &next, &[]) {
         ActionKind::Follow => (),
-        other => panic!("unexpected {:?}", other),
+        other => panic!("unexpected {other:?}"),
     }
 
     let next = Url::parse("http://foo/baz").unwrap();
     match policy.check(StatusCode::FOUND, &next, &[]) {
         ActionKind::Stop => (),
-        other => panic!("unexpected {:?}", other),
+        other => panic!("unexpected {other:?}"),
     }
 }
 


### PR DESCRIPTION
This will only work after migration to 2021 edition.  See #2023 