### PR TITLE
chore: Fix linting errors

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -197,7 +197,7 @@ impl ClientBuilder {
                 connect_timeout: None,
                 connection_verbose: false,
                 pool_idle_timeout: Some(Duration::from_secs(90)),
-                pool_max_idle_per_host: std::usize::MAX,
+                pool_max_idle_per_host: usize::MAX,
                 // TODO: Re-enable default duration once hyper's HttpConnector is fixed
                 // to no longer error when an option fails.
                 tcp_keepalive: None, //Some(Duration::from_secs(60)),
@@ -2785,10 +2785,9 @@ fn add_cookie_header(headers: &mut HeaderMap, cookie_store: &dyn cookie::CookieS
     }
 }
 
+#[cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
 #[cfg(test)]
 mod tests {
-    #![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
-
     #[tokio::test]
     async fn execute_request_rejects_invalid_urls() {
         let url_str = "hxxps://www.rust-lang.org/";

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -40,7 +40,7 @@ use tokio_util::io::StreamReader;
 use super::body::ResponseBody;
 use crate::error;
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub(super) struct Accepts {
     #[cfg(feature = "gzip")]
     pub(super) gzip: bool,
@@ -543,6 +543,22 @@ impl Accepts {
         #[cfg(not(feature = "deflate"))]
         {
             false
+        }
+    }
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for Accepts {
+    fn default() -> Accepts {
+        Accepts {
+            #[cfg(feature = "gzip")]
+            gzip: true,
+            #[cfg(feature = "brotli")]
+            brotli: true,
+            #[cfg(feature = "zstd")]
+            zstd: true,
+            #[cfg(feature = "deflate")]
+            deflate: true,
         }
     }
 }

--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -40,7 +40,7 @@ use tokio_util::io::StreamReader;
 use super::body::ResponseBody;
 use crate::error;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub(super) struct Accepts {
     #[cfg(feature = "gzip")]
     pub(super) gzip: bool,
@@ -543,21 +543,6 @@ impl Accepts {
         #[cfg(not(feature = "deflate"))]
         {
             false
-        }
-    }
-}
-
-impl Default for Accepts {
-    fn default() -> Accepts {
-        Accepts {
-            #[cfg(feature = "gzip")]
-            gzip: true,
-            #[cfg(feature = "brotli")]
-            brotli: true,
-            #[cfg(feature = "zstd")]
-            zstd: true,
-            #[cfg(feature = "deflate")]
-            deflate: true,
         }
     }
 }

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -647,10 +647,9 @@ impl TryFrom<Request> for HttpRequest<Body> {
     }
 }
 
+#[cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
 #[cfg(test)]
 mod tests {
-    #![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
-
     use super::{Client, HttpRequest, Request, RequestBuilder, Version};
     use crate::Method;
     use serde::Serialize;

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1227,7 +1227,7 @@ mod verbose {
                 } else if c == b'\0' {
                     write!(f, "\\0")?;
                 // ASCII printable
-                } else if c >= 0x20 && c < 0x7f {
+                } else if (0x20..0x7f).contains(&c) {
                     write!(f, "{}", c as char)?;
                 } else {
                     write!(f, "\\x{c:02x}")?;

--- a/src/dns/resolve.rs
+++ b/src/dns/resolve.rs
@@ -45,7 +45,7 @@ impl FromStr for Name {
     type Err = sealed::InvalidNameError;
 
     fn from_str(host: &str) -> Result<Self, Self::Err> {
-        HyperName::from_str(host.into())
+        HyperName::from_str(host)
             .map(Name)
             .map_err(|_| sealed::InvalidNameError { _ext: () })
     }

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -63,7 +63,7 @@ impl<'a> IntoUrlSealed for &'a String {
     }
 }
 
-impl<'a> IntoUrlSealed for String {
+impl IntoUrlSealed for String {
     fn into_url(self) -> crate::Result<Url> {
         (&*self).into_url()
     }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -470,12 +470,10 @@ impl Version {
     }
 }
 
-#[derive(Default)]
 pub(crate) enum TlsBackend {
     // This is the default and HTTP/3 feature does not use it so suppress it.
     #[allow(dead_code)]
     #[cfg(feature = "default-tls")]
-    #[default]
     Default,
     #[cfg(feature = "native-tls")]
     BuiltNativeTls(native_tls_crate::TlsConnector),
@@ -500,6 +498,24 @@ impl fmt::Debug for TlsBackend {
             TlsBackend::BuiltRustls(_) => write!(f, "BuiltRustls"),
             #[cfg(any(feature = "native-tls", feature = "__rustls",))]
             TlsBackend::UnknownPreconfigured => write!(f, "UnknownPreconfigured"),
+        }
+    }
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for TlsBackend {
+    fn default() -> TlsBackend {
+        #[cfg(all(feature = "default-tls", not(feature = "http3")))]
+        {
+            TlsBackend::Default
+        }
+
+        #[cfg(any(
+            all(feature = "__rustls", not(feature = "default-tls")),
+            feature = "http3"
+        ))]
+        {
+            TlsBackend::Rustls
         }
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -187,7 +187,7 @@ impl Certificate {
 
         Self::read_pem_certs(&mut reader)?
             .iter()
-            .map(|cert_vec| Certificate::from_der(&cert_vec))
+            .map(|cert_vec| Certificate::from_der(cert_vec))
             .collect::<crate::Result<Vec<Certificate>>>()
     }
 
@@ -470,10 +470,12 @@ impl Version {
     }
 }
 
+#[derive(Default)]
 pub(crate) enum TlsBackend {
     // This is the default and HTTP/3 feature does not use it so suppress it.
     #[allow(dead_code)]
     #[cfg(feature = "default-tls")]
+    #[default]
     Default,
     #[cfg(feature = "native-tls")]
     BuiltNativeTls(native_tls_crate::TlsConnector),
@@ -498,23 +500,6 @@ impl fmt::Debug for TlsBackend {
             TlsBackend::BuiltRustls(_) => write!(f, "BuiltRustls"),
             #[cfg(any(feature = "native-tls", feature = "__rustls",))]
             TlsBackend::UnknownPreconfigured => write!(f, "UnknownPreconfigured"),
-        }
-    }
-}
-
-impl Default for TlsBackend {
-    fn default() -> TlsBackend {
-        #[cfg(all(feature = "default-tls", not(feature = "http3")))]
-        {
-            TlsBackend::Default
-        }
-
-        #[cfg(any(
-            all(feature = "__rustls", not(feature = "default-tls")),
-            feature = "http3"
-        ))]
-        {
-            TlsBackend::Rustls
         }
     }
 }


### PR DESCRIPTION
As some code styles seems obsolete and inelegant, I modified some code to make `cargo clippy` emits no warnings and errors.