### PR TITLE
Refactor IntoProxyScheme, Escape, fix all clippy warnings

### DIFF
--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -437,6 +437,7 @@ impl Accepts {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for Accepts {
     fn default() -> Accepts {
         Accepts {

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1220,11 +1220,11 @@ mod verbose {
 
                 match c {
                     b'\\' => f.write_str("\\\\"),
-                    b'"' => f.write_str("\\\""), 
                     b'\n' => f.write_str("\\n"),
                     b'\r' => f.write_str("\\r"),
                     b'\t' => f.write_str("\\t"),
                     b'\0' => f.write_str("\\0"),
+                    b'"' => f.write_str("\\\""), 
 
                     // ASCII-printable range, no need to escape it if it's not anything above.
                     0x20..=0x7f => f.write_char(c as char),

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1223,7 +1223,7 @@ mod verbose {
                     b'\r' => write!(f, "\\r"),
                     b'\t' => write!(f, "\\t"),
                     b'\0' => write!(f, "\\0"),
-                    b'"' => write!(f, "\\\""), 
+                    b'"' => write!(f, "\\\""),
 
                     // ASCII-printable range, no need to escape it if it's not anything above.
                     0x20..=0x7f => write!(f, "{}", c as char),

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::too_many_arguments)]
 #[cfg(feature = "__tls")]
 use http::header::HeaderValue;
 use http::uri::{Authority, Scheme};
@@ -1209,30 +1210,30 @@ mod verbose {
         }
     }
 
+    use std::fmt::Write as _;
     struct Escape<'a>(&'a [u8]);
-
     impl fmt::Debug for Escape<'_> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "b\"")?;
             for &c in self.0 {
                 // https://doc.rust-lang.org/reference.html#byte-escapes
-                if c == b'\n' {
-                    write!(f, "\\n")?;
-                } else if c == b'\r' {
-                    write!(f, "\\r")?;
-                } else if c == b'\t' {
-                    write!(f, "\\t")?;
-                } else if c == b'\\' || c == b'"' {
-                    write!(f, "\\{}", c as char)?;
-                } else if c == b'\0' {
-                    write!(f, "\\0")?;
-                // ASCII printable
-                } else if c >= 0x20 && c < 0x7f {
-                    write!(f, "{}", c as char)?;
-                } else {
-                    write!(f, "\\x{c:02x}")?;
-                }
+
+                match c {
+                    b'\\' => f.write_str("\\\\"),
+                    b'"' => f.write_str("\\\""), 
+                    b'\n' => f.write_str("\\n"),
+                    b'\r' => f.write_str("\\r"),
+                    b'\t' => f.write_str("\\t"),
+                    b'\0' => f.write_str("\\0"),
+
+                    // ASCII-printable range, no need to escape it if it's not anything above.
+                    0x20..=0x7f => f.write_char(c as char),
+
+                    // Anything else should be a hex escape.
+                    _ => write!(f, "\\x{c:02x}"),
+                }?
             }
+
             write!(f, "\"")?;
             Ok(())
         }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1216,7 +1216,7 @@ mod verbose {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "b\"")?;
             for &c in self.0 {
-                // https://doc.rust-lang.org/reference.html#byte-escapes
+                // See: https://doc.rust-lang.org/reference.html#byte-escapes
 
                 match c {
                     b'\\' => f.write_str("\\\\"),

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1210,7 +1210,6 @@ mod verbose {
         }
     }
 
-    use std::fmt::Write as _;
     struct Escape<'a>(&'a [u8]);
     impl fmt::Debug for Escape<'_> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1219,15 +1218,15 @@ mod verbose {
                 // See: https://doc.rust-lang.org/reference.html#byte-escapes
 
                 match c {
-                    b'\\' => f.write_str("\\\\"),
-                    b'\n' => f.write_str("\\n"),
-                    b'\r' => f.write_str("\\r"),
-                    b'\t' => f.write_str("\\t"),
-                    b'\0' => f.write_str("\\0"),
-                    b'"' => f.write_str("\\\""), 
+                    b'\\' => write!(f, "\\\\"),
+                    b'\n' => write!(f, "\\n"),
+                    b'\r' => write!(f, "\\r"),
+                    b'\t' => write!(f, "\\t"),
+                    b'\0' => write!(f, "\\0"),
+                    b'"' => write!(f, "\\\""), 
 
                     // ASCII-printable range, no need to escape it if it's not anything above.
-                    0x20..=0x7f => f.write_char(c as char),
+                    0x20..=0x7f => write!(f, "{}", c as char),
 
                     // Anything else should be a hex escape.
                     _ => write!(f, "\\x{c:02x}"),

--- a/src/dns/resolve.rs
+++ b/src/dns/resolve.rs
@@ -43,11 +43,8 @@ impl Name {
 
 impl FromStr for Name {
     type Err = sealed::InvalidNameError;
-
     fn from_str(host: &str) -> Result<Self, Self::Err> {
-        HyperName::from_str(host.into())
-            .map(Name)
-            .map_err(|_| sealed::InvalidNameError { _ext: () })
+        HyperName::from_str(host).map(Name).map_err(|_| sealed::InvalidNameError { _ext: () })
     }
 }
 

--- a/src/dns/resolve.rs
+++ b/src/dns/resolve.rs
@@ -44,7 +44,9 @@ impl Name {
 impl FromStr for Name {
     type Err = sealed::InvalidNameError;
     fn from_str(host: &str) -> Result<Self, Self::Err> {
-        HyperName::from_str(host).map(Name).map_err(|_| sealed::InvalidNameError { _ext: () })
+        HyperName::from_str(host)
+            .map(Name)
+            .map_err(|_| sealed::InvalidNameError { _ext: () })
     }
 }
 

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -63,7 +63,7 @@ impl<'a> IntoUrlSealed for &'a String {
     }
 }
 
-impl<'a> IntoUrlSealed for String {
+impl IntoUrlSealed for String {
     fn into_url(self) -> crate::Result<Url> {
         (&*self).into_url()
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -105,7 +105,7 @@ pub enum ProxyScheme {
         auth: Option<HeaderValue>,
         host: http::uri::Authority,
     },
-    
+
     Https {
         auth: Option<HeaderValue>,
         host: http::uri::Authority,
@@ -145,12 +145,13 @@ impl<S: IntoUrl> IntoProxyScheme for S {
             let mut has_bad_scheme = false;
             while source.is_some() && !has_bad_scheme {
                 let src = source.unwrap();
-                has_bad_scheme = src.downcast_ref::<url::ParseError>() == Some(&url::ParseError::RelativeUrlWithoutBase) || 
-                                 src.downcast_ref::<crate::error::BadScheme>().is_some();
-                
+                has_bad_scheme = src.downcast_ref::<url::ParseError>()
+                    == Some(&url::ParseError::RelativeUrlWithoutBase)
+                    || src.downcast_ref::<crate::error::BadScheme>().is_some();
+
                 source = src.source();
             }
-            
+
             if !has_bad_scheme {
                 return Err(crate::error::builder(err));
             }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -129,7 +129,7 @@ impl ProxyScheme {
     }
 }
 
-/// Trait used for converting a URL into a proxy scheme. This trait supports
+/// Trait used for converting into a proxy scheme. This trait supports
 /// parsing from a URL-like type, whilst also supporting proxy schemes
 /// built directly using the factory methods.
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -185,7 +185,7 @@ impl Certificate {
 
         Self::read_pem_certs(&mut reader)?
             .iter()
-            .map(|cert_vec| Certificate::from_der(&cert_vec))
+            .map(|cert_vec| Certificate::from_der(cert_vec))
             .collect::<crate::Result<Vec<Certificate>>>()
     }
 
@@ -500,6 +500,7 @@ impl fmt::Debug for TlsBackend {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for TlsBackend {
     fn default() -> TlsBackend {
         #[cfg(all(feature = "default-tls", not(feature = "http3")))]


### PR DESCRIPTION
This PR refactors the implementations for `IntoProxyScheme` and `Escape` to make things cleaner. This also fixes all clippy warnings that had previously existed, or ignores them in cases where it's either not desirable or trivial to fix.