### PR TITLE
Remove duplicate example for ClientBuilder::default_headers

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -807,27 +807,6 @@ impl ClientBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// Override the default headers:
-    ///
-    /// ```rust
-    /// use reqwest::header;
-    /// # async fn doc() -> Result<(), reqwest::Error> {
-    /// let mut headers = header::HeaderMap::new();
-    /// headers.insert("X-MY-HEADER", header::HeaderValue::from_static("value"));
-    ///
-    /// // get a client builder
-    /// let client = reqwest::Client::builder()
-    ///     .default_headers(headers)
-    ///     .build()?;
-    /// let res = client
-    ///     .get("https://www.rust-lang.org")
-    ///     .header("X-MY-HEADER", "new_value")
-    ///     .send()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
     pub fn default_headers(mut self, headers: HeaderMap) -> ClientBuilder {
         for (key, value) in headers.iter() {
             self.config.headers.insert(key, value.clone());

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -157,26 +157,6 @@ impl ClientBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// Override the default headers:
-    ///
-    /// ```rust
-    /// use reqwest::header;
-    /// # fn build_client() -> Result<(), reqwest::Error> {
-    /// let mut headers = header::HeaderMap::new();
-    /// headers.insert("X-MY-HEADER", header::HeaderValue::from_static("value"));
-    ///
-    /// // get a client builder
-    /// let client = reqwest::blocking::Client::builder()
-    ///     .default_headers(headers)
-    ///     .build()?;
-    /// let res = client
-    ///     .get("https://www.rust-lang.org")
-    ///     .header("X-MY-HEADER", "new_value")
-    ///     .send()?;
-    /// # Ok(())
-    /// # }
-    /// ```
     pub fn default_headers(self, headers: header::HeaderMap) -> ClientBuilder {
         self.with_inner(move |inner| inner.default_headers(headers))
     }


### PR DESCRIPTION
The code example is listed twice, once with marking a header as sensitive and once without.
I've removed the the example without the sensitive part.