### PR TITLE
feat: allow pluggable tower layers in connector service stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Sean McArthur <sean@seanmonstar.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 autotests = true
 
 [package.metadata.docs.rs]
@@ -105,6 +105,7 @@ url = "2.4"
 bytes = "1.0"
 serde = "1.0"
 serde_urlencoded = "0.7.1"
+tower = { version = "0.5.2", default-features = false, features = ["timeout", "util"] }
 tower-service = "0.3"
 futures-core = { version = "0.3.28", default-features = false }
 futures-util = { version = "0.3.28", default-features = false }
@@ -169,7 +170,6 @@ quinn = { version = "0.11.1", default-features = false, features = ["rustls", "r
 slab = { version = "0.4.9", optional = true } # just to get minimal versions working with quinn
 futures-channel = { version = "0.3", optional = true }
 
-
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 env_logger = "0.10"
 hyper = { version = "1.1.0", default-features = false, features = ["http1", "http2", "client", "server"] }
@@ -222,6 +222,11 @@ features = [
 wasm-bindgen = { version = "0.2.89", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3"
 
+[dev-dependencies]
+tower = { version = "0.5.2", default-features = false, features = ["limit"] }
+num_cpus = "1.0"
+libc = "0"
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(reqwest_unstable)'] }
 
@@ -252,6 +257,10 @@ path = "examples/form.rs"
 [[example]]
 name = "simple"
 path = "examples/simple.rs"
+
+[[example]]
+name = "connect_via_lower_priority_tokio_runtime"
+path = "examples/connect_via_lower_priority_tokio_runtime.rs"
 
 [[test]]
 name = "blocking"

--- a/examples/connect_via_lower_priority_tokio_runtime.rs
+++ b/examples/connect_via_lower_priority_tokio_runtime.rs
@@ -1,0 +1,264 @@
+#![deny(warnings)]
+// This example demonstrates how to delegate the connect calls, which contain TLS handshakes,
+// to a secondary tokio runtime of lower OS thread priority using a custom tower layer.
+// This helps to ensure that long-running futures during handshake crypto operations don't block other I/O futures.
+//
+// This does introduce overhead of additional threads, channels, extra vtables, etc,
+// so it is best suited to services with large numbers of incoming connections or that
+// are otherwise very sensitive to any blocking futures.  Or, you might want fewer threads
+// and/or to use the current_thread runtime.
+//
+// This is using the `tokio` runtime and certain other dependencies:
+//
+// `tokio = { version = "1", features = ["full"] }`
+// `num_cpus = "1.0"`
+// `libc = "0"`
+// `pin-project-lite = "0.2"`
+// `tower = { version = "0.5", default-features = false}`
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() -> Result<(), reqwest::Error> {
+    background_threadpool::init_background_runtime();
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let client = reqwest::Client::builder()
+        .connector_layer(background_threadpool::BackgroundProcessorLayer::new())
+        .build()
+        .expect("should be able to build reqwest client");
+
+    let url = if let Some(url) = std::env::args().nth(1) {
+        url
+    } else {
+        println!("No CLI URL provided, using default.");
+        "https://hyper.rs".into()
+    };
+
+    eprintln!("Fetching {url:?}...");
+
+    let res = client.get(url).send().await?;
+
+    eprintln!("Response: {:?} {}", res.version(), res.status());
+    eprintln!("Headers: {:#?}\n", res.headers());
+
+    let body = res.text().await?;
+
+    println!("{body}");
+
+    Ok(())
+}
+
+// separating out for convenience to avoid a million #[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
+mod background_threadpool {
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::OnceLock,
+        task::{Context, Poll},
+    };
+
+    use futures_util::TryFutureExt;
+    use pin_project_lite::pin_project;
+    use tokio::{runtime::Handle, select, sync::mpsc::error::TrySendError};
+    use tower::{BoxError, Layer, Service};
+
+    static CPU_HEAVY_THREAD_POOL: OnceLock<
+        tokio::sync::mpsc::Sender<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,
+    > = OnceLock::new();
+
+    pub(crate) fn init_background_runtime() {
+        std::thread::Builder::new()
+            .name("cpu-heavy-background-threadpool".to_string())
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_multi_thread()
+                    .thread_name("cpu-heavy-background-pool-thread")
+                    .worker_threads(num_cpus::get() as usize)
+                    // ref: https://github.com/tokio-rs/tokio/issues/4941
+                    // consider uncommenting if seeing heavy task contention
+                    // .disable_lifo_slot()
+                    .on_thread_start(move || {
+                        #[cfg(target_os = "linux")]
+                        unsafe {
+                            // Increase thread pool thread niceness, so they are lower priority
+                            // than the foreground executor and don't interfere with I/O tasks
+                            {
+                                *libc::__errno_location() = 0;
+                                if libc::nice(10) == -1 && *libc::__errno_location() != 0 {
+                                    let error = std::io::Error::last_os_error();
+                                    log::error!("failed to set threadpool niceness: {}", error);
+                                }
+                            }
+                        }
+                    })
+                    .enable_all()
+                    .build()
+                    .unwrap_or_else(|e| panic!("cpu heavy runtime failed_to_initialize: {}", e));
+                rt.block_on(async {
+                    log::debug!("starting background cpu-heavy work");
+                    process_cpu_work().await;
+                });
+            })
+            .unwrap_or_else(|e| panic!("cpu heavy thread failed_to_initialize: {}", e));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn process_cpu_work() {
+        // we only use this channel for routing work, it should move pretty quick, it can be small
+        let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+        // share the handle to the background channel globally
+        CPU_HEAVY_THREAD_POOL.set(tx).unwrap();
+
+        while let Some(work) = rx.recv().await {
+            tokio::task::spawn(work);
+        }
+    }
+
+    // retrieve the sender to the background channel, and send the future over to it for execution
+    fn send_to_background_runtime(future: impl Future<Output = ()> + Send + 'static) {
+        let tx = CPU_HEAVY_THREAD_POOL.get().expect(
+            "start up the secondary tokio runtime before sending to `CPU_HEAVY_THREAD_POOL`",
+        );
+
+        match tx.try_send(Box::pin(future)) {
+            Ok(_) => (),
+            Err(TrySendError::Closed(_)) => {
+                panic!("background cpu heavy runtime channel is closed")
+            }
+            Err(TrySendError::Full(msg)) => {
+                log::warn!(
+                    "background cpu heavy runtime channel is full, task spawning loop delayed"
+                );
+                let tx = tx.clone();
+                Handle::current().spawn(async move {
+                    tx.send(msg)
+                        .await
+                        .expect("background cpu heavy runtime channel is closed")
+                });
+            }
+        }
+    }
+
+    // This tower layer injects futures with a oneshot channel, and then sends them to the background runtime for processing.
+    // We don't use the Buffer service because that is intended to process sequentially on a single task, whereas we want to
+    // spawn a new task per call.
+    #[derive(Copy, Clone)]
+    pub struct BackgroundProcessorLayer {}
+    impl BackgroundProcessorLayer {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+    impl<S> Layer<S> for BackgroundProcessorLayer {
+        type Service = BackgroundProcessor<S>;
+        fn layer(&self, service: S) -> Self::Service {
+            BackgroundProcessor::new(service)
+        }
+    }
+
+    impl std::fmt::Debug for BackgroundProcessorLayer {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.debug_struct("BackgroundProcessorLayer").finish()
+        }
+    }
+
+    // This tower service injects futures with a oneshot channel, and then sends them to the background runtime for processing.
+    #[derive(Debug, Clone)]
+    pub struct BackgroundProcessor<S> {
+        inner: S,
+    }
+
+    impl<S> BackgroundProcessor<S> {
+        pub fn new(inner: S) -> Self {
+            BackgroundProcessor { inner }
+        }
+    }
+
+    impl<S, Request> Service<Request> for BackgroundProcessor<S>
+    where
+        S: Service<Request>,
+        S::Response: Send + 'static,
+        S::Error: Into<BoxError> + Send,
+        S::Future: Send + 'static,
+    {
+        type Response = S::Response;
+
+        type Error = BoxError;
+
+        type Future = BackgroundResponseFuture<S::Response>;
+
+        fn poll_ready(
+            &mut self,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            match self.inner.poll_ready(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(r) => Poll::Ready(r.map_err(Into::into)),
+            }
+        }
+
+        fn call(&mut self, req: Request) -> Self::Future {
+            let response = self.inner.call(req);
+
+            // wrap our inner service's future with a future that writes to this oneshot channel
+            let (mut tx, rx) = tokio::sync::oneshot::channel();
+            let future = async move {
+                select!(
+                    _ = tx.closed() => {
+                        // receiver already dropped, don't need to do anything
+                    }
+                    result = response.map_err(|err| Into::<BoxError>::into(err)) => {
+                        // if this fails, the receiver already dropped, so we don't need to do anything
+                        let _ = tx.send(result);
+                    }
+                )
+            };
+            // send the wrapped future to the background
+            send_to_background_runtime(future);
+
+            BackgroundResponseFuture::new(rx)
+        }
+    }
+
+    // `BackgroundProcessor` response future
+    pin_project! {
+        #[derive(Debug)]
+        pub struct BackgroundResponseFuture<S> {
+            #[pin]
+            rx: tokio::sync::oneshot::Receiver<Result<S, BoxError>>,
+        }
+    }
+
+    impl<S> BackgroundResponseFuture<S> {
+        pub(crate) fn new(rx: tokio::sync::oneshot::Receiver<Result<S, BoxError>>) -> Self {
+            BackgroundResponseFuture { rx }
+        }
+    }
+
+    impl<S> Future for BackgroundResponseFuture<S>
+    where
+        S: Send + 'static,
+    {
+        type Output = Result<S, BoxError>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = self.project();
+
+            // now poll on the receiver end of the oneshot to get the result
+            match this.rx.poll(cx) {
+                Poll::Ready(v) => match v {
+                    Ok(v) => Poll::Ready(v.map_err(Into::into)),
+                    Err(err) => Poll::Ready(Err(Box::new(err) as BoxError)),
+                },
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}
+
+// The [cfg(not(target_arch = "wasm32"))] above prevent building the tokio::main function
+// for wasm32 target, because tokio isn't compatible with wasm32.
+// If you aren't building for wasm32, you don't need that line.
+// The two lines below avoid the "'main' function not found" error when building for wasm32 target.
+#[cfg(any(target_arch = "wasm32"))]
+fn main() {}

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -18,7 +18,8 @@ use crate::async_impl::h3_client::connect::H3Connector;
 #[cfg(feature = "http3")]
 use crate::async_impl::h3_client::{H3Client, H3ResponseFuture};
 use crate::connect::{
-    BoxedConnectorLayer, BoxedConnectorService, Conn, Connector, ConnectorBuilder,
+    sealed::{Conn, Unnameable},
+    BoxedConnectorLayer, BoxedConnectorService, Connector, ConnectorBuilder,
 };
 #[cfg(feature = "cookies")]
 use crate::cookie;
@@ -1987,8 +1988,9 @@ impl ClientBuilder {
     pub fn connector_layer<L>(mut self, layer: L) -> ClientBuilder
     where
         L: Layer<BoxedConnectorService> + Clone + Send + Sync + 'static,
-        L::Service: Service<Uri, Response = Conn, Error = BoxError> + Clone + Send + Sync + 'static,
-        <L::Service as Service<Uri>>::Future: Send + 'static,
+        L::Service:
+            Service<Unnameable, Response = Conn, Error = BoxError> + Clone + Send + Sync + 'static,
+        <L::Service as Service<Unnameable>>::Future: Send + 'static,
     {
         let layer = BoxCloneSyncServiceLayer::new(layer);
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -10,7 +10,6 @@ use std::thread;
 use std::time::Duration;
 
 use http::header::HeaderValue;
-use http::Uri;
 use log::{error, trace};
 use tokio::sync::{mpsc, oneshot};
 use tower::Layer;
@@ -19,8 +18,8 @@ use tower::Service;
 use super::request::{Request, RequestBuilder};
 use super::response::Response;
 use super::wait;
+use crate::connect::sealed::{Conn, Unnameable};
 use crate::connect::BoxedConnectorService;
-use crate::connect::Conn;
 use crate::dns::Resolve;
 use crate::error::BoxError;
 #[cfg(feature = "__tls")]
@@ -998,8 +997,9 @@ impl ClientBuilder {
     pub fn connector_layer<L>(self, layer: L) -> ClientBuilder
     where
         L: Layer<BoxedConnectorService> + Clone + Send + Sync + 'static,
-        L::Service: Service<Uri, Response = Conn, Error = BoxError> + Clone + Send + Sync + 'static,
-        <L::Service as Service<Uri>>::Future: Send + 'static,
+        L::Service:
+            Service<Unnameable, Response = Conn, Error = BoxError> + Clone + Send + Sync + 'static,
+        <L::Service as Service<Unnameable>>::Future: Send + 'static,
     {
         self.with_inner(|inner| inner.connector_layer(layer))
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -165,6 +165,18 @@ impl Error {
     }
 }
 
+/// Converts from external types to reqwest's
+/// internal equivalents.
+///
+/// Currently only is used for `tower::timeout::error::Elapsed`.
+pub(crate) fn cast_to_internal_error(error: BoxError) -> BoxError {
+    if error.is::<tower::timeout::error::Elapsed>() {
+        Box::new(crate::error::TimedOut) as BoxError
+    } else {
+        error
+    }
+}
+
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = f.debug_struct("reqwest::Error");

--- a/tests/connector_layers.rs
+++ b/tests/connector_layers.rs
@@ -1,0 +1,374 @@
+#![cfg(not(target_arch = "wasm32"))]
+#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+mod support;
+
+use std::time::Duration;
+
+use futures_util::future::join_all;
+use tower::layer::util::Identity;
+use tower::limit::ConcurrencyLimitLayer;
+use tower::timeout::TimeoutLayer;
+
+use support::{delay_layer::DelayLayer, server};
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn non_op_layer() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::Client::builder()
+        .connector_layer(Identity::new())
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    let res = client.get(url).send().await;
+
+    assert!(res.is_ok());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn non_op_layer_with_timeout() {
+    let _ = env_logger::try_init();
+
+    let client = reqwest::Client::builder()
+        .connector_layer(Identity::new())
+        .connect_timeout(Duration::from_millis(200))
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    // never returns
+    let url = "http://192.0.2.1:81/slow";
+
+    let res = client.get(url).send().await;
+
+    let err = res.unwrap_err();
+
+    assert!(err.is_connect() && err.is_timeout());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn with_connect_timeout_layer_never_returning() {
+    let _ = env_logger::try_init();
+
+    let client = reqwest::Client::builder()
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(100)))
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    // never returns
+    let url = "http://192.0.2.1:81/slow";
+
+    let res = client.get(url).send().await;
+
+    let err = res.unwrap_err();
+
+    assert!(err.is_connect() && err.is_timeout());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn with_connect_timeout_layer_slow() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(200)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(100)))
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    let res = client.get(url).send().await;
+
+    let err = res.unwrap_err();
+
+    assert!(err.is_connect() && err.is_timeout());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn multiple_timeout_layers_under_threshold() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(100)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(200)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(300)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(500)))
+        .connect_timeout(Duration::from_millis(200))
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    let res = client.get(url).send().await;
+
+    assert!(res.is_ok());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn multiple_timeout_layers_over_threshold() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(100)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(50)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(50)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(50)))
+        .connect_timeout(Duration::from_millis(50))
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    let res = client.get(url).send().await;
+
+    let err = res.unwrap_err();
+
+    assert!(err.is_connect() && err.is_timeout());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn with_concurrency_limit_layer_timeout() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(100)))
+        .connector_layer(ConcurrencyLimitLayer::new(1))
+        .timeout(Duration::from_millis(200))
+        .pool_max_idle_per_host(0) // disable connection reuse to force resource contention on the concurrency limit semaphore
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    // first call succeeds since no resource contention
+    let res = client.get(url.clone()).send().await;
+    assert!(res.is_ok());
+
+    // 3 calls where the second two wait on the first and time out
+    let mut futures = Vec::new();
+    for _ in 0..3 {
+        futures.push(client.clone().get(url.clone()).send());
+    }
+
+    let all_res = join_all(futures).await;
+
+    let timed_out = all_res
+        .into_iter()
+        .any(|res| res.is_err_and(|err| err.is_timeout()));
+
+    assert!(timed_out, "at least one request should have timed out");
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn with_concurrency_limit_layer_success() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(100)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(200)))
+        .connector_layer(ConcurrencyLimitLayer::new(1))
+        .timeout(Duration::from_millis(1000))
+        .pool_max_idle_per_host(0) // disable connection reuse to force resource contention on the concurrency limit semaphore
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    // first call succeeds since no resource contention
+    let res = client.get(url.clone()).send().await;
+    assert!(res.is_ok());
+
+    // 3 calls of which all are individually below the inner timeout
+    // and the sum is below outer timeout which affects the final call which waited the whole time
+    let mut futures = Vec::new();
+    for _ in 0..3 {
+        futures.push(client.clone().get(url.clone()).send());
+    }
+
+    let all_res = join_all(futures).await;
+
+    for res in all_res.into_iter() {
+        assert!(
+            res.is_ok(),
+            "neither outer long timeout or inner short timeout should be exceeded"
+        );
+    }
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn non_op_layer_blocking_client() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::blocking::Client::builder()
+        .connector_layer(Identity::new())
+        .build()
+        .unwrap();
+
+    let res = client.get(url).send();
+
+    assert!(res.is_ok());
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn timeout_layer_blocking_client() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::blocking::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(100)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(50)))
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    let res = client.get(url).send();
+    let err = res.unwrap_err();
+
+    assert!(err.is_connect() && err.is_timeout());
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn concurrency_layer_blocking_client_timeout() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::blocking::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(100)))
+        .connector_layer(ConcurrencyLimitLayer::new(1))
+        .timeout(Duration::from_millis(200))
+        .pool_max_idle_per_host(0) // disable connection reuse to force resource contention on the concurrency limit semaphore
+        .build()
+        .unwrap();
+
+    let res = client.get(url.clone()).send();
+
+    assert!(res.is_ok());
+
+    // 3 calls where the second two wait on the first and time out
+    let mut join_handles = Vec::new();
+    for _ in 0..3 {
+        let client = client.clone();
+        let url = url.clone();
+        let join_handle = std::thread::spawn(move || client.get(url.clone()).send());
+        join_handles.push(join_handle);
+    }
+
+    let timed_out = join_handles
+        .into_iter()
+        .any(|handle| handle.join().unwrap().is_err_and(|err| err.is_timeout()));
+
+    assert!(timed_out, "at least one request should have timed out");
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn concurrency_layer_blocking_client_success() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::blocking::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(100)))
+        .connector_layer(TimeoutLayer::new(Duration::from_millis(200)))
+        .connector_layer(ConcurrencyLimitLayer::new(1))
+        .timeout(Duration::from_millis(1000))
+        .pool_max_idle_per_host(0) // disable connection reuse to force resource contention on the concurrency limit semaphore
+        .build()
+        .unwrap();
+
+    let res = client.get(url.clone()).send();
+
+    assert!(res.is_ok());
+
+    // 3 calls of which all are individually below the inner timeout
+    // and the sum is below outer timeout which affects the final call which waited the whole time
+    let mut join_handles = Vec::new();
+    for _ in 0..3 {
+        let client = client.clone();
+        let url = url.clone();
+        let join_handle = std::thread::spawn(move || client.get(url.clone()).send());
+        join_handles.push(join_handle);
+    }
+
+    for handle in join_handles {
+        let res = handle.join().unwrap();
+        assert!(
+            res.is_ok(),
+            "neither outer long timeout or inner short timeout should be exceeded"
+        );
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn no_generic_bounds_required_for_client_new() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::Client::new();
+    let res = client.get(url).send().await;
+
+    assert!(res.is_ok());
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn no_generic_bounds_required_for_client_new_blocking() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}", server.addr());
+
+    let client = reqwest::blocking::Client::new();
+    let res = client.get(url).send();
+
+    assert!(res.is_ok());
+}

