### PR TITLE
feat: remove feature `__internal_proxy_sys_no_cache`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
         run: |
           cargo clean
           cargo update -Z minimal-versions
-          cargo update -p proc-macro2 --precise 1.0.62
+          cargo update -p proc-macro2 --precise 1.0.87
           cargo check
           cargo check --all-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,16 +91,12 @@ jobs:
 
         include:
           - name: linux / stable
-            test-features: "--features __internal_proxy_sys_no_cache"
           - name: linux / beta
             rust: beta
-            test-features: "--features __internal_proxy_sys_no_cache"
           # - name: linux / nightly
           #   rust: nightly
-          #   test-features: "--features __internal_proxy_sys_no_cache"
           - name: macOS / stable
             os: macOS-latest
-            test-features: "--features __internal_proxy_sys_no_cache"
 
           - name: windows / stable-x86_64-msvc
             os: windows-latest

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -7,7 +7,6 @@ use crate::into_url::{IntoUrl, IntoUrlSealed};
 use crate::Url;
 use http::{header::HeaderValue, Uri};
 use ipnet::IpNet;
-use once_cell::sync::Lazy;
 use percent_encoding::percent_decode;
 use std::collections::HashMap;
 use std::env;
@@ -280,13 +279,9 @@ impl Proxy {
     }
 
     pub(crate) fn system() -> Proxy {
-        let mut proxy = if cfg!(feature = "__internal_proxy_sys_no_cache") {
-            Proxy::new(Intercept::System(Arc::new(get_sys_proxies(
-                get_from_platform(),
-            ))))
-        } else {
-            Proxy::new(Intercept::System(SYS_PROXIES.clone()))
-        };
+        let mut proxy = Proxy::new(Intercept::System(Arc::new(get_sys_proxies(
+            get_from_platform(),
+        ))));
         proxy.no_proxy = NoProxy::from_env();
         proxy
     }
@@ -875,9 +870,6 @@ impl Dst for Uri {
         self.port().map(|p| p.as_u16())
     }
 }
-
-static SYS_PROXIES: Lazy<Arc<SystemProxyMap>> =
-    Lazy::new(|| Arc::new(get_sys_proxies(get_from_platform())));
 
 /// Get system proxies information.
 ///

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -163,7 +163,6 @@ async fn test_no_proxy() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
 }
 
-#[cfg_attr(not(feature = "__internal_proxy_sys_no_cache"), ignore)]
 #[tokio::test]
 async fn test_using_system_proxy() {
     let url = "http://not.a.real.sub.hyper.rs/prox";
@@ -174,9 +173,6 @@ async fn test_using_system_proxy() {
 
         async { http::Response::default() }
     });
-
-    // Note: we're relying on the `__internal_proxy_sys_no_cache` feature to
-    // check the environment every time.
 
     // save system setting first.
     let system_proxy = env::var("http_proxy");


### PR DESCRIPTION
Completely remove the `__internal_proxy_sys_no_cache` feature and all related caching logic for system proxies.
Now, every time a new Client is created, it always reflects the current system proxy settings.

fix this issue #2441 