### PR TITLE
feat: make DNS resolver implementations public

### DIFF
--- a/src/dns/gai.rs
+++ b/src/dns/gai.rs
@@ -5,10 +5,14 @@ use tower_service::Service;
 use crate::dns::{Addrs, Name, Resolve, Resolving};
 use crate::error::BoxError;
 
+/// A resolver using blocking `getaddrinfo` calls in a threadpool.
+///
+/// Based on [`hyper_util`]s [`GaiResolver`](hyper_util::client::legacy::connect::dns::GaiResolver).
 #[derive(Debug)]
 pub struct GaiResolver(HyperGaiResolver);
 
 impl GaiResolver {
+    /// Construct a new [`GaiResolver`].
     pub fn new() -> Self {
         Self(HyperGaiResolver::new())
     }

--- a/src/dns/hickory.rs
+++ b/src/dns/hickory.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use super::{Addrs, Name, Resolve, Resolving};
 
-/// Wrapper around an `AsyncResolver`, which implements the `Resolve` trait.
+/// Wrapper around an [`TokioAsyncResolver`], which implements the [`Resolve`] trait.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct HickoryDnsResolver {
     /// Since we might not have been called in the context of a

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -1,5 +1,8 @@
 //! DNS resolution
 
+pub use gai::GaiResolver;
+#[cfg(feature = "hickory-dns")]
+pub use hickory::HickoryDnsResolver;
 pub use resolve::{Addrs, Name, Resolve, Resolving};
 pub(crate) use resolve::{DnsResolverWithOverrides, DynResolver};
 


### PR DESCRIPTION
This allows library users to name and wrap these resolvers (e.g. for additional logging or metrics) w/o copy-pasting the code.