### PR TITLE
Add an implementation for RequestBuilder::from_parts and RequestBuilder::build_split for wasm targets

### DIFF
--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -115,6 +115,14 @@ impl RequestBuilder {
         RequestBuilder { client, request }
     }
 
+    /// Assemble a builder starting from an existing `Client` and a `Request`.
+    pub fn from_parts(client: crate::Client, request: crate::Request) -> crate::RequestBuilder {
+        crate::RequestBuilder {
+            client,
+            request: crate::Result::Ok(request),
+        }
+    }
+
     /// Modify the query string of the URL.
     ///
     /// Modifies the URL of this request, adding the parameters provided.

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -349,6 +349,15 @@ impl RequestBuilder {
         self.request
     }
 
+    /// Build a `Request`, which can be inspected, modified and executed with
+    /// `Client::execute()`.
+    ///
+    /// This is similar to [`RequestBuilder::build()`], but also returns the
+    /// embedded `Client`.
+    pub fn build_split(self) -> (Client, crate::Result<Request>) {
+        (self.client, self.request)
+    }
+
     /// Constructs the Request and sends it to the target URL, returning a
     /// future Response.
     ///


### PR DESCRIPTION
Currently, the implementation of `RequestBuilder` for WASM targets lacks an implementation of `RequestBuilder::from_parts` and `RequestBuilder::build_split`. I noticed this when the latest version of `reqwest-middleware` failed to compile for wasm32-unknown-unknown because these methods are missing.

Unless I am missing something, it should be safe to add these methods and let third party crates use them just like on native platforms.