### PR TITLE
Show timeout duration in error messages

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1864,6 +1864,7 @@ impl Client {
 
                 in_flight,
                 timeout,
+                timeout_duration: self.inner.request_timeout,
             }),
         }
     }
@@ -2131,6 +2132,7 @@ pin_project! {
         in_flight: ResponseFuture,
         #[pin]
         timeout: Option<Pin<Box<Sleep>>>,
+        timeout_duration: Option<Duration>,
     }
 }
 
@@ -2275,7 +2277,7 @@ impl Future for PendingRequest {
         if let Some(delay) = self.as_mut().timeout().as_mut().as_pin_mut() {
             if let Poll::Ready(()) = delay.poll(cx) {
                 return Poll::Ready(Err(
-                    crate::error::request(crate::error::TimedOut).with_url(self.url.clone())
+                    crate::error::request(crate::error::TimedOut(self.timeout_duration.unwrap())).with_url(self.url.clone())
                 ));
             }
         }
@@ -2463,7 +2465,7 @@ impl Future for PendingRequest {
                 res,
                 self.url.clone(),
                 self.client.accepts,
-                self.timeout.take(),
+                self.timeout.take().map(|timeoout| (timeoout, self.timeout_duration.unwrap())),
             );
             return Poll::Ready(Ok(res));
         }

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::time::Duration;
 
 use bytes::Bytes;
 use encoding_rs::{Encoding, UTF_8};
@@ -34,7 +35,7 @@ impl Response {
         res: hyper::Response<hyper::Body>,
         url: Url,
         accepts: Accepts,
-        timeout: Option<Pin<Box<Sleep>>>,
+        timeout: Option<(Pin<Box<Sleep>>, Duration)>,
     ) -> Response {
         let (mut parts, body) = res.into_parts();
         let decoder = Decoder::detect(&mut parts.headers, Body::response(body, timeout), accepts);

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -427,7 +427,7 @@ where
 {
     if let Some(to) = timeout {
         match tokio::time::timeout(to, f).await {
-            Err(_elapsed) => Err(Box::new(crate::error::TimedOut) as BoxError),
+            Err(_elapsed) => Err(Box::new(crate::error::TimedOut(to)) as BoxError),
             Ok(Ok(try_res)) => Ok(try_res),
             Ok(Err(e)) => Err(e),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
+use std::time::Duration;
 
 use crate::{StatusCode, Url};
 
@@ -311,11 +312,11 @@ pub(crate) fn decode_io(e: io::Error) -> Error {
 // internal Error "sources"
 
 #[derive(Debug)]
-pub(crate) struct TimedOut;
+pub(crate) struct TimedOut(pub(crate) Duration);
 
 impl fmt::Display for TimedOut {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("operation timed out")
+        write!(f, "operation timed out ({}s)", self.0.as_secs_f32())
     }
 }
 


### PR DESCRIPTION
Proof of concept to add the timeout duration to the error message. This helps users understand why the operation failed. Are you interested in such a change? In this case i would polish the code to make it ready to be reviewed and merged.

Before:

```
💥 my-app failed
  Caused by: Network request failed
  Caused by: error sending request for url (https://httpbin.org/): operation timed out
  Caused by: operation timed out
```

After:

```
💥 my-app failed
  Caused by: Network request failed
  Caused by: request or response body error: operation timed out (2s)
  Caused by: operation timed out (2s)
 ```