### PR TITLE
fix(wasm): handle null body in bytes_stream

### DIFF
--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -135,24 +135,30 @@ impl Response {
     /// Convert the response into a `Stream` of `Bytes` from the body.
     #[cfg(feature = "stream")]
     pub fn bytes_stream(self) -> impl futures_core::Stream<Item = crate::Result<Bytes>> {
+        use futures_core::Stream;
+        use std::pin::Pin;
+
         let web_response = self.http.into_body();
         let abort = self._abort;
-        let body = web_response
-            .body()
-            .expect("could not create wasm byte stream");
-        let body = wasm_streams::ReadableStream::from_raw(body.unchecked_into());
-        Box::pin(body.into_stream().map(move |buf_js| {
-            // Keep the abort guard alive as long as this stream is.
-            let _abort = &abort;
-            let buffer = Uint8Array::new(
-                &buf_js
-                    .map_err(crate::error::wasm)
-                    .map_err(crate::error::decode)?,
-            );
-            let mut bytes = vec![0; buffer.length() as usize];
-            buffer.copy_to(&mut bytes);
-            Ok(bytes.into())
-        }))
+
+        if let Some(body) = web_response.body() {
+            let body = wasm_streams::ReadableStream::from_raw(body.unchecked_into());
+            Box::pin(body.into_stream().map(move |buf_js| {
+                // Keep the abort guard alive as long as this stream is.
+                let _abort = &abort;
+                let buffer = Uint8Array::new(
+                    &buf_js
+                        .map_err(crate::error::wasm)
+                        .map_err(crate::error::decode)?,
+                );
+                let mut bytes = vec![0; buffer.length() as usize];
+                buffer.copy_to(&mut bytes);
+                Ok(bytes.into())
+            })) as Pin<Box<dyn Stream<Item = crate::Result<Bytes>>>>
+        } else {
+            // If there's no body, return an empty stream.
+            Box::pin(stream::empty()) as Pin<Box<dyn Stream<Item = crate::Result<Bytes>>>>
+        }
     }
 
     // util methods

--- a/src/wasm/response.rs
+++ b/src/wasm/response.rs
@@ -11,7 +11,7 @@ use crate::wasm::AbortGuard;
 use wasm_bindgen::JsCast;
 
 #[cfg(feature = "stream")]
-use futures_util::stream::StreamExt;
+use futures_util::stream::{self, StreamExt};
 
 #[cfg(feature = "json")]
 use serde::de::DeserializeOwned;


### PR DESCRIPTION
**Description:**

This PR fixes a panic in the `bytes_stream` function for the WASM target. 

Previously, if a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response/body) had a `null` body (a valid value - see docs), attempting to create a stream from it would lead to a panic with the message "could not create wasm byte stream". This could happen in various scenarios, such as handling certain types of redirects or responses explicitly designed to have no body content.

**Changes:**

The implementation now checks if `web_response.body()` returns `Some(body)` before attempting to use it.
- If a body exists, it proceeds to create the `wasm_streams::ReadableStream` and maps it to `Bytes` as before.
- If `web_response.body()` returns `None`, it now returns an empty stream (`futures_util::stream::empty()`) instead of panicking.