### PR TITLE
Clarify that `Response::content_length()` is not derived from a `Content-Length` header in docs

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -79,13 +79,21 @@ impl Response {
         self.res.headers_mut()
     }
 
-    /// Get the content-length of this response, if known.
+    /// Get the content length of the response, if it is known.
+    ///
+    /// This value is not computed by parsing the `Content-Length` header of the
+    /// response, but by looking at the number of bytes actually streamed from
+    /// the server.
+    ///
+    /// To read the value of the `Content-Length` header, use the
+    /// [`Response::headers`] method instead.
     ///
     /// Reasons it may not be known:
     ///
-    /// - The server didn't send a `content-length` header.
-    /// - The response is compressed and automatically decoded (thus changing
-    ///   the actual decoded length).
+    /// - The response does not include a body (e.g. it responds to a `HEAD`
+    ///   request).
+    /// - The response is gzipped and automatically decoded (thus changing the
+    ///   actual decoded length).
     pub fn content_length(&self) -> Option<u64> {
         use hyper::body::Body;
 

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -81,12 +81,9 @@ impl Response {
 
     /// Get the content length of the response, if it is known.
     ///
-    /// This value is not computed by parsing the `Content-Length` header of the
-    /// response, but by looking at the number of bytes actually streamed from
-    /// the server.
-    ///
-    /// To read the value of the `Content-Length` header, use the
-    /// [`Response::headers`] method instead.
+    /// This value does not directly represents the value of the `Content-Length`
+    /// header, but rather the size of the response's body. To read the header's
+    /// value, please use the [`Response::headers`] method instead.
     ///
     /// Reasons it may not be known:
     ///

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -188,13 +188,21 @@ impl Response {
         self.inner.extensions_mut()
     }
 
-    /// Get the content-length of the response, if it is known.
+    /// Get the content length of the response, if it is known.
+    ///
+    /// This value is not computed by parsing the `Content-Length` header of the
+    /// response, but by looking at the number of bytes actually streamed from
+    /// the server.
+    ///
+    /// To read the value of the `Content-Length` header, use the
+    /// [`Response::headers`] method instead.
     ///
     /// Reasons it may not be known:
     ///
-    /// - The server didn't send a `content-length` header.
-    /// - The response is gzipped and automatically decoded (thus changing
-    ///   the actual decoded length).
+    /// - The response does not include a body (e.g. it responds to a `HEAD`
+    ///   request).
+    /// - The response is gzipped and automatically decoded (thus changing the
+    ///   actual decoded length).
     pub fn content_length(&self) -> Option<u64> {
         self.inner.content_length()
     }

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -190,12 +190,10 @@ impl Response {
 
     /// Get the content length of the response, if it is known.
     ///
-    /// This value is not computed by parsing the `Content-Length` header of the
-    /// response, but by looking at the number of bytes actually streamed from
-    /// the server.
     ///
-    /// To read the value of the `Content-Length` header, use the
-    /// [`Response::headers`] method instead.
+    /// This value does not directly represents the value of the `Content-Length`
+    /// header, but rather the size of the response's body. To read the header's
+    /// value, please use the [`Response::headers`] method instead.
     ///
     /// Reasons it may not be known:
     ///


### PR DESCRIPTION
Something that's bitten me a few times (and that I see others get bitten by fairly often) is that the current documentation of `Response::content_length()` can lead users to believe its return value is a representation of the `Content-Length` header in responses. While the return value of this method and that header's value might happen to match in quite a few cases, it makes things very confusing when they don't, e.g. in `HEAD` requests.

This change updates the method's documentation (in both the blocking and async implementations) to clarify that its return value is calculated independently from the value of any `Content-Length` header, and directs users to use `Response::headers()` instead. It also removes the line about a lack of `Content-Length` header causing the method to "fail", since this doesn't match the implementation.