### PR TITLE
feat(client-builder): Add `http2_max_header_list_size` to the client builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.12.9
+
+- Add `tls::CertificateRevocationLists` support.
+- Add crate features to enable webpki roots without selecting a rustls provider.
+- Fix `connection_verbose()` to output read logs.
+- Fix `multipart::Part::file()` to automatically include content-length.
+- Fix proxy to internally no longer cache system proxy settings.
+
 ## v0.12.8
 
 - Add support for SOCKS4 proxies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ encoding_rs = { version = "0.8", optional = true }
 http-body = "1"
 http-body-util = "0.1"
 hyper = { version = "1.1", features = ["http1", "client"] }
-hyper-util = { version = "0.1.3", features = ["http1", "client", "client-legacy", "tokio"] }
+hyper-util = { version = "0.1.10", features = ["http1", "client", "client-legacy", "tokio"] }
 h2 = { version = "0.4", optional = true }
 once_cell = "1.18"
 log = "0.4.17"
@@ -173,7 +173,7 @@ futures-channel = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 env_logger = "0.10"
 hyper = { version = "1.1.0", default-features = false, features = ["http1", "http2", "client", "server"] }
-hyper-util = { version = "0.1.3", features = ["http1", "http2", "client", "client-legacy", "server-auto", "tokio"] }
+hyper-util = { version = "0.1.10", features = ["http1", "http2", "client", "client-legacy", "server-auto", "tokio"] }
 serde = { version = "1.0", features = ["derive"] }
 libflate = "2.1"
 brotli_crate = { package = "brotli", version = "6.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest"
-version = "0.12.8"
+version = "0.12.9"
 description = "higher level HTTP client library"
 keywords = ["http", "request", "client"]
 categories = ["web-programming::http-client", "wasm"]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -145,6 +145,8 @@ struct Config {
     #[cfg(feature = "http2")]
     http2_max_frame_size: Option<u32>,
     #[cfg(feature = "http2")]
+    http2_max_header_list_size: Option<u32>,
+    #[cfg(feature = "http2")]
     http2_keep_alive_interval: Option<Duration>,
     #[cfg(feature = "http2")]
     http2_keep_alive_timeout: Option<Duration>,
@@ -245,6 +247,8 @@ impl ClientBuilder {
                 http2_adaptive_window: false,
                 #[cfg(feature = "http2")]
                 http2_max_frame_size: None,
+                #[cfg(feature = "http2")]
+                http2_max_header_list_size: None,
                 #[cfg(feature = "http2")]
                 http2_keep_alive_interval: None,
                 #[cfg(feature = "http2")]
@@ -740,6 +744,9 @@ impl ClientBuilder {
             }
             if let Some(http2_max_frame_size) = config.http2_max_frame_size {
                 builder.http2_max_frame_size(http2_max_frame_size);
+            }
+            if let Some(http2_max_header_list_size_kib) = config.http2_max_header_list_size {
+                builder.http2_max_header_list_size(http2_max_header_list_size_kib);
             }
             if let Some(http2_keep_alive_interval) = config.http2_keep_alive_interval {
                 builder.http2_keep_alive_interval(http2_keep_alive_interval);
@@ -1305,6 +1312,16 @@ impl ClientBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_max_frame_size(mut self, sz: impl Into<Option<u32>>) -> ClientBuilder {
         self.config.http2_max_frame_size = sz.into();
+        self
+    }
+
+    /// Sets the maximum size of received header frames for HTTP2.
+    ///
+    /// Default is currently 16KB, but can change.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_header_list_size(mut self, max_header_size_bytes: u32) -> ClientBuilder {
+        self.config.http2_max_header_list_size = Some(max_header_size_bytes);
         self
     }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -745,8 +745,8 @@ impl ClientBuilder {
             if let Some(http2_max_frame_size) = config.http2_max_frame_size {
                 builder.http2_max_frame_size(http2_max_frame_size);
             }
-            if let Some(http2_max_header_list_size_kib) = config.http2_max_header_list_size {
-                builder.http2_max_header_list_size(http2_max_header_list_size_kib);
+            if let Some(http2_max_header_list_size) = config.http2_max_header_list_size {
+                builder.http2_max_header_list_size(http2_max_header_list_size);
             }
             if let Some(http2_keep_alive_interval) = config.http2_keep_alive_interval {
                 builder.http2_keep_alive_interval(http2_keep_alive_interval);

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -502,6 +502,15 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.http2_max_frame_size(sz))
     }
 
+    /// Sets the maximum size of received header frames for HTTP2.
+    ///
+    /// Default is currently 16KB, but can change.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_header_list_size(self, max_header_size_bytes: u32) -> ClientBuilder {
+        self.with_inner(|inner| inner.http2_max_header_list_size(max_header_size_bytes))
+    }
+
     /// This requires the optional `http3` feature to be
     /// enabled.
     #[cfg(feature = "http3")]


### PR DESCRIPTION
Currently the max size of received header frames for HTTP2 responses defaults to the 16KB when creating a hyper client. The 16KB default is defined in [hyper::proto::h2::DEFAULT_MAX_HEADER_LIST_SIZE](https://github.com/hyperium/hyper/blob/master/src/proto/h2/client.rs#L54).

This PR adds support to override this default value, to allow for custom limits of the maximum header sizes being received in HTTP/2 responses.