### PR TITLE
Add empty body conversion from unit

### DIFF
--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -208,6 +208,13 @@ impl From<hyper::Body> for Body {
 }
 */
 
+impl From<()> for Body {
+    #[inline]
+    fn from(_: ()) -> Body {
+        Body::empty()
+    }
+}
+
 impl From<Bytes> for Body {
     #[inline]
     fn from(bytes: Bytes) -> Body {
@@ -466,6 +473,22 @@ mod tests {
     use http_body::Body as _;
 
     use super::Body;
+
+    #[test]
+    fn empty() {
+        let body = Body::empty();
+        assert_eq!(body.as_bytes(), Some(&[] as &[u8]));
+        assert_eq!(body.size_hint().exact(), Some(0));
+        assert!(body.is_end_stream());
+    }
+
+    #[test]
+    fn from_unit() {
+        let body = Body::from(());
+        assert_eq!(body.as_bytes(), Some(&[] as &[u8]));
+        assert_eq!(body.size_hint().exact(), Some(0));
+        assert!(body.is_end_stream());
+    }
 
     #[test]
     fn test_as_bytes() {

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -656,6 +656,7 @@ mod tests {
 
     use super::{Client, HttpRequest, Request, RequestBuilder, Version};
     use crate::Method;
+    use http::HeaderMap;
     use serde::Serialize;
     use std::collections::BTreeMap;
     use std::convert::TryFrom;
@@ -875,6 +876,19 @@ mod tests {
         assert_eq!(req.url().as_str(), "https://localhost/");
         assert_eq!(req.headers()["hiding"], "in plain sight");
         assert!(req.headers()["hiding"].is_sensitive());
+    }
+
+    #[test]
+    fn from_empty_http_request() {
+        let http_request = HttpRequest::builder()
+            .uri("http://localhost/")
+            .body(())
+            .unwrap();
+        let req = Request::try_from(http_request).unwrap();
+        assert_eq!(req.body().unwrap().as_bytes(), Some(&[] as &[u8]));
+        assert_eq!(req.headers(), &HeaderMap::new());
+        assert_eq!(req.method(), Method::GET);
+        assert_eq!(req.url().as_str(), "http://localhost/");
     }
 
     #[test]

--- a/src/blocking/body.rs
+++ b/src/blocking/body.rs
@@ -115,6 +115,12 @@ impl Body {
         }
     }
 
+    pub(crate) fn empty() -> Body {
+        Body {
+            kind: Kind::Bytes(Bytes::new()),
+        }
+    }
+
     #[cfg(feature = "multipart")]
     pub(crate) fn len(&self) -> Option<u64> {
         match self.kind {
@@ -164,6 +170,20 @@ impl Kind {
             Kind::Reader(..) => None,
             Kind::Bytes(v) => Some(Kind::Bytes(v.clone())),
         }
+    }
+}
+
+impl Default for Body {
+    #[inline]
+    fn default() -> Body {
+        Body::empty()
+    }
+}
+
+impl From<()> for Body {
+    #[inline]
+    fn from(_: ()) -> Body {
+        Body::empty()
     }
 }
 
@@ -366,4 +386,27 @@ pub(crate) fn read_to_string(mut body: Body) -> io::Result<String> {
         Kind::Bytes(ref mut bytes) => (&**bytes).read_to_string(&mut s),
     }
     .map(|_| s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Body;
+
+    #[test]
+    fn empty() {
+        let body = Body::empty();
+        assert_eq!(body.as_bytes(), Some(&[] as &[u8]));
+    }
+
+    #[test]
+    fn from_unit() {
+        let body = Body::from(());
+        assert_eq!(body.as_bytes(), Some(&[] as &[u8]));
+    }
+
+    #[test]
+    fn from_vec() {
+        let body = Body::from(vec![1, 2, 3]);
+        assert_eq!(body.as_bytes(), Some(&[1, 2, 3][..]));
+    }
 }

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -1011,6 +1011,20 @@ mod tests {
     }
 
     #[test]
+    fn from_empty_http_request() {
+        let http_request = HttpRequest::builder()
+            .method("GET")
+            .uri("http://localhost/")
+            .body(())
+            .unwrap();
+        let req = Request::try_from(http_request).unwrap();
+        assert_eq!(req.body().unwrap().as_bytes(), Some(&[] as &[u8]));
+        assert_eq!(req.headers(), &HeaderMap::new());
+        assert_eq!(req.method(), Method::GET);
+        assert_eq!(req.url().as_str(), "http://localhost/");
+    }
+
+    #[test]
     fn convert_from_http_request() {
         let http_request = HttpRequest::builder()
             .method("GET")

--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -129,6 +129,20 @@ impl Body {
             Inner::MultipartForm(_) => None,
         }
     }
+
+    #[inline]
+    pub(crate) fn empty() -> Body {
+        Body {
+            inner: Inner::Single(Single::Bytes(Bytes::new())),
+        }
+    }
+}
+
+impl From<()> for Body {
+    #[inline]
+    fn from(_: ()) -> Body {
+        Body::empty()
+    }
 }
 
 impl From<Bytes> for Body {
@@ -201,6 +215,12 @@ mod tests {
         // `log(..)`
         #[wasm_bindgen(js_namespace = console)]
         fn log(s: String);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_body_empty() {
+        let body = Body::empty();
+        assert_eq!(body.as_bytes(), Some(&[] as &[u8]));
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
This makes it possible to convert an http::Request with an empty body by
passing `()` to the `body` method. This is useful when writing sans-io
libraries where you want to create requests that are agnostic to the
specific reqwest implementation (async, blocking, wasm).

E.g.:

```rust
let http_request = http::Request::builder()
    .uri("http://localhost/")
    .body(())?;

let req = reqwest::Request::try_from(http_request)?;
reqwest::Client::new().execute(req).await?;

// or
let req = reqwest::blocking::Request::try_from(http_request)?;
reqwest::blocking::Client::new().execute(req)?;
```
