### PR TITLE
re-add fetch_mode_no_cors shim when not in wasm, but deprecated

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -459,6 +459,19 @@ impl RequestBuilder {
         self
     }
 
+    // This was a shell only meant to help with rendered documentation.
+    // However, docs.rs can now show the docs for the wasm platforms, so this
+    // is no longer needed.
+    //
+    // You should not otherwise depend on this function. It's deprecation
+    // is just to nudge people to reduce breakage. It may be removed in a
+    // future patch version.
+    #[doc(hidden)]
+    #[cfg_attr(target_arch = "wasm32", deprecated)]
+    pub fn fetch_mode_no_cors(self) -> RequestBuilder {
+        self
+    }
+
     /// Build a `Request`, which can be inspected, modified and executed with
     /// `Client::execute()`.
     pub fn build(self) -> crate::Result<Request> {


### PR DESCRIPTION
Closes #2596 