### PR TITLE
expose default headers with a function on `Client`

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2173,9 +2173,9 @@ impl Client {
         }
     }
 
-    /// Returns default headers on client
-    pub fn default_headers(&self) -> HeaderMap {
-        self.inner.headers.clone()
+    /// Returns a reference to default headers on the client
+    pub fn default_headers(&self) -> &HeaderMap {
+        &self.inner.headers
     }
 
     fn proxy_auth(&self, dst: &Uri, headers: &mut HeaderMap) {


### PR DESCRIPTION
### Motivation
This change was made to address an issue I encountered at work while trying to verify if a `Client` had the user-agent set on it (needed for debugging purposes on an authentication backend). My current workaround was to format the debug implementation to a `String` then using `.contains("user-agent")`.  This is a quality of life change so I don't need to use this string parsing approach.