--- a/tests/support/delay_layer.rs
+++ b/tests/support/delay_layer.rs
@@ -1,0 +1,119 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use pin_project_lite::pin_project;
+use tokio::time::Sleep;
+use tower::{BoxError, Layer, Service};
+
+/// This tower layer injects an arbitrary delay before calling downstream layers.
+#[derive(Clone)]
+pub struct DelayLayer {
+    delay: Duration,
+}
+
+impl DelayLayer {
+    pub const fn new(delay: Duration) -> Self {
+        DelayLayer { delay }
+    }
+}
+
+impl<S> Layer<S> for DelayLayer {
+    type Service = Delay<S>;
+    fn layer(&self, service: S) -> Self::Service {
+        Delay::new(service, self.delay)
+    }
+}
+
+impl std::fmt::Debug for DelayLayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("DelayLayer")
+            .field("delay", &self.delay)
+            .finish()
+    }
+}
+
+/// This tower service injects an arbitrary delay before calling downstream layers.
+#[derive(Debug, Clone)]
+pub struct Delay<S> {
+    inner: S,
+    delay: Duration,
+}
+impl<S> Delay<S> {
+    pub fn new(inner: S, delay: Duration) -> Self {
+        Delay { inner, delay }
+    }
+}
+
+impl<S, Request> Service<Request> for Delay<S>
+where
+    S: Service<Request>,
+    S::Error: Into<BoxError>,
+{
+    type Response = S::Response;
+
+    type Error = BoxError;
+
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        match self.inner.poll_ready(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(r) => Poll::Ready(r.map_err(Into::into)),
+        }
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let response = self.inner.call(req);
+        let sleep = tokio::time::sleep(self.delay);
+
+        ResponseFuture::new(response, sleep)
+    }
+}
+
+// `Delay` response future
+pin_project! {
+    #[derive(Debug)]
+    pub struct ResponseFuture<S> {
+        #[pin]
+        response: S,
+        #[pin]
+        sleep: Sleep,
+    }
+}
+
+impl<S> ResponseFuture<S> {
+    pub(crate) fn new(response: S, sleep: Sleep) -> Self {
+        ResponseFuture { response, sleep }
+    }
+}
+
+impl<F, S, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<S, E>>,
+    E: Into<BoxError>,
+{
+    type Output = Result<S, BoxError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        // First poll the sleep until complete
+        match this.sleep.poll(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(_) => {}
+        }
+
+        // Then poll the inner future
+        match this.response.poll(cx) {
+            Poll::Ready(v) => Poll::Ready(v.map_err(Into::into)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,4 @@
+pub mod delay_layer;
 pub mod delay_server;
 pub mod server;
 

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -338,6 +338,24 @@ fn timeout_blocking_request() {
 }
 
 #[cfg(feature = "blocking")]
+#[test]
+fn connect_timeout_blocking_request() {
+    let _ = env_logger::try_init();
+
+    let client = reqwest::blocking::Client::builder()
+        .connect_timeout(Duration::from_millis(100))
+        .build()
+        .unwrap();
+
+    // never returns
+    let url = "http://192.0.2.1:81/slow";
+
+    let err = client.get(url).send().unwrap_err();
+
+    assert!(err.is_timeout());
+}
+
+#[cfg(feature = "blocking")]
 #[cfg(feature = "stream")]
 #[test]
 fn blocking_request_timeout_body() {


### PR DESCRIPTION
## Background
Closes: https://github.com/seanmonstar/reqwest/issues/2490

This PR adds support for injecting arbitrary layers into the `Connector`'s tower service stack, provided their corresponding futures have `Send + Sync + 'static` bounds (as well as the layer itself, in the blocking client's case).

I included a working example showing my specific use case that this unblocks: delegating the connection future to a secondary, low priority executor. (This has to do with perf issues with long-polling TLS futures, ref: https://github.com/rustls/tokio-rustls/issues/94)

This required bumping the MSRV to 1.64 to get access to: https://github.com/tower-rs/tower/pull/777

Sample usage:
```
let client = reqwest::Client::builder()
                  // resolved to outermost layer, so before the semaphore permit is attempted
                  .connect_timeout(Duration::from_millis(100)) 
                  // underneath the concurrency check, so only after a semaphore permit is acquired
                  .connector_layer(tower::timeout::TimeoutLayer::new(Duration::from_millis(50)))
                  .connector_layer(tower::limit::concurrency::ConcurrencyLimitLayer::new(2))
                  .build()
                  .unwrap();
```

## Performance ramifications 
I took care to ensure that there is no meaningful overhead in the case of the caller not using any custom layers. We just use the base service on its own, basically. We actually could probably optimize it a tiny bit further beyond the existing state by splitting the base service into one with a timeout and one without, to avoid that branching every connection, but I didn't bother. My focus was just on avoiding indirection/allocation, mostly.

For cases with custom layers, I took the middle ground of using generics on the input side, but type erasing when constructing the tower stack to avoid badly polluting the rest of the library with generics. We are able to avoid muddying the input API with generics (which would be a breaking change) by initializing our builder with the non-op `tower_layer::Identity` layer.

The custom layer approach approach does involve an extra allocation/v-table, since we are using [BoxCloneSyncService](https://docs.rs/tower-http-client/latest/tower_http_client/util/struct.BoxCloneSyncService.html) on the very outside of the stack to type-erase our layer stack. The generic input bounds let us avoid an additional indirection layer per custom layer, at least. 

My feeling is, if the caller cares to avoid that final allocation, they probably want to construct a lower level client anyway. Theoretically we could flatten the current `Box::pin()` we do for the base service, into the outer `Box::pin()`, but it would take changes to the `Connect` trait in `hyper-util`.


## Relationship to connect_timeout() config
If the caller specifies any custom layers, we implicitly hoist `builder.connect_timeout()` settings to an outermost `TimeoutLayer`. I feel that this is what the average caller would expect. If they need to move a timeout somewhere else in the stack, they can just compose the `TimeoutLayer` directly in their stack. I have doc comments showing this case directly.

Meanwhile, in the case of no custom layers, we just keep the old behavior of evaluating the timeout directly inside the base tower service future. We do it that way since using a separate timeout layer forces an extra `Box::pin` as the tokio `Timeout` future is `Unpin`. 

I would have preferred to always use the timeout layer approach, but we're currently unconditionally `Box::pin`-ing inside the base service due to bounds imposed by the underlying `Connect` trait in `hyper-util`. Didn't want to go deeper there.

## Added dependency on `tower`
I want to call out that this adds a dependency on `tower`, with features `util` and `timeout`. Previously we only had `tower_service`. I need this for:
```
tower::ServiceBuilder,
tower::Layer
tower::layer::util::Identity
tower::layer::util::Stack
tower::timeout::TimeoutLayer
```
Also some additional dev dependencies to show some sample usages in tests/examples.

I could see an argument for putting this behind a feature flag. My feeling was, tower pluggability of reqwest is only going to grow, and it probably doesn't make sense to keep as a feature gate long term since it will (perhaps) become a core feature as the tower middleware ecosystem grows. 

But, glad to throw this functionality behind a feature flag, up to the maintainers. I probably would switch to type erasing at every passed in tower layer at that point, since managing all the generic bounds w/r/t conditional compiling sounds miserable.

## Testing
The tests should be fairly resilient. There are integration tests probing behavior of the connector with timeout, concurrency limit, and non-op layers, including both blocking and non-blocking clients.

I wrote a custom layer in the `/tests/` directory that injects arbitrary delays. Previously the only support for connect delays we had was all-or-nothing. This was handy for testing things like concurrency limits on the client usage without doing more complex server construction.

I did test my new example locally, it resolves properly via the background channel tls handshake.

I would have preferred to unit test the composed stacks more directly inside `async_impl::connect`, but I didn't see a convenient way to construct a throwaway client inside that module. It seemed like most cases where we construct a client are in the integration tests. Please correct me if I'm missing something :)