### PR TITLE
Allow overriding the DNS resolver for the blocking client.

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -16,6 +16,7 @@ use tokio::sync::{mpsc, oneshot};
 use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::wait;
+use crate::dns::Resolve;
 #[cfg(feature = "__tls")]
 use crate::tls;
 #[cfg(feature = "__tls")]
@@ -918,6 +919,15 @@ impl ClientBuilder {
     /// to the conventional port for the given scheme (e.g. 80 for http).
     pub fn resolve_to_addrs(self, domain: &str, addrs: &[SocketAddr]) -> ClientBuilder {
         self.with_inner(|inner| inner.resolve_to_addrs(domain, addrs))
+    }
+
+    /// Override the DNS resolver implementation.
+    ///
+    /// Pass an `Arc` wrapping a trait object implementing `Resolve`.
+    /// Overrides for specific names passed to `resolve` and `resolve_to_addrs` will
+    /// still be applied on top of this resolver.
+    pub fn dns_resolver<R: Resolve + 'static>(self, resolver: Arc<R>) -> ClientBuilder {
+        self.with_inner(|inner| inner.dns_resolver(resolver))
     }
 
     // private


### PR DESCRIPTION
While there is the possibility to override the DNS resolver there is no way to enable it for the blocking client. This pull request adds the same "dns_resolver" function to the blocking client that the async client already has.