### PR TITLE
feat(redirect): Using `tower-http` policy instead.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ tower-service = "0.3"
 futures-core = { version = "0.3.28", default-features = false }
 futures-util = { version = "0.3.28", default-features = false }
 sync_wrapper = { version = "1.0", features = ["futures"] }
+tower-http = { git="https://github.com/firefantasy/tower-http.git", rev= "89599d88673bfae74a96ffa44e46df41661d36bc", default-features = false, features = ["follow-redirect"] }
 
 # Optional deps...
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -3,7 +3,8 @@ use std::any::Any;
 use std::future::Future;
 use std::net::IpAddr;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::time::Duration;
 use std::{collections::HashMap, convert::TryInto, net::SocketAddr};
@@ -57,6 +58,9 @@ use quinn::VarInt;
 use tokio::time::Sleep;
 use tower::util::BoxCloneSyncServiceLayer;
 use tower::{Layer, Service};
+use tower_http::follow_redirect::policy::{
+    Action as TowerAction, Attempt as TowerAttempt, Policy as TowerPolicy,
+};
 
 type HyperResponseFuture = hyper_util::client::legacy::ResponseFuture;
 
@@ -795,6 +799,14 @@ impl ClientBuilder {
 
         let proxies_maybe_http_auth = proxies.iter().any(|p| p.maybe_has_http_auth());
 
+        let redirect_policy_display = {
+            if config.redirect_policy.is_default() {
+                None
+            } else {
+                Some(format!("{:?}", &config.redirect_policy))
+            }
+        };
+
         Ok(Client {
             inner: Arc::new(ClientRef {
                 accepts: config.accepts,
@@ -811,13 +823,14 @@ impl ClientBuilder {
                 },
                 hyper: builder.build(connector_builder.build(config.connector_layers)),
                 headers: config.headers,
-                redirect_policy: config.redirect_policy,
+                redirect_policy: Mutex::new(config.redirect_policy.into_tower_policy()),
                 referer: config.referer,
                 read_timeout: config.read_timeout,
                 request_timeout: config.timeout,
                 proxies,
                 proxies_maybe_http_auth,
                 https_only: config.https_only,
+                redirect_policy_display,
             }),
         })
     }
