### PR TITLE
chore: Update `system-configuration` to `v0.6`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ futures-util = { version = "0.3.0", default-features = false, features = ["std",
 winreg = "0.50.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-system-configuration = "0.5.1"
+system-configuration = "0.6"
 
 # wasm
 


### PR DESCRIPTION
This patch relates to #2006 . An update to `system-configuration` that alleges to fix the underlying problem has landed: https://github.com/mullvad/system-configuration-rs/issues/41#issuecomment-1919130676

This change bumps the `system-configuration` version. Preliminary local tests suggest this may fix #2006 .