### PR TITLE
Expose a `Form::into_reader()` method on blocking multipart forms.

### DIFF
--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -148,6 +148,11 @@ impl Form {
         Reader::new(self)
     }
 
+    /// Produce a reader over the multipart form data.
+    pub fn into_reader(self) -> impl Read {
+        self.reader()
+    }
+
     // If predictable, computes the length the request will have
     // The length should be predictable if only String and file fields have been added,
     // but not if a generic reader has been added;


### PR DESCRIPTION
An example use case is compressing multipart form data with zstd. The entire contents of the payload have to be compressed together, which requires accessing the contents of the `Form`.

The existing reader functionality already implements what we need, but just isn't publicly accessible. This PR adds a `pub` method for it.