### PR TITLE
client/redirect: expose previous and next request methods

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2862,6 +2862,7 @@ impl Future for PendingRequest {
                     }
                 }
             }
+            let previous_method = self.method.clone();
             let should_redirect = match res.status() {
                 StatusCode::MOVED_PERMANENTLY | StatusCode::FOUND | StatusCode::SEE_OTHER => {
                     self.body = None;
@@ -2923,10 +2924,13 @@ impl Future for PendingRequest {
                     }
                     let url = self.url.clone();
                     self.as_mut().urls().push(url);
-                    let action = self
-                        .client
-                        .redirect_policy
-                        .check(res.status(), &loc, &self.urls);
+                    let action = self.client.redirect_policy.check(
+                        res.status(),
+                        &self.method,
+                        &loc,
+                        &previous_method,
+                        &self.urls,
+                    );
 
                     match action {
                         redirect::ActionKind::Follow => {


### PR DESCRIPTION
This augments `redirect::Attempt` in order to expose two relevant HTTP methods during redirects:
 - the methods for the previous request.
 - the method to be performed on the next request upon following a redirection.

The two methods can different, notably when redirecting `POST` requests:
https://en.wikipedia.org/wiki/Post/Redirect/Get

Towards https://github.com/seanmonstar/reqwest/issues/1777#issuecomment-2363279906.