### PR TITLE
feat: Send `form` allows overriding of `CONTENT_TYPE`

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -411,10 +411,11 @@ impl RequestBuilder {
         if let Ok(ref mut req) = self.request {
             match serde_urlencoded::to_string(form) {
                 Ok(body) => {
-                    req.headers_mut().insert(
-                        CONTENT_TYPE,
-                        HeaderValue::from_static("application/x-www-form-urlencoded"),
-                    );
+                    req.headers_mut()
+                    .entry(CONTENT_TYPE)
+                    .or_insert(HeaderValue::from_static(
+                        "application/x-www-form-urlencoded",
+                    ));
                     *req.body_mut() = Some(body.into());
                 }
                 Err(err) => error = Some(crate::error::builder(err)),

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -412,10 +412,10 @@ impl RequestBuilder {
             match serde_urlencoded::to_string(form) {
                 Ok(body) => {
                     req.headers_mut()
-                    .entry(CONTENT_TYPE)
-                    .or_insert(HeaderValue::from_static(
-                        "application/x-www-form-urlencoded",
-                    ));
+                        .entry(CONTENT_TYPE)
+                        .or_insert(HeaderValue::from_static(
+                            "application/x-www-form-urlencoded",
+                        ));
                     *req.body_mut() = Some(body.into());
                 }
                 Err(err) => error = Some(crate::error::builder(err)),

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -455,10 +455,10 @@ impl RequestBuilder {
             match serde_urlencoded::to_string(form) {
                 Ok(body) => {
                     req.headers_mut()
-                    .entry(CONTENT_TYPE)
-                    .or_insert(HeaderValue::from_static(
-                        "application/x-www-form-urlencoded",
-                    ));
+                        .entry(CONTENT_TYPE)
+                        .or_insert(HeaderValue::from_static(
+                            "application/x-www-form-urlencoded",
+                        ));
                     *req.body_mut() = Some(body.into());
                 }
                 Err(err) => error = Some(crate::error::builder(err)),

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -454,10 +454,11 @@ impl RequestBuilder {
         if let Ok(ref mut req) = self.request {
             match serde_urlencoded::to_string(form) {
                 Ok(body) => {
-                    req.headers_mut().insert(
-                        CONTENT_TYPE,
-                        HeaderValue::from_static("application/x-www-form-urlencoded"),
-                    );
+                    req.headers_mut()
+                    .entry(CONTENT_TYPE)
+                    .or_insert(HeaderValue::from_static(
+                        "application/x-www-form-urlencoded",
+                    ));
                     *req.body_mut() = Some(body.into());
                 }
                 Err(err) => error = Some(crate::error::builder(err)),


### PR DESCRIPTION
This allows overriding the default `Content-Type` set by the form method, similar to how the json method handles it. On some servers, we may need to use `application/x-www-form-urlencoded;charset=utf-8` to replace the default `application/x-www-form-urlencoded`.

- json

https://github.com/seanmonstar/reqwest/blob/3099f30f089854f8109c49e13898d2f88b9fc0f2/src/async_impl/request.rs#L446