### PR TITLE
refactor: change Debug of Error to output url as str

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -432,7 +432,7 @@ impl Response {
 impl fmt::Debug for Response {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Response")
-            .field("url", self.url())
+            .field("url", &self.url().as_str())
             .field("status", &self.status())
             .field("headers", self.headers())
             .finish()

--- a/src/error.rs
+++ b/src/error.rs
@@ -172,7 +172,7 @@ impl fmt::Debug for Error {
         builder.field("kind", &self.inner.kind);
 
         if let Some(ref url) = self.inner.url {
-            builder.field("url", url);
+            builder.field("url", &url.as_str());
         }
         if let Some(ref source) = self.inner.source {
             builder.field("source", source);


### PR DESCRIPTION
I don't believe anyone every needs the full debug output of URLs when seeing an `Error`, just it as a string is fine.