### PR TITLE
feat: improve interop with `http::Request<()>`

### DIFF
--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -213,6 +213,14 @@ impl From<Bytes> for Body {
     }
 }
 
+impl From<()> for Body {
+    #[inline]
+    fn from(_: ()) -> Body {
+        // useful for `TryFrom<http::Request<()>>`
+        Body::empty()
+    }
+}
+
 impl From<Vec<u8>> for Body {
     #[inline]
     fn from(vec: Vec<u8>) -> Body {

--- a/src/blocking/body.rs
+++ b/src/blocking/body.rs
@@ -167,6 +167,14 @@ impl Kind {
     }
 }
 
+impl From<()> for Body {
+    #[inline]
+    fn from(_: ()) -> Body {
+        // useful for `TryFrom<http::Request<()>>`
+        Body::empty()
+    }
+}
+
 impl From<Vec<u8>> for Body {
     #[inline]
     fn from(v: Vec<u8>) -> Body {

--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -140,6 +140,14 @@ impl From<Bytes> for Body {
     }
 }
 
+impl From<()> for Body {
+    #[inline]
+    fn from(_: ()) -> Body {
+        // useful for `TryFrom<http::Request<()>>`
+        Body::empty()
+    }
+}
+
 impl From<Vec<u8>> for Body {
     #[inline]
     fn from(vec: Vec<u8>) -> Body {


### PR DESCRIPTION
see https://github.com/seanmonstar/reqwest/pull/2196 for reasons why, and to make sure that I'm not the only crazy person who needs this

I need `impl TryFrom<HttpRequest<()>> for Request`, which already exists for `T: Into<Body>`:
https://github.com/seanmonstar/reqwest/blob/695bc0463726bb243e235f17c7f8833974835ec8/src/async_impl/request.rs#L598-L601

only thing we need to do is make sure that `(): Into<Body>`, which is what this PR does