### PR TITLE
Use `windows-registry` instead of `winreg` for reading proxy settings on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ futures-util = { version = "0.3.28", default-features = false, features = ["std"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.52.0"
+windows-registry = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 system-configuration = { version = "0.5.1", optional = true }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -29,10 +29,6 @@ use system_configuration::{
     sys::schema_definitions::kSCPropNetProxiesHTTPSPort,
     sys::schema_definitions::kSCPropNetProxiesHTTPSProxy,
 };
-#[cfg(target_os = "windows")]
-use winreg::enums::HKEY_CURRENT_USER;
-#[cfg(target_os = "windows")]
-use winreg::RegKey;
 
 /// Configuration of a proxy that a `Client` should pass requests to.
 ///
@@ -937,12 +933,10 @@ fn is_cgi() -> bool {
 
 #[cfg(target_os = "windows")]
 fn get_from_platform_impl() -> Result<Option<String>, Box<dyn Error>> {
-    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    let internet_setting: RegKey =
-        hkcu.open_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings")?;
+    let internet_setting = windows_registry::CURRENT_USER.open("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings")?;
     // ensure the proxy is enable, if the value doesn't exist, an error will returned.
-    let proxy_enable: u32 = internet_setting.get_value("ProxyEnable")?;
-    let proxy_server: String = internet_setting.get_value("ProxyServer")?;
+    let proxy_enable = internet_setting.get_u32("ProxyEnable")?;
+    let proxy_server = internet_setting.get_string("ProxyServer")?;
 
     Ok((proxy_enable == 1).then_some(proxy_server))
 }


### PR DESCRIPTION
`winreg`, the crate that `reqwest` uses for reading proxy settings on Windows, has not been updated since last year, and currently depends on an outdated version of `windows-rs` (0.48.0).

When compiling applications that use newer versions of `windows-rs` targeting Windows 7, it can cause linker error such as these:

https://www.reddit.com/r/rust/comments/1dikeq6/compiling_for_win7_missing_windows0485lib/
https://www.reddit.com/r/rust/comments/18v3sjj/rustc_linker_cannot_find_windows0485/
https://github.com/rust-lang/rust/issues/128218

`windows-rs` crate now has an official sub-crate `windows-registry` for Windows Registry access.
By replacing `winreg` with `windows-registry`, Rust no longer tries to link two versions of `windows-targets` and solves the linker error.