### PR TITLE
Safer instantiation for preconfigured nativetls and rustls backends

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1516,6 +1516,21 @@ impl ClientBuilder {
         self
     }
 
+    /// Use a preconfigured native TLS backend.
+    ///
+    /// Since multiple TLS backends can be optionally enabled, this option will
+    /// force the `native-tls` backend to be used for this `Client`.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `native-tls` feature to be enabled.
+    #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
+    pub fn use_preconfigured_native_tls(mut self, tls: TlsConnector) -> ClientBuilder {
+        self.config.tls = TlsBackend::BuiltNativeTls(tls);
+        self
+    }
+
     /// Force using the Rustls TLS backend.
     ///
     /// Since multiple TLS backends can be optionally enabled, this option will
@@ -1528,6 +1543,21 @@ impl ClientBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     pub fn use_rustls_tls(mut self) -> ClientBuilder {
         self.config.tls = TlsBackend::Rustls;
+        self
+    }
+
+    /// Use a preconfigured Rustls TLS backend.
+    ///
+    /// Since multiple TLS backends can be optionally enabled, this option will
+    /// force the `rustls` backend to be used for this `Client`.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `rustls-tls(-...)` feature to be enabled.
+    #[cfg(feature = "__rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    pub fn use_preconfigured_rustls_tls(mut self, tls: rustls::ClientConfig) -> ClientBuilder {
+        self.config.tls = TlsBackend::BuiltRustls(tls);
         self
     }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1521,6 +1521,15 @@ impl ClientBuilder {
     /// Since multiple TLS backends can be optionally enabled, this option will
     /// force the `native-tls` backend to be used for this `Client`.
     ///
+    /// # Advanced
+    ///
+    /// This is an advanced option, and can be somewhat brittle. Usage requires
+    /// keeping the preconfigured TLS argument version in sync with reqwest,
+    /// since version mismatches will result in an "unknown" TLS backend.
+    ///
+    /// If possible, it's preferable to use the methods on `ClientBuilder`
+    /// to configure reqwest's TLS.
+    ///
     /// # Optional
     ///
     /// This requires the optional `native-tls` feature to be enabled.
@@ -1550,6 +1559,15 @@ impl ClientBuilder {
     ///
     /// Since multiple TLS backends can be optionally enabled, this option will
     /// force the `rustls` backend to be used for this `Client`.
+    ///
+    /// # Advanced
+    ///
+    /// This is an advanced option, and can be somewhat brittle. Usage requires
+    /// keeping the preconfigured TLS argument version in sync with reqwest,
+    /// since version mismatches will result in an "unknown" TLS backend.
+    ///
+    /// If possible, it's preferable to use the methods on `ClientBuilder`
+    /// to configure reqwest's TLS.
     ///
     /// # Optional
     ///

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1581,6 +1581,7 @@ impl ClientBuilder {
     /// `rustls-tls(-...)` to be enabled.
     #[cfg(any(feature = "native-tls", feature = "__rustls",))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
+    #[deprecated(note = "use `use_preconfigured_native_tls` or `use_preconfigured_rustls_tls` instead", since = "0.13.0")]
     pub fn use_preconfigured_tls(mut self, tls: impl Any) -> ClientBuilder {
         let mut tls = Some(tls);
         #[cfg(feature = "native-tls")]

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -757,6 +757,20 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.use_native_tls())
     }
 
+    /// Use a preconfigured native TLS backend.
+    ///
+    /// Since multiple TLS backends can be optionally enabled, this option will
+    /// force the `native-tls` backend to be used for this `Client`.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `native-tls` feature to be enabled.
+    #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
+    pub fn use_preconfigured_native_tls(self, tls: native_tls_crate::TlsConnector) -> ClientBuilder {
+        self.with_inner(move |inner| inner.use_preconfigured_native_tls(tls))
+    }
+
     /// Force using the Rustls TLS backend.
     ///
     /// Since multiple TLS backends can be optionally enabled, this option will
@@ -769,6 +783,20 @@ impl ClientBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     pub fn use_rustls_tls(self) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_rustls_tls())
+    }
+
+    /// Use a preconfigured Rustls TLS backend.
+    ///
+    /// Since multiple TLS backends can be optionally enabled, this option will
+    /// force the `rustls` backend to be used for this `Client`.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `rustls-tls(-...)` feature to be enabled.
+    #[cfg(feature = "__rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    pub fn use_preconfigured_rustls_tls(self, tls: rustls::ClientConfig) -> ClientBuilder {
+        self.with_inner(move |inner| inner.use_preconfigured_rustls_tls(tls))
     }
 
     /// Add TLS information as `TlsInfo` extension to responses.

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -838,7 +838,9 @@ impl ClientBuilder {
     /// `rustls-tls(-...)` to be enabled.
     #[cfg(any(feature = "native-tls", feature = "__rustls",))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
+    #[deprecated(note = "use `use_preconfigured_native_tls` or `use_preconfigured_rustls_tls` instead", since = "0.13.0")]
     pub fn use_preconfigured_tls(self, tls: impl Any) -> ClientBuilder {
+        #[allow(deprecated)]
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))
     }
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -762,6 +762,15 @@ impl ClientBuilder {
     /// Since multiple TLS backends can be optionally enabled, this option will
     /// force the `native-tls` backend to be used for this `Client`.
     ///
+    /// # Advanced
+    ///
+    /// This is an advanced option, and can be somewhat brittle. Usage requires
+    /// keeping the preconfigured TLS argument version in sync with reqwest,
+    /// since version mismatches will result in an "unknown" TLS backend.
+    ///
+    /// If possible, it's preferable to use the methods on `ClientBuilder`
+    /// to configure reqwest's TLS.
+    ///
     /// # Optional
     ///
     /// This requires the optional `native-tls` feature to be enabled.
@@ -789,6 +798,15 @@ impl ClientBuilder {
     ///
     /// Since multiple TLS backends can be optionally enabled, this option will
     /// force the `rustls` backend to be used for this `Client`.
+    ///
+    /// # Advanced
+    ///
+    /// This is an advanced option, and can be somewhat brittle. Usage requires
+    /// keeping the preconfigured TLS argument version in sync with reqwest,
+    /// since version mismatches will result in an "unknown" TLS backend.
+    ///
+    /// If possible, it's preferable to use the methods on `ClientBuilder`
+    /// to configure reqwest's TLS.
     ///
     /// # Optional
     ///

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -326,7 +326,7 @@ fn use_preconfigured_tls_with_bogus_backend() {
 
 #[cfg(feature = "native-tls")]
 #[test]
-fn use_preconfigured_native_tls_default() {
+fn use_preconfigured_native_tls_dynamic_default() {
     extern crate native_tls_crate;
 
     let tls = native_tls_crate::TlsConnector::builder()
@@ -337,6 +337,37 @@ fn use_preconfigured_native_tls_default() {
         .use_preconfigured_tls(tls)
         .build()
         .expect("preconfigured default tls");
+}
+
+#[cfg(feature = "native-tls")]
+#[test]
+fn use_preconfigured_native_tls_default() {
+    extern crate native_tls_crate;
+
+    let tls = native_tls_crate::TlsConnector::builder()
+        .build()
+        .expect("tls builder");
+
+    reqwest::Client::builder()
+        .use_preconfigured_native_tls(tls)
+        .build()
+        .expect("preconfigured default tls");
+}
+
+#[cfg(feature = "__rustls")]
+#[test]
+fn use_preconfigured_rustls_dynamic_default() {
+    extern crate rustls;
+
+    let root_cert_store = rustls::RootCertStore::empty();
+    let tls = rustls::ClientConfig::builder()
+        .with_root_certificates(root_cert_store)
+        .with_no_client_auth();
+
+    reqwest::Client::builder()
+        .use_preconfigured_tls(tls)
+        .build()
+        .expect("preconfigured rustls tls");
 }
 
 #[cfg(feature = "__rustls")]
@@ -350,7 +381,7 @@ fn use_preconfigured_rustls_default() {
         .with_no_client_auth();
 
     reqwest::Client::builder()
-        .use_preconfigured_tls(tls)
+        .use_preconfigured_rustls_tls(tls)
         .build()
         .expect("preconfigured rustls tls");
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -318,6 +318,7 @@ async fn overridden_dns_resolution_with_hickory_dns_multiple() {
 fn use_preconfigured_tls_with_bogus_backend() {
     struct DefinitelyNotTls;
 
+    #[allow(deprecated)]
     reqwest::Client::builder()
         .use_preconfigured_tls(DefinitelyNotTls)
         .build()
@@ -333,6 +334,7 @@ fn use_preconfigured_native_tls_dynamic_default() {
         .build()
         .expect("tls builder");
 
+    #[allow(deprecated)]
     reqwest::Client::builder()
         .use_preconfigured_tls(tls)
         .build()
@@ -364,6 +366,7 @@ fn use_preconfigured_rustls_dynamic_default() {
         .with_root_certificates(root_cert_store)
         .with_no_client_auth();
 
+    #[allow(deprecated)]
     reqwest::Client::builder()
         .use_preconfigured_tls(tls)
         .build()


### PR DESCRIPTION
I believe the current `use_preconfigured_tls` can be replaced by much simpler `use_preconfigured_native_tls` and `use_preconfigured_rustls_tls` that can give compile time type warnings.

Is there a reason for using `Any` types?

- [x] Tests for `use_preconfigured_native_tls` and `use_preconfigured_rustls_tls`.
- [x] Add deprecation warnings for `use_preconfigured_tls`.