### PR TITLE
chore: replace rustls-pemfile with rustls-pki-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,11 +88,11 @@ http3 = ["rustls-tls-manual-roots", "dep:h3", "dep:h3-quinn", "dep:quinn", "dep:
 # Don't rely on these whatsoever. They may disappear at any time.
 
 # Enables common types used for TLS. Useless on its own.
-__tls = ["dep:rustls-pemfile", "tokio/io-util"]
+__tls = ["dep:rustls-pki-types", "tokio/io-util"]
 
 # Enables common rustls code.
 # Equivalent to rustls-tls-manual-roots but shorter :)
-__rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls", "dep:rustls-pemfile", "dep:rustls-pki-types"]
+__rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls"]
 __rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "quinn?/ring"]
 
 [dependencies]
@@ -131,7 +131,7 @@ pin-project-lite = "0.2.11"
 ipnet = "2.3"
 
 # Optional deps...
-rustls-pemfile = { version = "2", optional = true }
+rustls-pki-types = { version = "1.9.0", features = ["std"], optional = true }
 
 ## default-tls
 hyper-tls = { version = "0.6", optional = true }
@@ -141,7 +141,6 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 # rustls-tls
 hyper-rustls = { version = "0.27.0", default-features = false, optional = true, features = ["http1", "tls12"] }
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
-rustls-pki-types = { version = "1.1.0", features = ["alloc"] ,optional = true }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 webpki-roots = { version = "0.26.0", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }


### PR DESCRIPTION
Replaces rustls-pemfile crate with the rustls-pki-types api.