### PR TITLE
feat: add base_url parsing

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -33,11 +33,11 @@ use crate::cookie::service::CookieService;
 use crate::dns::hickory::HickoryDnsResolver;
 use crate::dns::{gai::GaiResolver, DnsResolverWithOverrides, DynResolver, Resolve};
 use crate::error::{self, BoxError};
-use crate::into_url::try_uri;
 use crate::proxy::Matcher as ProxyMatcher;
 use crate::redirect::{self, TowerRedirectPolicy};
 #[cfg(feature = "__rustls")]
 use crate::tls::CertificateRevocationList;
+use crate::into_url::{try_uri, IntoUrlSealed};
 #[cfg(feature = "__tls")]
 use crate::tls::{self, TlsBackend};
 #[cfg(feature = "__tls")]
@@ -1140,7 +1140,7 @@ impl ClientBuilder {
     /// base url has been set.
     pub fn base_url<U>(mut self, base_url: U) -> ClientBuilder
     where
-        U: IntoUrl
+        U: IntoUrl,
     {
         match base_url.into_url() {
             Ok(base_url) => {
@@ -2570,25 +2570,14 @@ impl Client {
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
-        let mut maybe_url = url.into_url();
-
-        if let Some(base_url) = &self.inner.base_url {
-            if let Err(url_parse_error) = &maybe_url {
-                if url_parse_error.is_builder() {
-                    if let Some(url) = url_parse_error.url() {
-                        if !url.has_host() {
-                            let mut replacement_url = base_url.clone();
-
-                            replacement_url.set_path(url.path());
-                            replacement_url.set_query(url.query());
-                            replacement_url.set_fragment(url.fragment());
-
-                            maybe_url = Ok(replacement_url);
-                        }
-                    }
-                }
-            }
-        }
+        let maybe_url = match &self.inner.base_url {
+            Some(ref base_url) => Url::options()
+                .base_url(Some(base_url))
+                .parse(url.as_str())
+                .map_err(crate::error::builder)
+                .and_then(IntoUrlSealed::into_url),
+            None => url.into_url(),
+        };
 
         let req = maybe_url.map(move |url| Request::new(method, url));
         RequestBuilder::new(self.clone(), req)

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -260,11 +260,11 @@ struct Config {
     h3_send_grease: Option<bool>,
     dns_overrides: HashMap<String, Vec<SocketAddr>>,
     dns_resolver: Option<Arc<dyn Resolve>>,
-
     #[cfg(unix)]
     unix_socket: Option<Arc<std::path::Path>>,
     #[cfg(target_os = "windows")]
     windows_named_pipe: Option<Arc<std::ffi::OsStr>>,
+    base_url: Option<Url>,
 }
 
 impl Default for ClientBuilder {
@@ -388,6 +388,7 @@ impl ClientBuilder {
                 unix_socket: None,
                 #[cfg(target_os = "windows")]
                 windows_named_pipe: None,
+                base_url: None,
             },
         }
     }
@@ -1090,6 +1091,7 @@ impl ClientBuilder {
                 proxies_maybe_http_custom_headers,
                 https_only: config.https_only,
                 redirect_policy_desc,
+                base_url: config.base_url,
             }),
         })
     }
@@ -2548,7 +2550,27 @@ impl Client {
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
-        let req = url.into_url().map(move |url| Request::new(method, url));
+        let mut maybe_url = url.into_url();
+
+        if let Some(base_url) = &self.inner.base_url {
+            if let Err(url_parse_error) = &maybe_url {
+                if url_parse_error.is_builder() {
+                    if let Some(url) = url_parse_error.url() {
+                        if !url.has_host() {
+                            let mut replacement_url = base_url.clone();
+
+                            replacement_url.set_path(url.path());
+                            replacement_url.set_query(url.query());
+                            replacement_url.set_fragment(url.fragment());
+
+                            maybe_url = Ok(replacement_url);
+                        }
+                    }
+                }
+            }
+        }
+
+        let req = maybe_url.map(move |url| Request::new(method, url));
         RequestBuilder::new(self.clone(), req)
     }
 
