### PR TITLE
Fix missing tokio/io-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ socks = ["tokio-socks"]
 # Don't rely on these whatsoever. They may disappear at anytime.
 
 # Enables common types used for TLS. Useless on its own.
-__tls = ["dep:rustls-pemfile"]
+__tls = ["dep:rustls-pemfile", "tokio/io-util"]
 
 # Enables common rustls code.
 # Equivalent to rustls-tls-manual-roots but shorter :)


### PR DESCRIPTION
https://github.com/seanmonstar/reqwest/blob/037111f2fbd471e9c3c5b3815a5b10283b2729af/src/connect.rs#L756

This read needs the feature `tokio/io-util`. So `__tls` feature needs `tokio/io-util`