### PR TITLE
Update cookie_store to fix security issue in idna<1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ rustls-native-certs = { version = "0.8.0", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }
-cookie_store = { version = "0.21.0", optional = true }
+cookie_store = { version = "0.21.1", optional = true }
 
 ## compression
 async-compression = { version = "0.4.0", default-features = false, features = ["tokio"], optional = true }


### PR DESCRIPTION
Looks like MSRV did not change and tests via `cargo test --features cookies` run fine on my machine.
Link to described issue https://rustsec.org/advisories/RUSTSEC-2024-0421.html