### PR TITLE
feat: impl From<Name> for HyperName

### DIFF
--- a/src/dns/resolve.rs
+++ b/src/dns/resolve.rs
@@ -41,6 +41,12 @@ impl Name {
     }
 }
 
+impl From<Name> for HyperName {
+    fn from(value: Name) -> Self {
+        value.0
+    }
+}
+
 impl FromStr for Name {
     type Err = sealed::InvalidNameError;
 


### PR DESCRIPTION
For context, we ([Conduit](https://conduit.rs)) want this so that we can use [`GaiResolver`](https://docs.rs/hyper-util/latest/hyper_util/client/legacy/connect/dns/struct.GaiResolver.html) when implementing [`Resolve`](https://docs.rs/reqwest/latest/reqwest/dns/trait.Resolve.html), as it implements `TowerService<Name>`. [Here is what we are doing currently to get around this](https://gitlab.com/famedly/conduit/-/merge_requests/627/diffs#07f65c411d6f6be8e678fb63ef98e88c80dbcd07_141_142).