### PR TITLE
fix: Display for Error shouldn't include source

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -206,10 +206,6 @@ impl fmt::Display for Error {
             write!(f, " for url ({url})")?;
         }
 
-        if let Some(e) = &self.inner.source {
-            write!(f, ": {e}")?;
-        }
-
         Ok(())
     }
 }

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -84,13 +84,14 @@ if_hyper! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error;
 
     #[test]
     fn into_url_file_scheme() {
         let err = "file:///etc/hosts".into_url().unwrap_err();
         assert_eq!(
-            err.to_string(),
-            "builder error for url (file:///etc/hosts): URL scheme is not allowed"
+            err.source().unwrap().to_string(),
+            "URL scheme is not allowed"
         );
     }
 
@@ -98,8 +99,8 @@ mod tests {
     fn into_url_blob_scheme() {
         let err = "blob:https://example.com".into_url().unwrap_err();
         assert_eq!(
-            err.to_string(),
-            "builder error for url (blob:https://example.com): URL scheme is not allowed"
+            err.source().unwrap().to_string(),
+            "URL scheme is not allowed"
         );
     }
 


### PR DESCRIPTION
This was _supposed_ to be in 0.12 and forgotten. Getting it into 0.12.1 just a couple days after should be early enough.