### PR TITLE
Update `windows-registry` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ futures-util = { version = "0.3.28", default-features = false, features = ["std"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-registry = "0.2"
+windows-registry = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 system-configuration = { version = "0.6.0", optional = true }


### PR DESCRIPTION
The latest release of the `windows-registry` crate is now available.

https://github.com/microsoft/windows-rs/releases/tag/0.61.0

This also syncs the version of the `windows-registry` crate with the version used to build `rustup`. https://github.com/rust-lang/rustup/pull/4146