### PR TITLE
Do not pull in an entirely different DEFLATE implementation just for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ env_logger = "0.10"
 hyper = { version = "1.1.0", default-features = false, features = ["http1", "http2", "client", "server"] }
 hyper-util = { version = "0.1.10", features = ["http1", "http2", "client", "client-legacy", "server-auto", "tokio"] }
 serde = { version = "1.0", features = ["derive"] }
-libflate = "2.1"
+flate2 = "1.0.13"
 brotli_crate = { package = "brotli", version = "7.0.0" }
 zstd_crate = { package = "zstd", version = "0.13" }
 doc-comment = "0.3"

--- a/tests/deflate.rs
+++ b/tests/deflate.rs
@@ -1,4 +1,6 @@
 mod support;
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
 use std::io::Write;
 use support::server;
 use tokio::io::AsyncWriteExt;
@@ -92,13 +94,10 @@ async fn deflate_case(response_size: usize, chunk_size: usize) {
         .into_iter()
         .map(|i| format!("test {i}"))
         .collect();
-    let mut encoder = libflate::zlib::Encoder::new(Vec::new()).unwrap();
-    match encoder.write(content.as_bytes()) {
-        Ok(n) => assert!(n > 0, "Failed to write to encoder."),
-        _ => panic!("Failed to deflate encode string."),
-    };
 
-    let deflated_content = encoder.finish().into_result().unwrap();
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(content.as_bytes()).unwrap();
+    let deflated_content = encoder.finish().unwrap();
 
     let mut response = format!(
         "\
@@ -158,12 +157,9 @@ const COMPRESSED_RESPONSE_HEADERS: &[u8] = b"HTTP/1.1 200 OK\x0d\x0a\
 const RESPONSE_CONTENT: &str = "some message here";
 
 fn deflate_compress(input: &[u8]) -> Vec<u8> {
-    let mut encoder = libflate::zlib::Encoder::new(Vec::new()).unwrap();
-    match encoder.write(input) {
-        Ok(n) => assert!(n > 0, "Failed to write to encoder."),
-        _ => panic!("Failed to deflate encode string."),
-    };
-    encoder.finish().into_result().unwrap()
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
 }
 
 #[tokio::test]

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -1,4 +1,6 @@
 mod support;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use support::server;
 
 use std::io::Write;
@@ -94,13 +96,10 @@ async fn gzip_case(response_size: usize, chunk_size: usize) {
         .into_iter()
         .map(|i| format!("test {i}"))
         .collect();
-    let mut encoder = libflate::gzip::Encoder::new(Vec::new()).unwrap();
-    match encoder.write(content.as_bytes()) {
-        Ok(n) => assert!(n > 0, "Failed to write to encoder."),
-        _ => panic!("Failed to gzip encode string."),
-    };
 
-    let gzipped_content = encoder.finish().into_result().unwrap();
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(content.as_bytes()).unwrap();
+    let gzipped_content = encoder.finish().unwrap();
 
     let mut response = format!(
         "\
@@ -160,12 +159,9 @@ const COMPRESSED_RESPONSE_HEADERS: &[u8] = b"HTTP/1.1 200 OK\x0d\x0a\
 const RESPONSE_CONTENT: &str = "some message here";
 
 fn gzip_compress(input: &[u8]) -> Vec<u8> {
-    let mut encoder = libflate::gzip::Encoder::new(Vec::new()).unwrap();
-    match encoder.write(input) {
-        Ok(n) => assert!(n > 0, "Failed to write to encoder."),
-        _ => panic!("Failed to gzip encode string."),
-    };
-    encoder.finish().into_result().unwrap()
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
Use the `flate2` crate that underpins `async-compression` in tests, as opposed to pulling in an entirely different DEFLATE implementation just for tests.

The flate2 crate version is selected to match the minimum requirement of `async-compression` and is extremely conservative. I've verified that it still works even with a version that old using `cargo update -p flate2 --precise=1.0.13`.