### PR TITLE
chore: Depend on wasm-bindgen 0.2.89 or higher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ system-configuration = { version = "0.6.0", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.45"
 serde_json = "1.0"
-wasm-bindgen = "0.2.68"
+wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.18"
 wasm-streams = { version = "0.4", optional = true }
 
@@ -216,7 +216,7 @@ features = [
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen = { version = "0.2.68", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.89", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3"
 
 [lints.rust]


### PR DESCRIPTION
wasm-bindgen 0.2.68 is not compatible with a wasm ABI change that rustc wishes to enable by default for wasm32-unknown-unknown, currently gated behind passing the -Zwasm-c-abi flag to rustc.

wasm-bindgen 0.2.89 should exhibit seamless behavior before and after the ABI change to match the C ABI, so depend on that.

For more information, see
- https://github.com/rust-lang/rust/issues/115666
- https://github.com/rust-lang/rust/pull/117918
- https://github.com/rust-lang/rust/issues/122532