### PR TITLE
Remove the need for sync on stream methods

### DIFF
--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 
 use bytes::Bytes;
 use http_body::Body as HttpBody;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 //use sync_wrapper::SyncWrapper;
 #[cfg(feature = "stream")]
 use tokio::fs::File;
@@ -20,7 +20,7 @@ pub struct Body {
 
 enum Inner {
     Reusable(Bytes),
-    Streaming(BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>),
+    Streaming(UnsyncBoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>),
 }
 
 /// A body with a total timeout.
@@ -73,7 +73,7 @@ impl Body {
     #[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
     pub fn wrap_stream<S>(stream: S) -> Body
     where
-        S: futures_core::stream::TryStream + Send + Sync + 'static,
+        S: futures_core::stream::TryStream + Send + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         Bytes: From<S::Ok>,
     {
@@ -83,7 +83,7 @@ impl Body {
     #[cfg(any(feature = "stream", feature = "multipart", feature = "blocking"))]
     pub(crate) fn stream<S>(stream: S) -> Body
     where
-        S: futures_core::stream::TryStream + Send + Sync + 'static,
+        S: futures_core::stream::TryStream + Send + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
         Bytes: From<S::Ok>,
     {
@@ -91,7 +91,7 @@ impl Body {
         use http_body::Frame;
         use http_body_util::StreamBody;
 
-        let body = http_body_util::BodyExt::boxed(StreamBody::new(
+        let body = http_body_util::BodyExt::boxed_unsync(StreamBody::new(
             stream
                 .map_ok(|d| Frame::data(Bytes::from(d)))
                 .map_err(Into::into),
@@ -125,7 +125,7 @@ impl Body {
     // pub?
     pub(crate) fn streaming<B>(inner: B) -> Body
     where
-        B: HttpBody + Send + Sync + 'static,
+        B: HttpBody + Send + 'static,
         B::Data: Into<Bytes>,
         B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
@@ -134,7 +134,7 @@ impl Body {
         let boxed = inner
             .map_frame(|f| f.map_data(Into::into))
             .map_err(Into::into)
-            .boxed();
+            .boxed_unsync();
 
         Body {
             inner: Inner::Streaming(boxed),
@@ -309,7 +309,7 @@ where
 }
 
 pub(crate) type ResponseBody =
-    http_body_util::combinators::BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
+    http_body_util::combinators::UnsyncBoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
 
 pub(crate) fn response(
     body: hyper::body::Incoming,
@@ -318,9 +318,9 @@ pub(crate) fn response(
     use http_body_util::BodyExt;
 
     if let Some(timeout) = timeout {
-        total_timeout(body, timeout).map_err(Into::into).boxed()
+        total_timeout(body, timeout).map_err(Into::into).boxed_unsync()
     } else {
-        body.map_err(Into::into).boxed()
+        body.map_err(Into::into).boxed_unsync()
     }
 }
 

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -299,8 +299,8 @@ impl HttpBody for Decoder {
 }
 
 fn empty() -> ResponseBody {
-    use http_body_util::{combinators::BoxBody, BodyExt, Empty};
-    BoxBody::new(Empty::new().map_err(|never| match never {}))
+    use http_body_util::{combinators::UnsyncBoxBody, BodyExt, Empty};
+    UnsyncBoxBody::new(Empty::new().map_err(|never| match never {}))
 }
 
 impl Future for Pending {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,6 @@ fn _assert_impls() {
     assert_sync::<Error>();
 
     assert_send::<Body>();
-    assert_sync::<Body>();
 }
 
 if_hyper! {


### PR DESCRIPTION
This makes reqwest body stream compatible with Axum body stream.