### PR TITLE
don't truncate the filepath to the filename

### DIFF
--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -273,9 +273,7 @@ impl Part {
     #[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
     pub async fn file<T: AsRef<Path>>(path: T) -> io::Result<Part> {
         let path = path.as_ref();
-        let file_name = path
-            .file_name()
-            .map(|filename| filename.to_string_lossy().into_owned());
+        let file_name = path.to_string_lossy().into_owned();
         let ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
         let mime = mime_guess::from_ext(ext).first_or_octet_stream();
         let file = File::open(path).await?;
@@ -286,11 +284,7 @@ impl Part {
         }
         .mime(mime);
 
-        Ok(if let Some(file_name) = file_name {
-            field.file_name(file_name)
-        } else {
-            field
-        })
+        Ok(field.file_name(file_name))
     }
 
     fn new(value: Body, body_length: Option<u64>) -> Part {

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -222,19 +222,12 @@ impl Part {
     /// Errors when the file cannot be opened.
     pub fn file<T: AsRef<Path>>(path: T) -> io::Result<Part> {
         let path = path.as_ref();
-        let file_name = path
-            .file_name()
-            .map(|filename| filename.to_string_lossy().into_owned());
+        let file_name = path.to_string_lossy().into_owned();
         let ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
         let mime = mime_guess::from_ext(ext).first_or_octet_stream();
         let file = File::open(path)?;
         let field = Part::new(Body::from(file)).mime(mime);
-
-        Ok(if let Some(file_name) = file_name {
-            field.file_name(file_name)
-        } else {
-            field
-        })
+        Ok(field.file_name(file_name))
     }
 
     fn new(value: Body) -> Part {


### PR DESCRIPTION
This is deceiving. In most cases the user probably wants to send the actual filepath that they used the original function with.


On the otherhand i understand if its like /home/users/frank/whatever/the/fuck but if its a relative path, I want the relative path.