### PR TITLE
Upgrade to hyper-rustls 0.27/rustls 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -715,12 +715,12 @@
   - Timeouts now affect DNS and socket connection.
   - Pool much better at evicting sockets when they die.
   - An `unstable` Cargo feature to enable `reqwest::unstable::async`.
-- A huge docs improvement! 
+- A huge docs improvement!
 
 ### Fixes
 
 - Publicly exports `RedirectAction` and `RedirectAttempt`
-- `Error::get_ref` returns `Error + Send + Sync`  
+- `Error::get_ref` returns `Error + Send + Sync`
 
 ### Breaking Changes
 
@@ -789,7 +789,7 @@
 
 ### Breaking Changes
 
-The only breaking change is a behavioral one, all programs should still compile without modification. The automatic GZIP decoding could interfere in cases where a user was expecting the GZIP bytes, either to save to a file or decode themselves. To restore this functionality, set `client.gzip(false)`. 
+The only breaking change is a behavioral one, all programs should still compile without modification. The automatic GZIP decoding could interfere in cases where a user was expecting the GZIP bytes, either to save to a file or decode themselves. To restore this functionality, set `client.gzip(false)`.
 
 # v0.4.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,13 @@ native-tls-alpn = ["native-tls", "native-tls-crate?/alpn", "hyper-tls?/alpn"]
 native-tls-vendored = ["native-tls", "native-tls-crate?/vendored"]
 
 rustls-tls = ["rustls-tls-webpki-roots"]
-rustls-tls-manual-roots = ["__rustls"]
-rustls-tls-webpki-roots = ["dep:webpki-roots", "__rustls"]
-rustls-tls-native-roots = ["dep:rustls-native-certs", "__rustls"]
+rustls-tls-manual-roots = ["__rustls_crypto_ring"]
+rustls-tls-webpki-roots = ["__rustls_roots_webpki", "__rustls_crypto_ring"]
+rustls-tls-native-roots = ["__rustls_roots_native", "__rustls_crypto_ring"]
+rustls-tls-aws-lc-manual-roots = ["__rustls_crypto_aws_lc"]
+rustls-tls-aws-lc-webpki-roots = ["__rustls_roots_webpki", "__rustls_crypto_aws_lc"]
+rustls-tls-aws-lc-native-roots = ["__rustls_roots_native", "__rustls_crypto_aws_lc"]
+rustls-base = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls", "rustls-pki-types"]
 
 blocking = ["futures-channel/sink", "futures-util/io", "futures-util/sink", "tokio/sync"]
 
@@ -84,9 +88,13 @@ macos-system-configuration = ["dep:system-configuration"]
 # Enables common types used for TLS. Useless on its own.
 __tls = ["dep:rustls-pemfile", "tokio/io-util"]
 
-# Enables common rustls code.
-# Equivalent to rustls-tls-manual-roots but shorter :)
-__rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls", "dep:rustls-pemfile", "rustls-pki-types"]
+# Provide common feature flags along two axes:
+# - crypto provider: ring or aws-lc
+# - root certificate provider: webpki-roots or rustls-native-certs
+__rustls_roots_webpki = ["dep:webpki-roots"]
+__rustls_roots_native = ["dep:rustls-native-certs"]
+__rustls_crypto_ring = ["rustls-base", "rustls/ring"]
+__rustls_crypto_aws_lc = ["rustls-base", "rustls/aws_lc_rs"]
 
 # When enabled, disable using the cached SYS_PROXIES.
 __internal_proxy_sys_no_cache = []
@@ -134,10 +142,10 @@ native-tls-crate = { version = "0.2.10", optional = true, package = "native-tls"
 tokio-native-tls = { version = "0.3.0", optional = true }
 
 # rustls-tls
-hyper-rustls = { version = "0.26.0", default-features = false, optional = true }
-rustls = { version = "0.22.2", optional = true }
-rustls-pki-types = { version = "1.1.0", features = ["alloc"] ,optional = true }
-tokio-rustls = { version = "0.25", optional = true }
+hyper-rustls = { version = "0.27", default-features = false, optional = true, features = ["http1", "http2", "logging", "native-tokio", "ring", "tls12"] }
+rustls = { version = "0.23.4", default-features = false, features = ["logging", "std", "tls12"], optional = true }
+rustls-pki-types = { version = "1.1.0", features = ["alloc"], optional = true }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"], optional = true }
 webpki-roots = { version = "0.26.0", optional = true }
 rustls-native-certs = { version = "0.7", optional = true }
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "native-tls", feature = "__rustls",))]
+#[cfg(any(feature = "native-tls", feature = "rustls-base",))]
 use std::any::Any;
 use std::convert::TryInto;
 use std::fmt;
