### PR TITLE
Pin idna_adapter instead of url in MSRV CI task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
           cargo update -p log --precise 0.4.18
           cargo update -p tokio --precise 1.29.1
           cargo update -p tokio-util --precise 0.7.11
-          cargo update -p url --precise 2.5.0
+          cargo update -p idna_adapter --precise 1.1.0
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
This allows for `url` crate updates while staying below `reqwest`'s MSRV.