### PR TITLE
fix: Fix `log` dependency specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ hyper = { version = "1", features = ["http1", "client"] }
 hyper-util = { version = "0.1.3", features = ["http1", "client", "client-legacy", "tokio"] }
 h2 = { version = "0.4", optional = true }
 once_cell = "1"
-log = "0.4"
+log = "0.4.6"
 mime = "0.3.16"
 percent-encoding = "2.1"
 tokio = { version = "1.0", default-features = false, features = ["net", "time"] }


### PR DESCRIPTION
The `log::log_enabled!` macro was added in version 0.4.6 of the crate. Hence, a version specification of 0.4 is insufficient. Fix it.