### PR TITLE
Added osv-scanner.toml file to ignore npm packages in vuln scans.

### DIFF
--- a/examples/wasm_github_fetch/osv-scanner.toml
+++ b/examples/wasm_github_fetch/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[PackageOverrides]]
+ecosystem = "npm"
+ignore = true


### PR DESCRIPTION
Closes #2592.