### PR TITLE
tls: fix from_pem_bundle method (#2125)

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -163,7 +163,7 @@ impl Certificate {
 
         Self::read_pem_certs(&mut reader)?
             .iter()
-            .map(|cert_vec| Certificate::from_pem(&cert_vec))
+            .map(|cert_vec| Certificate::from_der(&cert_vec))
             .collect::<crate::Result<Vec<Certificate>>>()
     }
 


### PR DESCRIPTION
the rustls_pemfile::certs method inside it returns der encoded certificate so use correct certificate constructor for that.