### PR TITLE
Fix `.header()` unsetting `sensitive` on `HeaderValue` (`blocking`)

### DIFF
--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -211,7 +211,12 @@ impl RequestBuilder {
             match <HeaderName as TryFrom<K>>::try_from(key) {
                 Ok(key) => match <HeaderValue as TryFrom<V>>::try_from(value) {
                     Ok(mut value) => {
-                        value.set_sensitive(sensitive);
+                        // We want to potentially make an unsensitive header
+                        // to be sensitive, not the reverse. So, don't turn off
+                        // a previously sensitive header.
+                        if sensitive {
+                            value.set_sensitive(true);
+                        }
                         req.headers_mut().append(key, value);
                     }
                     Err(e) => error = Some(crate::error::builder(e.into())),


### PR DESCRIPTION
Fixes #2352

It seems that the issue was already reported in https://github.com/seanmonstar/reqwest/issues/1549 and fixed for async by https://github.com/seanmonstar/reqwest/commit/d536ce261c6e92d9956cc9a3d28c4288046f454b, but the blocking implementation was forgotten.