### PR TITLE
tests: bypass the proxy if testing DNS override

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -246,6 +246,7 @@ async fn overridden_dns_resolution_with_gai() {
         server.addr().port()
     );
     let client = reqwest::Client::builder()
+        .no_proxy()
         .resolve(overridden_domain, server.addr())
         .build()
         .expect("client builder");
@@ -270,6 +271,7 @@ async fn overridden_dns_resolution_with_gai_multiple() {
     // the server runs on IPv4 localhost, so provide both IPv4 and IPv6 and let the happy eyeballs
     // algorithm decide which address to use.
     let client = reqwest::Client::builder()
+        .no_proxy()
         .resolve_to_addrs(
             overridden_domain,
             &[
@@ -302,6 +304,7 @@ async fn overridden_dns_resolution_with_hickory_dns() {
         server.addr().port()
     );
     let client = reqwest::Client::builder()
+        .no_proxy()
         .resolve(overridden_domain, server.addr())
         .hickory_dns(true)
         .build()
@@ -328,6 +331,7 @@ async fn overridden_dns_resolution_with_hickory_dns_multiple() {
     // the server runs on IPv4 localhost, so provide both IPv4 and IPv6 and let the happy eyeballs
     // algorithm decide which address to use.
     let client = reqwest::Client::builder()
+        .no_proxy()
         .resolve_to_addrs(
             overridden_domain,
             &[


### PR DESCRIPTION
If an explicit proxy is configured in the environment, then the request will go through it rather than actually resolving the domain. Either we're hitting the target domain on a weird port which will likely fail, or the proxy straight up denies that weird request.

To work around this, we actually modify the environment variables to make sure that our target domain is in the exception list for the proxy.

We're hitting this issue in the Ubuntu CI. Amazingly enough, the tests actually passed *once* there, although the exact circumstances that allowed this are still a bit of a mystery.