### PR TITLE
dep: upgrade url from 2.4 to 2.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ __internal_proxy_sys_no_cache = []
 [dependencies]
 base64 = "0.22"
 http = "1"
-url = "2.4"
+url = "2.5"
 bytes = "1.0"
 serde = "1.0"
 serde_urlencoded = "0.7.1"


### PR DESCRIPTION
That is to pull `idna` dependency of version `1.0`, which fixes a bug where Punycode labels that produce any non-ASCII characters are accepted and decoded.