### PR TITLE
chore: remove empty wasm shell function

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -459,19 +459,6 @@ impl RequestBuilder {
         self
     }
 
-    /// Disable CORS on fetching the request.
-    ///
-    /// # WASM
-    ///
-    /// This option is only effective with WebAssembly target.
-    ///
-    /// The [request mode][mdn] will be set to 'no-cors'.
-    ///
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
-    pub fn fetch_mode_no_cors(self) -> RequestBuilder {
-        self
-    }
-
     /// Build a `Request`, which can be inspected, modified and executed with
     /// `Client::execute()`.
     pub fn build(self) -> crate::Result<Request> {


### PR DESCRIPTION
Remove the empty WebAssembly shell function from async_client's RequestBuilder. The function is not needed on the non-wasm side, and only creates confusion on the documentation.

Related discussion in #2568.