### PR TITLE
Add `from_parts` and `build_split` methods to `blocking::RequestBuilder` struct

### DIFF
--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -167,6 +167,14 @@ impl RequestBuilder {
         }
     }
 
+    /// Assemble a builder starting from an existing `Client` and a `Request`.
+    pub fn from_parts(client: Client, request: Request) -> RequestBuilder {
+        RequestBuilder {
+            client,
+            request: crate::Result::Ok(request),
+        }
+    }
+
     /// Add a `Header` to this Request.
     ///
     /// ```rust
@@ -548,6 +556,15 @@ impl RequestBuilder {
     /// `Client::execute()`.
     pub fn build(self) -> crate::Result<Request> {
         self.request
+    }
+
+    /// Build a `Request`, which can be inspected, modified and executed with
+    /// `Client::execute()`.
+    ///
+    /// This is similar to [`RequestBuilder::build()`], but also returns the
+    /// embedded `Client`.
+    pub fn build_split(self) -> (Client, crate::Result<Request>) {
+        (self.client, self.request)
     }
 
     /// Constructs the Request and sends it the target URL, returning a Response.


### PR DESCRIPTION
Hello,

I needed these two methods for a project and noticed that they were missing when using the `blocking` feature.
I am not sure why that was the case so if there was a reason feel free to reject the PR and tell me why 🙏.