@@ -21,7 +21,7 @@ use crate::dns::Resolve;
 use crate::tls;
 #[cfg(feature = "__tls")]
 use crate::Certificate;
-#[cfg(any(feature = "native-tls", feature = "__rustls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls-base"))]
 use crate::Identity;
 use crate::{async_impl, header, redirect, IntoUrl, Method, Proxy};
 
@@ -630,8 +630,8 @@ impl ClientBuilder {
     /// Sets whether to load webpki root certs with rustls.
     ///
     /// If the feature is enabled, this value is `true` by default.
-    #[cfg(feature = "rustls-tls-webpki-roots")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls-webpki-roots")))]
+    #[cfg(feature = "__rustls_roots_webpki")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "__rustls_roots_webpki")))]
     pub fn tls_built_in_webpki_certs(self, enabled: bool) -> ClientBuilder {
         self.with_inner(move |inner| inner.tls_built_in_webpki_certs(enabled))
     }
@@ -639,8 +639,8 @@ impl ClientBuilder {
     /// Sets whether to load native root certs with rustls.
     ///
     /// If the feature is enabled, this value is `true` by default.
-    #[cfg(feature = "rustls-tls-native-roots")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls-native-roots")))]
+    #[cfg(feature = "__rustls_roots_native")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "__rustls_roots_native")))]
     pub fn tls_built_in_native_certs(self, enabled: bool) -> ClientBuilder {
         self.with_inner(move |inner| inner.tls_built_in_native_certs(enabled))
     }
@@ -651,7 +651,7 @@ impl ClientBuilder {
     ///
     /// This requires the optional `native-tls` or `rustls-tls(-...)` feature to be
     /// enabled.
-    #[cfg(any(feature = "native-tls", feature = "__rustls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-base"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
     pub fn identity(self, identity: Identity) -> ClientBuilder {
         self.with_inner(move |inner| inner.identity(identity))
@@ -795,7 +795,7 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// This requires the optional `rustls-tls(-...)` feature to be enabled.
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "rustls-base")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     pub fn use_rustls_tls(self) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_rustls_tls())
@@ -838,7 +838,7 @@ impl ClientBuilder {
     ///
     /// This requires one of the optional features `native-tls` or
     /// `rustls-tls(-...)` to be enabled.
-    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-base",))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
     pub fn use_preconfigured_tls(self, tls: impl Any) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 #[cfg(feature = "default-tls")]
 use self::native_tls_conn::NativeTlsConn;
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-base")]
 use self::rustls_tls_conn::RustlsTlsConn;
 use crate::dns::DynResolver;
 use crate::error::BoxError;
@@ -49,7 +49,7 @@ enum Inner {
     Http(HttpConnector),
     #[cfg(feature = "default-tls")]
     DefaultTls(HttpConnector, TlsConnector),
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "rustls-base")]
     RustlsTls {
         http: HttpConnector,
         tls: Arc<rustls::ClientConfig>,
@@ -148,7 +148,7 @@ impl Connector {
         }
     }
 
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "rustls-base")]
     pub(crate) fn new_rustls_tls<T>(
         mut http: HttpConnector,
         tls: rustls::ClientConfig,
@@ -235,7 +235,7 @@ impl Connector {
                     });
                 }
             }
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "rustls-base")]
             Inner::RustlsTls { tls, .. } => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     use std::convert::TryFrom;
