### PR TITLE
Move log into a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 ]
 
 [features]
-default = ["default-tls"]
+default = ["default-tls", "log"]
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.
@@ -62,6 +62,8 @@ trust-dns = ["trust-dns-resolver"]
 stream = ["tokio/fs", "tokio-util", "wasm-streams"]
 
 socks = ["tokio-socks"]
+
+log = ["dep:log"]
 
 # Experimental HTTP/3 client.
 http3 = ["rustls-tls-manual-roots", "h3", "h3-quinn", "quinn", "futures-channel"]
@@ -104,7 +106,7 @@ http-body = "0.4.0"
 hyper = { version = "0.14.21", default-features = false, features = ["tcp", "http1", "http2", "client", "runtime"] }
 h2 = "0.3.14"
 once_cell = "1"
-log = "0.4"
+log = { version = "0.4", optional = true }
 mime = "0.3.16"
 percent-encoding = "2.1"
 tokio = { version = "1.0", default-features = false, features = ["net", "time"] }

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -154,6 +154,7 @@ impl Decoder {
     #[cfg(any(feature = "brotli", feature = "gzip", feature = "deflate"))]
     fn detect_encoding(headers: &mut HeaderMap, encoding_str: &str) -> bool {
         use http::header::{CONTENT_ENCODING, CONTENT_LENGTH, TRANSFER_ENCODING};
+        #[cfg(feature = "log")]
         use log::warn;
 
         let mut is_content_encoded = {
@@ -169,6 +170,7 @@ impl Decoder {
         if is_content_encoded {
             if let Some(content_length) = headers.get(CONTENT_LENGTH) {
                 if content_length == "0" {
+                    #[cfg(feature = "log")]
                     warn!("{} response with content-length of 0", encoding_str);
                     is_content_encoded = false;
                 }

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -11,6 +11,7 @@ use connect::H3Connector;
 use futures_util::future;
 use http::{Request, Response};
 use hyper::Body as HyperBody;
+#[cfg(feature = "log")]
 use log::trace;
 use std::future::Future;
 use std::pin::Pin;
@@ -33,10 +34,12 @@ impl H3Client {
 
     async fn get_pooled_client(&mut self, key: Key) -> Result<PoolClient, BoxError> {
         if let Some(client) = self.pool.try_pool(&key) {
+            #[cfg(feature = "log")]
             trace!("getting client from pool with key {:?}", key);
             return Ok(client);
         }
 
+        #[cfg(feature = "log")]
         trace!("did not find connection {:?} in pool so connecting...", key);
 
         let dest = pool::domain_as_uri(key.clone());

--- a/src/blocking/wait.rs
+++ b/src/blocking/wait.rs
@@ -13,6 +13,7 @@ where
     enter();
 
     let deadline = timeout.map(|d| {
+        #[cfg(feature = "log")]
         log::trace!("wait at most {:?}", d);
         Instant::now() + d
     });
@@ -35,10 +36,12 @@ where
         if let Some(deadline) = deadline {
             let now = Instant::now();
             if now >= deadline {
+                #[cfg(feature = "log")]
                 log::trace!("wait timeout exceeded");
                 return Err(Waited::TimedOut(crate::error::TimedOut));
             }
 
+            #[cfg(feature = "log")]
             log::trace!(
                 "({:?}) park timeout {:?}",
                 thread::current().id(),
@@ -46,6 +49,7 @@ where
             );
             thread::park_timeout(deadline - now);
         } else {
+            #[cfg(feature = "log")]
             log::trace!("({:?}) park without timeout", thread::current().id());
             thread::park();
         }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -898,6 +898,7 @@ fn get_from_environment() -> SystemProxyMap {
     let mut proxies = HashMap::new();
 
     if is_cgi() {
+        #[cfg(feature = "log")]
         if log::log_enabled!(log::Level::Warn) && env::var_os("HTTP_PROXY").is_some() {
             log::warn!("HTTP_PROXY environment variable ignored in CGI");
         }


### PR DESCRIPTION
Within my application, I don't want `reqwest`'s logs to show at all. While I could use a more sophisticated logger and filter out all logs coming from `reqwest`, I believe adding `log` behind a feature flag would be the easiest way.