### PR TITLE
feat: add customizable headers in proxy mode

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2249,9 +2249,12 @@ impl Client {
     fn proxy_custom_headers(&self, dst: &Uri, headers: &mut HeaderMap) {
         for proxy in self.inner.proxies.iter() {
             if proxy.is_match(dst) {
-                for (key, value) in proxy.http_custom_headers(dst).unwrap().iter() {
-                    headers.insert(key.clone(), value.clone());
+                if let Some(iter) = proxy.http_custom_headers(dst) {
+                    iter.iter().for_each(|(key, value)| {
+                        headers.insert(key, value.clone());
+                    });
                 }
+
                 break;
             }
         }

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2166,6 +2166,7 @@ impl Client {
         };
 
         self.proxy_auth(&uri, &mut headers);
+        self.proxy_custom_headers(&uri, &mut headers);
 
         let builder = hyper::Request::builder()
             .method(method.clone())
@@ -2240,6 +2241,17 @@ impl Client {
                     headers.insert(PROXY_AUTHORIZATION, header);
                 }
 
+                break;
+            }
+        }
+    }
+
+    fn proxy_custom_headers(&self, dst: &Uri, headers: &mut HeaderMap) {
+        for proxy in self.inner.proxies.iter() {
+            if proxy.is_match(dst) {
+                for (key, value) in proxy.http_custom_headers(dst).unwrap().iter() {
+                    headers.insert(key.clone(), value.clone());
+                }
                 break;
             }
         }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -529,7 +529,7 @@ impl ConnectorService {
                         port,
                         self.user_agent.clone(),
                         auth,
-                        misc
+                        misc,
                     )
                     .await?;
                     let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
@@ -565,7 +565,8 @@ impl ConnectorService {
                     log::trace!("tunneling HTTPS over proxy");
                     let maybe_server_name = ServerName::try_from(host.as_str().to_owned())
                         .map_err(|_| "Invalid Server Name");
-                    let tunneled = tunnel(conn, host, port, self.user_agent.clone(), auth, misc).await?;
+                    let tunneled =
+                        tunnel(conn, host, port, self.user_agent.clone(), auth, misc).await?;
                     let server_name = maybe_server_name?;
                     let io = RustlsConnector::from(tls)
                         .connect(server_name, TokioIo::new(tunneled))
@@ -1576,7 +1577,7 @@ mod tests {
                 port,
                 ua(),
                 Some(proxy::encode_basic_auth("Aladdin", "open sesame")),
-                None
+                None,
             )
             .await
         };

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "__tls")]
 use http::header::HeaderValue;
 use http::uri::{Authority, Scheme};
-use http::{HeaderMap, Uri};
+#[cfg(feature = "__tls")]
+use http::HeaderMap;
+use http::Uri;
 use hyper::rt::{Read, ReadBufCursor, Write};
 use hyper_util::client::legacy::connect::{Connected, Connection};
 #[cfg(any(feature = "socks", feature = "__tls"))]
