### PR TITLE
docs: improve error message on identity+rustls

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -428,7 +428,7 @@ impl ClientBuilder {
                     {
                         // Default backend + rustls Identity doesn't work.
                         if let Some(_id) = config.identity {
-                            return Err(crate::error::builder("incompatible TLS identity type"));
+                            return Err(crate::error::builder("Default backend doesn't support identity with rustls. Create a client with use_rustls_tls."));
                         }
                     }
 


### PR DESCRIPTION
Currently, it is a little bit misleading for newbies: They might think that identity+rustls doesn't work at all.