### PR TITLE
chore: update sync_wrapper to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ serde_urlencoded = "0.7.1"
 tower-service = "0.3"
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
-sync_wrapper = "0.1.2"
+sync_wrapper = "1.0"
 
 # Optional deps...
 


### PR DESCRIPTION
This updates `sync_wrapper` to its latest version (`1.0.1`).

Ref: https://github.com/Actyx/sync_wrapper/compare/v0.1.2...v1.0.1