### PR TITLE
feat: print source for error to make it easier to debug

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -206,6 +206,10 @@ impl fmt::Display for Error {
             write!(f, " for url ({url})")?;
         }
 
+        if let Some(source) = &self.inner.source {
+            write!(f, ": {source}")?;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
Currently when encounter errors, the `Error` type only prints a message like this:

```
error sending request for url (http://xxx)
```

It doesn't print the underlying cause, so it's hard to debug.

This PR also prints the inner source which makes it easier to debug, such as:

```
error sending request for url (http://xxx): operation timed out
```