### PR TITLE
Enable happy eyeballs when using `hickory-dns`

### DIFF
--- a/src/dns/hickory.rs
+++ b/src/dns/hickory.rs
@@ -1,6 +1,8 @@
 //! DNS resolution via the [hickory-resolver](https://github.com/hickory-dns/hickory-dns) crate
 
-use hickory_resolver::{lookup_ip::LookupIpIntoIter, system_conf, TokioAsyncResolver, config::LookupIpStrategy};
+use hickory_resolver::{
+    config::LookupIpStrategy, lookup_ip::LookupIpIntoIter, system_conf, TokioAsyncResolver,
+};
 use once_cell::sync::OnceCell;
 
 use std::io;


### PR DESCRIPTION
Happy Eyeballs algorithm is implemented for hyper, however it is not working correctly for IPv6 only hosts because the default resolver option in hickory is `Ipv4ThenIpv6`, meaning it only sends AAAA queries if it cannot resolve an IPv4 address. Thus the address list `hyper` receives is almost always IPv4 only given most servers have an IPv4 address. To make the Happy Eyeballs algorithm work correctly, we need the resolver to resolve both IP versions. This also aligns with the default GAI resolver behavior for both glibc and musl.