### PR TITLE
chore: update Brotli to v6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ hyper = { version = "1.1.0", default-features = false, features = ["http1", "htt
 hyper-util = { version = "0.1.3", features = ["http1", "http2", "client", "client-legacy", "server-auto", "tokio"] }
 serde = { version = "1.0", features = ["derive"] }
 libflate = "1.0"
-brotli_crate = { package = "brotli", version = "3.3.0" }
+brotli_crate = { package = "brotli", version = "6.0.0" }
 zstd_crate = { package = "zstd", version = "0.13" }
 doc-comment = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Brotli before v6 do not play well with other versions because it used to include FFI.  This change is needed to avoid any multi-brotli conflicts in the same dep tree.