### PR TITLE
fix: remove tower as dependency for wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ url = "2.4"
 bytes = "1.0"
 serde = "1.0"
 serde_urlencoded = "0.7.1"
-tower = { version = "0.5.2", default-features = false, features = ["timeout", "util"] }
 tower-service = "0.3"
 futures-core = { version = "0.3.28", default-features = false }
 futures-util = { version = "0.3.28", default-features = false }
@@ -130,6 +129,7 @@ log = "0.4.17"
 mime = "0.3.16"
 percent-encoding = "2.3"
 tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
+tower = { version = "0.5.2", default-features = false, features = ["timeout", "util"] }
 pin-project-lite = "0.2.11"
 ipnet = "2.3"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -169,6 +169,7 @@ impl Error {
 /// internal equivalents.
 ///
 /// Currently only is used for `tower::timeout::error::Elapsed`.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn cast_to_internal_error(error: BoxError) -> BoxError {
     if error.is::<tower::timeout::error::Elapsed>() {
         Box::new(crate::error::TimedOut) as BoxError

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@
 //!
 //! The Client implementation automatically switches to the WASM one when the target_arch is wasm32,
 //! the usage is basically the same as the async api. Some of the features are disabled in wasm
-//! : [`tls`], [`cookie`], [`blocking`].
+//! : [`tls`], [`cookie`], [`blocking`], as well as various `ClientBuilder` methods such as `timeout()` and `connector_layer()`.
 //!
 //!
 //! ## Optional Features


### PR DESCRIPTION
Closes #2509  

This addresses the change likely that caused the wasm regression. 

(EDIT: I've now reproduced the failure and can confirm this fixes it)

---

Changes to dependencies on wasm32-unknown-unknown:

Old (has tower):
```
> cargo tree --target wasm32-unknown-unknown

reqwest v0.12.11 (/workplace/jlizen/reqwest)
<snip>
├── tower v0.5.2
│   ├── futures-core v0.3.31
│   ├── futures-util v0.3.31 (*)
│   ├── pin-project-lite v0.2.15
│   ├── sync_wrapper v1.0.2 (*)
│   ├── tokio v1.42.0
│   │   └── pin-project-lite v0.2.15
│   ├── tokio-util v0.7.13
│   │   ├── bytes v1.9.0
│   │   ├── futures-core v0.3.31
│   │   ├── futures-sink v0.3.31
│   │   ├── pin-project-lite v0.2.15
│   │   └── tokio v1.42.0 (*)
│   ├── tower-layer v0.3.3
│   ├── tower-service v0.3.3
│   └── tracing v0.1.41
│       ├── pin-project-lite v0.2.15
│       └── tracing-core v0.1.33
│           └── once_cell v1.20.2
├── tower-service v0.3.3
<snip>
[dev-dependencies]
<snip>
```

New (tower is only for tests):
```
cargo tree --target wasm32-unknown-unknown
reqwest v0.12.11 (/workplace/jlizen/reqwest)
<snip>
├── tower-service v0.3.3
<snip>
[dev-dependencies]
<snip>
├── tower v0.5.2
│   ├── futures-core v0.3.31
│   ├── pin-project-lite v0.2.15
│   ├── tokio v1.42.0
│   │   └── pin-project-lite v0.2.15
│   ├── tokio-util v0.7.13
│   │   ├── bytes v1.9.0
│   │   ├── futures-core v0.3.31
│   │   ├── futures-sink v0.3.31
│   │   ├── pin-project-lite v0.2.15
│   │   └── tokio v1.42.0 (*)
│   ├── tower-layer v0.3.3
│   ├── tower-service v0.3.3
│   └── tracing v0.1.41
│       ├── pin-project-lite v0.2.15
│       └── tracing-core v0.1.33
│           └── once_cell v1.20.2
<snip>
```