### PR TITLE
Bump the version of rustlts used in v0.11 because of RUSTSEC-2024-0336

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 
 # rustls-tls
 hyper-rustls = { version = "0.24.0", default-features = false, optional = true }
-rustls = { version = "0.21.6", features = ["dangerous_configuration"], optional = true }
+rustls = { version = "0.21.11", features = ["dangerous_configuration"], optional = true }
 tokio-rustls = { version = "0.24", optional = true }
 webpki-roots = { version = "0.25", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }


### PR DESCRIPTION
This addresses the vulnerability in rustlts described here - https://rustsec.org/advisories/RUSTSEC-2024-0336 - for version 0.11