### PR TITLE
fix extraction of server certificate out of rustls connection

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -573,8 +573,7 @@ impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::n
             .1
             .peer_certificates()
             .and_then(|certs| certs.first())
-            .map(|c| c.first())
-            .and_then(|c| c.map(|cc| vec![*cc]));
+            .map(|c| c.to_vec());
         Some(crate::tls::TlsInfo { peer_certificate })
     }
 }
@@ -591,8 +590,7 @@ impl TlsInfoFactory
             .1
             .peer_certificates()
             .and_then(|certs| certs.first())
-            .map(|c| c.first())
-            .and_then(|c| c.map(|cc| vec![*cc]));
+            .map(|c| c.to_vec());
         Some(crate::tls::TlsInfo { peer_certificate })
     }
 }


### PR DESCRIPTION
In `reqwest@0.12` with `rustls` the `TlsInfo.peer_certificate()` returns only first 2 bytes of server's TLS certificate. This PR fixes extraction of the first TLS certificate out of the rustls connection.