@@ -2919,6 +2941,7 @@ struct ClientRef {
     proxies_maybe_http_custom_headers: bool,
     https_only: bool,
     redirect_policy_desc: Option<String>,
+    base_url: Option<Url>,
 }
 
 impl ClientRef {

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1133,6 +1133,26 @@ impl ClientBuilder {
         };
         self
     }
+
+    /// Sets a base url to be used on all requests with a relative URL.
+    ///
+    /// By default relative URLs are rejected, but will be allowed if a
+    /// base url has been set.
+    pub fn base_url<U>(mut self, base_url: U) -> ClientBuilder
+    where
+        U: IntoUrl
+    {
+        match base_url.into_url() {
+            Ok(base_url) => {
+                self.config.base_url = Some(base_url);
+            }
+            Err(e) => {
+                self.config.error = Some(e);
+            }
+        }
+        self
+    }
+
     /// Sets the default headers for every request.
     ///
     /// # Example

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -547,3 +547,34 @@ async fn error_has_url() {
     let err = reqwest::get(u).await.unwrap_err();
     assert_eq!(err.url().map(AsRef::as_ref), Some(u), "{err:?}");
 }
+
+#[test]
+fn client_cannot_be_built_with_non_absolute_url() {
+    let result = reqwest::Client::builder().base_url("/users/123").build();
+
+    assert!(result.is_err());
+}
+
+/*
+#[tokio::test]
+async fn todo_() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
+
+    let url = format!(
+        "http://{overridden_domain}:{}/domain_override",
+        server.addr().port()
+    );
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .resolve(overridden_domain, server.addr())
+        .build()
+        .expect("client builder");
+    let req = client.get(&url);
+    let res = req.send().await.expect("request");
+
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    let text = res.text().await.expect("Failed to get text");
+    assert_eq!("Hello", text);
+}
+ */

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -549,32 +549,59 @@ async fn error_has_url() {
 }
 
 #[test]
-fn client_cannot_be_built_with_non_absolute_url() {
+fn client_cannot_be_built_with_relative_base_url() {
     let result = reqwest::Client::builder().base_url("/users/123").build();
 
     assert!(result.is_err());
 }
 
-/*
+#[test]
+fn client_can_be_built_with_absolute_base_url() {
+    let result = reqwest::Client::builder()
+        .base_url("http://example.com/users/123")
+        .build();
+
+    assert!(result.is_ok());
+}
+
 #[tokio::test]
-async fn todo_() {
+async fn client_with_base_url_accepts_relative_urls() {
     let _ = env_logger::builder().is_test(true).try_init();
     let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
 
-    let url = format!(
-        "http://{overridden_domain}:{}/domain_override",
-        server.addr().port()
-    );
+    let server_base_url = format!("http://{}", server.addr());
     let client = reqwest::Client::builder()
+        .base_url(server_base_url)
         .no_proxy()
-        .resolve(overridden_domain, server.addr())
         .build()
         .expect("client builder");
-    let req = client.get(&url);
+
+    // use a relative url on request
+    let req = client.get("/hello");
     let res = req.send().await.expect("request");
 
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     let text = res.text().await.expect("Failed to get text");
     assert_eq!("Hello", text);
 }
- */
+
+#[tokio::test]
+async fn client_with_base_url_accepts_absolute_urls() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
+
+    let client = reqwest::Client::builder()
+        .base_url("http://example.com")
+        .no_proxy()
+        .build()
+        .expect("client builder");
+
+    // use an absolute url on request
+    let request_absolute_url = format!("http://{}/hello", server.addr());
+    let req = client.get(request_absolute_url);
+    let res = req.send().await.expect("request");
+
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    let text = res.text().await.expect("Failed to get text");
+    assert_eq!("Hello", text);
+}


### PR DESCRIPTION
This adds support for `base_url` to the client when making a request.

# Changes

 * Add `ClientBuilder::base_url` for setting a base url for the client.
 * Change `Client::send` to use the base url, if it is set.

Implements #988 
