### PR TITLE
tests: serialize tests that read/write the same environment variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ __tls = ["dep:rustls-pemfile", "tokio/io-util"]
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls", "dep:rustls-pemfile", "dep:rustls-pki-types"]
 __rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "quinn?/ring"]
 
-# When enabled, disable using the cached SYS_PROXIES.
+# Unused since v0.12.9, only present for backwards compatibility (PR#2442)
 __internal_proxy_sys_no_cache = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,6 @@ __tls = ["dep:rustls-pemfile", "tokio/io-util"]
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls", "dep:rustls-pemfile", "dep:rustls-pki-types"]
 __rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "quinn?/ring"]
 
-# Unused since v0.12.9, only present for backwards compatibility (PR#2442)
-__internal_proxy_sys_no_cache = []
-
 [dependencies]
 base64 = "0.22"
 http = "1"


### PR DESCRIPTION
This avoids race conditions between tests that change the same environment variable, and fixes flaky test failures in multi-threaded environments present since since #2442.

Also updates the comment in Cargo.toml for the `__internal_proxy_sys_no_cache` feature, which is a noop since that PR landed, and is only present for backwards compatibility.

Fixes #2468