### PR TITLE
Bump rustls-native-certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ rustls = { version = "0.23.4", optional = true, default-features = false, featur
 rustls-pki-types = { version = "1.1.0", features = ["alloc"] ,optional = true }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 webpki-roots = { version = "0.26.0", optional = true }
-rustls-native-certs = { version = "0.7", optional = true }
+rustls-native-certs = { version = "0.8.0", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }


### PR DESCRIPTION
The current version of reqwest will pull in two versions of `rustls-native-certs` if that feature is enabled, this just bumps the version so that there is only one.

```
   ├ rustls-native-certs v0.7.3
      └── reqwest v0.12.7
    ├ rustls-native-certs v0.8.0
      └── hyper-rustls v0.27.3
          └── reqwest v0.12.7
```