### PR TITLE
feat: add tls_info flag to connections using proxy

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -393,7 +393,7 @@ impl ConnectorService {
                     return Ok(Conn {
                         inner: self.verbose.wrap(RustlsTlsConn { inner: io }),
                         is_proxy: false,
-                        tls_info: false,
+                        tls_info: self.tls_info,
                     });
                 }
             }
@@ -404,7 +404,7 @@ impl ConnectorService {
         socks::connect(proxy, dst, dns).await.map(|tcp| Conn {
             inner: self.verbose.wrap(TokioIo::new(tcp)),
             is_proxy: false,
-            tls_info: false,
+            tls_info: self.tls_info,
         })
     }
 
@@ -540,7 +540,7 @@ impl ConnectorService {
                             inner: TokioIo::new(io),
                         }),
                         is_proxy: false,
-                        tls_info: false,
+                        tls_info: self.tls_info,
                     });
                 }
             }
@@ -575,7 +575,7 @@ impl ConnectorService {
                             inner: TokioIo::new(io),
                         }),
                         is_proxy: false,
-                        tls_info: false,
+                        tls_info: self.tls_info,
                     });
                 }
             }


### PR DESCRIPTION
adds `tls_info` flag to connections using proxy

Fixes #2589 

note:
I wanted to add other tests but noticed that the fake server does not supports https, and there are some skipped test that have the `#[ignore = "Needs TLS support in the test server"]` so not sure this is something that maintainers would like to have.