### PR TITLE
WASM cookies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,9 @@ sync_wrapper = { version = "1.0", features = ["futures"] }
 
 # Optional deps...
 
+## cookies
+cookie_crate = { version = "0.18.0", package = "cookie", optional = true }
+cookie_store = { version = "0.21.0", optional = true }
 ## json
 serde_json = { version = "1.0", optional = true }
 ## multipart
@@ -147,10 +150,6 @@ rustls-pki-types = { version = "1.1.0", features = ["alloc"] ,optional = true }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 webpki-roots = { version = "0.26.0", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
-
-## cookies
-cookie_crate = { version = "0.18.0", package = "cookie", optional = true }
-cookie_store = { version = "0.21.0", optional = true }
 
 ## compression
 async-compression = { version = "0.4.0", default-features = false, features = ["tokio"], optional = true }
@@ -192,6 +191,7 @@ system-configuration = { version = "0.6.0", optional = true }
 # wasm
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+hyper = { version = "1.1.0", default-features = false }
 js-sys = "0.3.45"
 serde_json = "1.0"
 wasm-bindgen = "0.2.89"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,8 @@ if_hyper! {
 if_wasm! {
     mod wasm;
     mod util;
+    #[cfg(feature = "cookies")]
+    pub mod cookie;
 
     pub use self::wasm::{Body, Client, ClientBuilder, Request, RequestBuilder, Response};
     #[cfg(feature = "multipart")]

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -156,7 +156,7 @@ impl Client {
         // Add cookies from the cookie store.
         #[cfg(feature = "cookies")]
         {
-            if let Some(cookie_store) = self.inner.cookie_store.as_ref() {
+            if let Some(cookie_store) = self.config.cookie_store.as_ref() {
                 if headers.get(crate::header::COOKIE).is_none() {
                     add_cookie_header(&mut headers, &**cookie_store, &url);
                 }

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -400,7 +400,7 @@ impl Config {
     fn fmt_fields(&self, f: &mut fmt::DebugStruct<'_, '_>) {
         #[cfg(feature = "cookies")]
         {
-            if let Some(_) = self.cookie_store {
+            if self.cookie_store.is_some() {
                 f.field("cookie_store", &true);
             }
         }

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -201,6 +201,7 @@ impl fmt::Debug for ClientBuilder {
 // > `init.method(m)` to `init.set_method(m)`
 // For now, ignore their deprecation.
 #[allow(deprecated)]
+#[cfg_attr(not(feature = "cookies"), allow(unused_variables))] // client only used if cookies are enabled
 async fn fetch(req: Request, client: Client) -> crate::Result<Response> {
     // Build the js Request
     let mut init = web_sys::RequestInit::new();

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -366,12 +366,20 @@ impl Default for ClientBuilder {
     }
 }
 
-#[derive(Debug)]
 struct Config {
+    // NOTE: When adding a new field, update `fmt_fields` in impl Config
     headers: HeaderMap,
     #[cfg(feature = "cookies")]
     cookie_store: Option<Arc<dyn cookie::CookieStore>>,
     error: Option<crate::Error>,
+}
+
+impl fmt::Debug for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut builder = f.debug_struct("Config");
+        self.fmt_fields(&mut builder);
+        builder.finish()
+    }
 }
 
 impl Default for Config {

--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+#[cfg(feature = "cookies")]
+use crate::cookie;
 use bytes::Bytes;
 use http::{HeaderMap, StatusCode};
 use js_sys::Uint8Array;
@@ -70,6 +72,19 @@ impl Response {
             .ok()?
             .parse()
             .ok()
+    }
+
+    /// Retrieve the cookies contained in the response.
+    ///
+    /// Note that invalid 'Set-Cookie' headers will be ignored.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `cookies` feature to be enabled.
+    #[cfg(feature = "cookies")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "cookies")))]
+    pub fn cookies<'a>(&'a self) -> impl Iterator<Item = cookie::Cookie<'a>> + 'a {
+        cookie::extract_response_cookies(self.http.headers()).filter_map(Result::ok)
     }
 
     /// Get the final `Url` of this `Response`.


### PR DESCRIPTION
I got cookies working for WASM to the best of my knowledge. I tested it in my use case and it works. I'm not sure how to add tests for the cookie functionality I added for WASM.

I also have one [part of the code](https://github.com/c-git/reqwest/blob/e9aa25d22f1b4c1b5637cdbc0c03a768ae20b95c/src/wasm/client.rs#L162) that I'm unsure of because I didn't see a clear translation between the native version and the WASM version.

Please let me know what you need me to do or change anything (including if the code I mentioned that I was unsure of is ok).

Edit: 

If you need this functionality before the PR lands you can add the following to the bottom of your `Cargo.toml`. If you need me to rebase to keep up with changes to `reqwest` [let me know](https://github.com/c-git/reqwest/issues/new) (replying here would work as well) as I may not update unless a reason comes up such as I'm doing an updates on my dependencies or a security fixed comes out.

```toml
# https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#testing-a-bugfix
[patch.crates-io]
reqwest = { git = "https://github.com/c-git/reqwest.git", branch = "wasm-cookies" }
```