@@ -2416,13 +2429,16 @@ struct ClientRef {
     hyper: HyperClient,
     #[cfg(feature = "http3")]
     h3_client: Option<H3Client>,
-    redirect_policy: redirect::Policy,
+    redirect_policy: Mutex<
+        Option<Box<dyn TowerPolicy<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync>>,
+    >,
     referer: bool,
     request_timeout: Option<Duration>,
     read_timeout: Option<Duration>,
     proxies: Arc<Vec<Proxy>>,
     proxies_maybe_http_auth: bool,
     https_only: bool,
+    redirect_policy_display: Option<String>,
 }
 
 impl ClientRef {
@@ -2443,8 +2459,8 @@ impl ClientRef {
             f.field("proxies", &self.proxies);
         }
 
-        if !self.redirect_policy.is_default() {
-            f.field("redirect_policy", &self.redirect_policy);
+        if let Some(msg) = &self.redirect_policy_display {
+            f.field("redirect_policy", &msg);
         }
 
         if self.referer {
@@ -2769,47 +2785,51 @@ impl Future for PendingRequest {
                     }
                     let url = self.url.clone();
                     self.as_mut().urls().push(url);
-                    let action = self
-                        .client
-                        .redirect_policy
-                        .check(res.status(), &loc, &self.urls);
+                    let pervious = Uri::from_str(self.url.clone().as_str()).unwrap();
+                    let next = Uri::from_str(loc.as_str()).unwrap();
+                    let tower_attempt = TowerAttempt::new(res.status(), &next, &pervious);
+                    let client = self.client.clone();
+                    let mut tower_policy = client.redirect_policy.lock().unwrap();
+                    if let Some(tower_policy) = tower_policy.as_deref_mut() {
+                        match tower_policy.redirect(&tower_attempt) {
+                            Ok(TowerAction::Follow) => {
+                                debug!("redirecting '{}' to '{}'", self.url, loc);
 
-                    match action {
-                        redirect::ActionKind::Follow => {
-                            debug!("redirecting '{}' to '{}'", self.url, loc);
-
-                            if loc.scheme() != "http" && loc.scheme() != "https" {
-                                return Poll::Ready(Err(error::url_bad_scheme(loc)));
-                            }
-
-                            if self.client.https_only && loc.scheme() != "https" {
-                                return Poll::Ready(Err(error::redirect(
-                                    error::url_bad_scheme(loc.clone()),
-                                    loc,
-                                )));
-                            }
-
-                            self.url = loc;
-                            let mut headers =
-                                std::mem::replace(self.as_mut().headers(), HeaderMap::new());
-
-                            remove_sensitive_headers(&mut headers, &self.url, &self.urls);
-                            let uri = try_uri(&self.url)?;
-                            let body = match self.body {
-                                Some(Some(ref body)) => Body::reusable(body.clone()),
-                                _ => Body::empty(),
-                            };
-
-                            // Add cookies from the cookie store.
-                            #[cfg(feature = "cookies")]
-                            {
-                                if let Some(ref cookie_store) = self.client.cookie_store {
-                                    add_cookie_header(&mut headers, &**cookie_store, &self.url);
+                                if loc.scheme() != "http" && loc.scheme() != "https" {
+                                    return Poll::Ready(Err(error::url_bad_scheme(loc)));
                                 }
-                            }
 
-                            *self.as_mut().in_flight().get_mut() =
-                                match *self.as_mut().in_flight().as_ref() {
+                                if self.client.https_only && loc.scheme() != "https" {
+                                    return Poll::Ready(Err(error::redirect(
+                                        error::url_bad_scheme(loc.clone()),
+                                        loc,
+                                    )));
+                                }
+
+                                self.url = loc;
+                                let mut headers =
+                                    std::mem::replace(self.as_mut().headers(), HeaderMap::new());
+
+                                remove_sensitive_headers(&mut headers, &self.url, &self.urls);
+                                let uri = try_uri(&self.url)?;
+                                let body = match self.body {
+                                    Some(Some(ref body)) => Body::reusable(body.clone()),
+                                    _ => Body::empty(),
+                                };
+
+                                // Add cookies from the cookie store.
+                                #[cfg(feature = "cookies")]
+                                {
+                                    if let Some(ref cookie_store) = self.client.cookie_store {
+                                        add_cookie_header(&mut headers, &**cookie_store, &self.url);
+                                    }
+                                }
+
+                                *self.as_mut().in_flight().get_mut() = match *self
+                                    .as_mut()
+                                    .in_flight()
+                                    .as_ref()
+                                {
                                     #[cfg(feature = "http3")]
                                     ResponseFuture::H3(_) => {
                                         let mut req = hyper::Request::builder()
@@ -2820,9 +2840,9 @@ impl Future for PendingRequest {
                                         *req.headers_mut() = headers.clone();
                                         std::mem::swap(self.as_mut().headers(), &mut headers);
                                         ResponseFuture::H3(self.client.h3_client
-                        .as_ref()
-                        .expect("H3 client must exists, otherwise we can't have a h3 request here")
-                                            .request(req))
+                            .as_ref()
+                            .expect("H3 client must exists, otherwise we can't have a h3 request here")
+                                                .request(req))
                                     }
                                     _ => {
                                         let mut req = hyper::Request::builder()
@@ -2835,15 +2855,20 @@ impl Future for PendingRequest {
                                         ResponseFuture::Default(self.client.hyper.request(req))
                                     }
                                 };
-
-                            continue;
+                                continue;
+                            }
+                            Ok(TowerAction::Stop) => {
+                                debug!("redirect policy disallowed redirection to '{loc}'");
+                            }
+                            Err(err) => {
+                                return Poll::Ready(Err(crate::error::redirect(
+                                    err,
+                                    self.url.clone(),
+                                )));
+                            }
                         }
-                        redirect::ActionKind::Stop => {
-                            debug!("redirect policy disallowed redirection to '{loc}'");
-                        }
-                        redirect::ActionKind::Error(err) => {
-                            return Poll::Ready(Err(crate::error::redirect(err, self.url.clone())));
-                        }
+                    } else {
+                        debug!("redirect policy disallowed redirection to '{loc}'");
                     }
                 }
             }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -11,6 +11,10 @@ use crate::header::{HeaderMap, AUTHORIZATION, COOKIE, PROXY_AUTHORIZATION, WWW_A
 use hyper::StatusCode;
 
 use crate::Url;
+use tower_http::follow_redirect::policy::{
+    redirect_fn, Action as TowerAction, Attempt as TowerAttempt, Limited,
+    Policy as TowerPolicy,
+};
 
 /// A type that controls the policy on how to handle the following of redirects.
 ///
@@ -149,6 +153,44 @@ impl Policy {
 
     pub(crate) fn is_default(&self) -> bool {
         matches!(self.inner, PolicyKind::Limit(10))
+    }
+
+    pub(crate) fn into_tower_policy(
+        self,
+    ) -> Option<Box<dyn TowerPolicy<(), Box<dyn StdError + Send + Sync>> + Send + Sync>>
+where {
+        match self.inner {
+            PolicyKind::Custom(custom) => {
+                let t = redirect_fn(move |attemp: &TowerAttempt<'_>| -> Result<TowerAction, Box<dyn StdError + Send + Sync>> {
+                    Ok(match custom(Attempt {
+                        status: attemp.status(),
+                        next: &Url::parse(&attemp.location().to_string()).unwrap(),
+                        previous: &[Url::parse(&attemp.previous().to_string()).unwrap()],
+                    })
+                    .inner
+                    {
+                        ActionKind::Follow => TowerAction::Follow,
+                        ActionKind::Stop => TowerAction::Stop,
+                        ActionKind::Error(err) => return Err(err),
+                    })
+                });
+                Some(Box::new(t))
+            }
+            PolicyKind::Limit(max) => {
+                let mut policy = Limited::new(max);
+                let t = redirect_fn(move |attemp: &TowerAttempt<'_>| -> Result<TowerAction, Box<dyn StdError + Send + Sync>> {
+                    match <dyn TowerPolicy<(), Box<dyn StdError + Send + Sync>>>::redirect(&mut policy, attemp)
+                    {
+                        Ok(TowerAction::Follow) => Ok(TowerAction::Follow),
+                        Ok(TowerAction::Stop) =>  Err(Box::new(TooManyRedirects)),
+                        Err(err) =>  Err(err),
+                    }
+                });
+                Some(Box::new(t))
+            }
+
+            PolicyKind::None => None,
+        }
     }
 }
 

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -376,3 +376,68 @@ async fn test_redirect_https_only_enforced_gh1312() {
     let err = res.unwrap_err();
     assert!(err.is_redirect());
 }
+
+#[tokio::test]
+async fn test_redirect_limit() {
+    let server = server::http(move |req| async move {
+        let i: i32 = req
+            .uri()
+            .path()
+            .rsplit('/')
+            .next()
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+        assert!(req.uri().path().ends_with(&format!("/redirect/{i}")));
+        http::Response::builder()
+            .status(302)
+            .header("location", format!("/redirect/{}", i + 1))
+            .body(Body::default())
+            .unwrap()
+    });
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::limited(3))
+        .build()
+        .unwrap();
+
+    let url = format!("http://{}/redirect/0", server.addr());
+    let res = client.get(&url).send().await.unwrap_err();
+    assert_eq!(
+        res.url().unwrap().as_str(),
+        format!("http://{}/redirect/2", server.addr()).as_str()
+    );
+    assert!(res.is_redirect());
+}
+
+#[tokio::test]
+async fn test_redirect_custom() {
+    let server = server::http(move |req| async move {
+        assert!(req.uri().path().ends_with("/foo"));
+        http::Response::builder()
+            .status(302)
+            .header("location", "/should_not_be_called")
+            .body(Body::default())
+            .unwrap()
+    });
+
+    let url = format!("http://{}/foo", server.addr());
+
+    let res = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if attempt.url().path().ends_with("/should_not_be_called") {
+                attempt.stop()
+            } else {
+                attempt.follow()
+            }
+        }))
+        .build()
+        .unwrap()
+        .get(&url)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.url().as_str(), url);
+    assert_eq!(res.status(), reqwest::StatusCode::FOUND);
+}

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -405,7 +405,7 @@ async fn test_redirect_limit() {
     let res = client.get(&url).send().await.unwrap_err();
     assert_eq!(
         res.url().unwrap().as_str(),
-        format!("http://{}/redirect/2", server.addr()).as_str()
+        format!("http://{}/redirect/3", server.addr()).as_str()
     );
     assert!(res.is_redirect());
 }


### PR DESCRIPTION
## What does this want to do

Working on https://github.com/seanmonstar/reqwest/issues/2576

Inspired by https://github.com/seanmonstar/reqwest/pull/2613#issuecomment-2749124630

This PR converts the `rewqest::redirect::Policy` as `tower_http::follow_redirect::policy::Policy`. 

Why the policy conversion needs happen in the `ClientBuild::build` function?

Because the `Policies` from `tower-http` needs to be `mut` and will change their inner state during redirect. See the[ Limited code](https://github.com/firefantasy/tower-http/blob/711a86d6cbe2fb2767a21cf06a2de088bc5f9ceb/tower-http/src/follow_redirect/policy/limited.rs#L26-L35).


## How to test

The first commit add the `Limit` and `Custom` policy test. The second commit make the implementation and updated the test.

## Others
Needs to do
- should remove the `Policy::check` method and test ?
- Add [PR](https://github.com/firefantasy/tower-http/commit/89599d88673bfae74a96ffa44e46df41661d36bc) to `tower-http`