@@ -321,7 +321,7 @@ impl Connector {
                     })
                 }
             }
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "rustls-base")]
             Inner::RustlsTls { http, tls, .. } => {
                 let mut http = http.clone();
 
@@ -405,7 +405,7 @@ impl Connector {
                     });
                 }
             }
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "rustls-base")]
             Inner::RustlsTls {
                 http,
                 tls,
@@ -451,7 +451,7 @@ impl Connector {
         match &mut self.inner {
             #[cfg(feature = "default-tls")]
             Inner::DefaultTls(http, _tls) => http.set_keepalive(dur),
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "rustls-base")]
             Inner::RustlsTls { http, .. } => http.set_keepalive(dur),
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => http.set_keepalive(dur),
@@ -571,7 +571,7 @@ impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStrea
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-base")]
 impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::net::TcpStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
@@ -584,7 +584,7 @@ impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::n
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-base")]
 impl TlsInfoFactory
     for tokio_rustls::client::TlsStream<
         TokioIo<hyper_rustls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>>>,
@@ -601,7 +601,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-base")]
 impl TlsInfoFactory for hyper_rustls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         match self {
@@ -910,7 +910,7 @@ mod native_tls_conn {
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-base")]
 mod rustls_tls_conn {
     use super::TlsInfoFactory;
     use hyper::rt::{Read, ReadBufCursor, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,14 +184,26 @@
 //! - **native-tls**: Enables TLS functionality provided by `native-tls`.
 //! - **native-tls-vendored**: Enables the `vendored` feature of `native-tls`.
 //! - **native-tls-alpn**: Enables the `alpn` feature of `native-tls`.
-//! - **rustls-tls**: Enables TLS functionality provided by `rustls`.
-//!   Equivalent to `rustls-tls-webpki-roots`.
-//! - **rustls-tls-manual-roots**: Enables TLS functionality provided by `rustls`,
-//!   without setting any root certificates. Roots have to be specified manually.
-//! - **rustls-tls-webpki-roots**: Enables TLS functionality provided by `rustls`,
-//!   while using root certificates from the `webpki-roots` crate.
-//! - **rustls-tls-native-roots**: Enables TLS functionality provided by `rustls`,
-//!   while using root certificates from the `rustls-native-certs` crate.
+//! - **rustls-tls**: Enables TLS functionality provided by `rustls` with the
+//!   ring crypto provider. Equivalent to `rustls-tls-webpki-roots`.
+//! - **rustls-tls-manual-roots**: Enables TLS functionality provided by `rustls`
+//!   with the ring crypto provider, without setting any root certificates. Roots
+//!   have to be specified manually.
+//! - **rustls-tls-webpki-roots**: Enables TLS functionality provided by `rustls`
+//!   with the ring crypto provider, while using root certificates from the
+//!   `webpki-roots` crate.
+//! - **rustls-tls-native-roots**: Enables TLS functionality provided by `rustls`
+//!   with the ring crypto provider, while using root certificates from the
+//!   `rustls-native-certs` crate.
+//! - **rustls-tls-aws-lc-manual-roots**: Enables TLS functionality provided by `rustls`
+//!   with the aws-lc-rs crypto provider, without setting any root certificates. Roots
+//!   have to be specified manually.
+//! - **rustls-tls-aws-lc-webpki-roots**: Enables TLS functionality provided by `rustls`
+//!   with the aws-lc-rs crypto provider, while using root certificates from the
+//!   `webpki-roots` crate.
+//! - **rustls-tls-aws-lc-native-roots**: Enables TLS functionality provided by `rustls`
+//!   with the aws-lc-rs crypto provider, while using root certificates from the
+//!   `rustls-native-certs` crate.
 //! - **blocking**: Provides the [blocking][] client API.
 //! - **charset** *(enabled by default)*: Improved support for decoding text.
 //! - **cookies**: Provides cookie session support.

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -18,10 +18,7 @@ async fn test_badssl_modern() {
     assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
 }
 
-#[cfg(any(
-    feature = "rustls-tls-webpki-roots",
-    feature = "rustls-tls-native-roots"
-))]
+#[cfg(any(feature = "__rustls_roots_webpki", feature = "__rustls_roots_native"))]
 #[tokio::test]
 async fn test_rustls_badssl_modern() {
     let text = reqwest::Client::builder()

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -319,7 +319,7 @@ async fn overridden_dns_resolution_with_hickory_dns_multiple() {
     assert_eq!("Hello", text);
 }
 
-#[cfg(any(feature = "native-tls", feature = "__rustls",))]
+#[cfg(any(feature = "native-tls", feature = "rustls-base",))]
 #[test]
 fn use_preconfigured_tls_with_bogus_backend() {
     struct DefinitelyNotTls;
@@ -345,7 +345,7 @@ fn use_preconfigured_native_tls_default() {
         .expect("preconfigured default tls");
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-base")]
 #[test]
 fn use_preconfigured_rustls_default() {
     extern crate rustls;
@@ -361,7 +361,7 @@ fn use_preconfigured_rustls_default() {
         .expect("preconfigured rustls tls");
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-base")]
 #[tokio::test]
 #[ignore = "Needs TLS support in the test server"]
 async fn http2_upgrade() {

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -348,7 +348,7 @@ async fn test_redirect_302_with_set_cookies() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-base")]
 #[tokio::test]
 #[ignore = "Needs TLS support in the test server"]
 async fn test_redirect_https_only_enforced_gh1312() {


### PR DESCRIPTION
Sticks with *ring* as the default crypto provider for rustls for now (see #2136).

This is also a prerequisite for re-enabling a Quinn-based H3 backend, since Quinn is skipping rustls 0.22.