### PR TITLE
Improve RequestBuilder::multipart's documentation

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -309,6 +309,9 @@ impl RequestBuilder {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// In additional the request's body, the Content-Type and Content-Length fields are
+    /// appropriately set.
     #[cfg(feature = "multipart")]
     #[cfg_attr(docsrs, doc(cfg(feature = "multipart")))]
     pub fn multipart(self, mut multipart: multipart::Form) -> RequestBuilder {


### PR DESCRIPTION
Making it clear that Content-Type is set will help prevent callers from
building maleformed requests where that field is present multiple times.
