### PR TITLE
chore: remove unused sync_wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,6 @@ serde_urlencoded = "0.7.1"
 tower-service = "0.3"
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
-sync_wrapper = "0.1.2"
 
 # Optional deps...
 


### PR DESCRIPTION
`sync_wrapper` crate seems not to be used.