### PR TITLE
Make `Response::bytes_stream` return a concrete type

### DIFF
--- a/src/async_impl/mod.rs
+++ b/src/async_impl/mod.rs
@@ -1,7 +1,7 @@
 pub use self::body::Body;
 pub use self::client::{Client, ClientBuilder};
 pub use self::request::{Request, RequestBuilder};
-pub use self::response::Response;
+pub use self::response::{Response, BytesStream};
 pub use self::upgrade::Upgraded;
 
 #[cfg(feature = "blocking")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@ if_hyper! {
     doctest!("../README.md");
 
     pub use self::async_impl::{
-        Body, Client, ClientBuilder, Request, RequestBuilder, Response, Upgraded,
+        Body, Client, ClientBuilder, Request, RequestBuilder, Response, Upgraded, BytesStream,
     };
     pub use self::proxy::{Proxy,NoProxy};
     #[cfg(feature = "__tls")]


### PR DESCRIPTION
in my project I needed to store the resulting stream to avoid an allocation, but the fact that the method returns an `impl Stream` means that it wasn't possible to do so without boxing it