@@ -500,7 +502,7 @@ impl ConnectorService {
     ) -> Result<Conn, BoxError> {
         log::debug!("proxy({proxy_scheme:?}) intercepts '{dst:?}'");
 
-        let (proxy_dst, _auth, misc) = match proxy_scheme {
+        let (proxy_dst, _auth, _misc) = match proxy_scheme {
             ProxyScheme::Http { host, auth, misc } => (into_uri(Scheme::HTTP, host), auth, misc),
             ProxyScheme::Https { host, auth, misc } => (into_uri(Scheme::HTTPS, host), auth, misc),
             #[cfg(feature = "socks")]
@@ -511,6 +513,9 @@ impl ConnectorService {
 
         #[cfg(feature = "__tls")]
         let auth = _auth;
+
+        #[cfg(feature = "__tls")]
+        let misc = _misc;
 
         match &self.inner {
             #[cfg(feature = "default-tls")]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -365,8 +365,21 @@ impl Proxy {
         self
     }
 
-    /// Adds a Custom Headers to Proxy
+    /// Adds custom headers to this Proxy
     ///
+    /// # Example
+    /// ```
+    /// # extern crate reqwest;
+    /// # use reqwest::header::*;
+    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut headers = HeaderMap::new();
+    /// headers.insert(USER_AGENT, "reqwest".parse().unwrap();
+    /// let proxy = reqwest::Proxy::https("http://localhost:1234")?
+    ///     .headers(headers);
+    /// # Ok(())
+    /// # }
+    /// # fn main() {}
+    /// ```
     pub fn headers(mut self, headers: HeaderMap) -> Proxy {
         self.intercept.set_custom_headers(headers);
         self

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -378,7 +378,7 @@ impl Proxy {
     /// # use reqwest::header::*;
     /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut headers = HeaderMap::new();
-    /// headers.insert(USER_AGENT, "reqwest".parse().unwrap();
+    /// headers.insert(USER_AGENT, "reqwest".parse().unwrap());
     /// let proxy = reqwest::Proxy::https("http://localhost:1234")?
     ///     .headers(headers);
     /// # Ok(())
@@ -422,9 +422,9 @@ impl Proxy {
             Intercept::System(system) => system
                 .get("http")
                 .and_then(|s| s.maybe_http_custom_headers().cloned()),
-            Intercept::Custom(custom) => {
-                custom.call(uri).and_then(|s| s.maybe_http_custom_headers().cloned())
-            }
+            Intercept::Custom(custom) => custom
+                .call(uri)
+                .and_then(|s| s.maybe_http_custom_headers().cloned()),
             Intercept::Https(_) => None,
         }
     }
@@ -621,7 +621,7 @@ impl ProxyScheme {
         Ok(ProxyScheme::Http {
             auth: None,
             host: host.parse().map_err(crate::error::builder)?,
-            misc: None
+            misc: None,
         })
     }
 
@@ -630,7 +630,7 @@ impl ProxyScheme {
         Ok(ProxyScheme::Https {
             auth: None,
             host: host.parse().map_err(crate::error::builder)?,
-            misc: None
+            misc: None,
         })
     }
 
@@ -855,8 +855,16 @@ impl ProxyScheme {
 impl fmt::Debug for ProxyScheme {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ProxyScheme::Http { auth: _auth, host, misc: _misc } => write!(f, "http://{host}"),
-            ProxyScheme::Https { auth: _auth, host, misc: _misc } => write!(f, "https://{host}"),
+            ProxyScheme::Http {
+                auth: _auth,
+                host,
+                misc: _misc,
+            } => write!(f, "http://{host}"),
+            ProxyScheme::Https {
+                auth: _auth,
+                host,
+                misc: _misc,
+            } => write!(f, "https://{host}"),
             #[cfg(feature = "socks")]
             ProxyScheme::Socks4 { addr, remote_dns } => {
                 let h = if *remote_dns { "a" } else { "" };
@@ -918,7 +926,7 @@ impl Intercept {
             | Intercept::Http(ref mut s)
             | Intercept::Https(ref mut s) => s.set_custom_headers(headers),
             Intercept::System(_) => unimplemented!(),
-            Intercept::Custom(_) => unimplemented!()
+            Intercept::Custom(_) => unimplemented!(),
         }
     }
 }
@@ -1823,7 +1831,7 @@ mod tests {
             intercept: Intercept::Http(ProxyScheme::Http {
                 auth: Some(HeaderValue::from_static("auth1")),
                 host: http::uri::Authority::from_static("authority"),
-                misc: None
+                misc: None,
             }),
             no_proxy: None,
         };
@@ -1837,7 +1845,7 @@ mod tests {
             intercept: Intercept::Http(ProxyScheme::Http {
                 auth: None,
                 host: http::uri::Authority::from_static("authority"),
-                misc: None
+                misc: None,
             }),
             no_proxy: None,
         };
@@ -1851,7 +1859,7 @@ mod tests {
             intercept: Intercept::Http(ProxyScheme::Https {
                 auth: Some(HeaderValue::from_static("auth2")),
                 host: http::uri::Authority::from_static("authority"),
-                misc: None
+                misc: None,
             }),
             no_proxy: None,
         };
@@ -1865,7 +1873,7 @@ mod tests {
             intercept: Intercept::All(ProxyScheme::Http {
                 auth: Some(HeaderValue::from_static("auth3")),
                 host: http::uri::Authority::from_static("authority"),
-                misc: None
+                misc: None,
             }),
             no_proxy: None,
         };
@@ -1879,7 +1887,7 @@ mod tests {
             intercept: Intercept::All(ProxyScheme::Https {
                 auth: Some(HeaderValue::from_static("auth4")),
                 host: http::uri::Authority::from_static("authority"),
-                misc: None
+                misc: None,
             }),
             no_proxy: None,
         };
@@ -1893,7 +1901,7 @@ mod tests {
             intercept: Intercept::All(ProxyScheme::Https {
                 auth: None,
                 host: http::uri::Authority::from_static("authority"),
-                misc: None
+                misc: None,
             }),
             no_proxy: None,
         };
@@ -1911,7 +1919,7 @@ mod tests {
                     ProxyScheme::Http {
                         auth: Some(HeaderValue::from_static("auth5")),
                         host: http::uri::Authority::from_static("authority"),
-                        misc: None
+                        misc: None,
                     },
                 );
                 m
@@ -1932,7 +1940,7 @@ mod tests {
                     ProxyScheme::Https {
                         auth: Some(HeaderValue::from_static("auth6")),
                         host: http::uri::Authority::from_static("authority"),
-                        misc: None
+                        misc: None,
                     },
                 );
                 m

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -191,15 +191,11 @@ async fn test_custom_headers() {
     headers.insert(
         // reqwest::header::HeaderName::from_static("Proxy-Authorization"),
         reqwest::header::PROXY_AUTHORIZATION,
-        "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==".parse().unwrap()
+        "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==".parse().unwrap(),
     );
 
     let res = reqwest::Client::builder()
-        .proxy(
-            reqwest::Proxy::http(&proxy)
-                .unwrap()
-                .headers(headers),
-        )
+        .proxy(reqwest::Proxy::http(&proxy).unwrap().headers(headers))
         .build()
         .unwrap()
         .get(url)

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -174,11 +174,11 @@ async fn test_no_proxy() {
 
 #[tokio::test]
 async fn test_custom_headers() {
-    let url = "http://hyper.rs/prox";
+    let url = "http://hyper.rs.local/prox";
     let server = server::http(move |req| {
         assert_eq!(req.method(), "GET");
         assert_eq!(req.uri(), url);
-        assert_eq!(req.headers()["host"], "hyper.rs");
+        assert_eq!(req.headers()["host"], "hyper.rs.local");
         assert_eq!(
             req.headers()["proxy-authorization"],
             "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -173,6 +173,45 @@ async fn test_no_proxy() {
 }
 
 #[tokio::test]
+async fn test_custom_headers() {
+    let url = "http://hyper.rs/prox";
+    let server = server::http(move |req| {
+        assert_eq!(req.method(), "GET");
+        assert_eq!(req.uri(), url);
+        assert_eq!(req.headers()["host"], "hyper.rs");
+        assert_eq!(
+            req.headers()["proxy-authorization"],
+            "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+        );
+        async { http::Response::default() }
+    });
+
+    let proxy = format!("http://{}", server.addr());
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        // reqwest::header::HeaderName::from_static("Proxy-Authorization"),
+        reqwest::header::PROXY_AUTHORIZATION,
+        "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==".parse().unwrap()
+    );
+
+    let res = reqwest::Client::builder()
+        .proxy(
+            reqwest::Proxy::http(&proxy)
+                .unwrap()
+                .headers(headers),
+        )
+        .build()
+        .unwrap()
+        .get(url)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.url().as_str(), url);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
 async fn test_using_system_proxy() {
     let url = "http://not.a.real.sub.hyper.rs/prox";
     let server = server::http(move |req| {


### PR DESCRIPTION
Implement #2552. As suggested, I followed up the way that `Proxy::basic_auth` finishes its job by extending `Proxy` and `ProxyScheme` with a new field called `misc`. Spare me with the name `misc` because I can't come up with another word with four letter so that it aligns with `host` and `auth`.

I already tested with HTTP and HTTPS proxies but yet with `Custom` since I haven't taken a look at the custom part. So I will leave it to a future implementation.

~~Found that something broke with `HeaderName::from_static` and no one is using it, so I guess we're only able to use those pre-defined HTTP fields for now.~~ It works fine but weird. Why does it have to be lower case?