### PR TITLE
chore: update system-configuration dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 windows-registry = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-system-configuration = { version = "0.5.1", optional = true }
+system-configuration = { version = "0.6.0", optional = true }
 
 # wasm
 


### PR DESCRIPTION
Bump `system-configuration` dependency to its latest released version