### PR TITLE
chore: Align the name usage of TotalTimeout

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -17,7 +17,7 @@ use super::Body;
 use crate::async_impl::h3_client::connect::{H3ClientConfig, H3Connector};
 #[cfg(feature = "http3")]
 use crate::async_impl::h3_client::{H3Client, H3ResponseFuture};
-use crate::config::{RequestConfig, RequestTimeout};
+use crate::config::{RequestConfig, TotalTimeout};
 use crate::connect::{
     sealed::{Conn, Unnameable},
     BoxedConnectorLayer, BoxedConnectorService, Connector, ConnectorBuilder,
@@ -906,7 +906,7 @@ impl ClientBuilder {
                 redirect_policy: config.redirect_policy,
                 referer: config.referer,
                 read_timeout: config.read_timeout,
-                request_timeout: RequestConfig::new(config.timeout),
+                total_timeout: RequestConfig::new(config.timeout),
                 proxies,
                 proxies_maybe_http_auth,
                 https_only: config.https_only,
@@ -2358,7 +2358,7 @@ impl Client {
 
         let total_timeout = self
             .inner
-            .request_timeout
+            .total_timeout
             .fetch(&extensions)
             .copied()
             .map(tokio::time::sleep)
@@ -2602,7 +2602,7 @@ struct ClientRef {
     h3_client: Option<H3Client>,
     redirect_policy: redirect::Policy,
     referer: bool,
-    request_timeout: RequestConfig<RequestTimeout>,
+    total_timeout: RequestConfig<TotalTimeout>,
     read_timeout: Option<Duration>,
     proxies: Arc<Vec<Proxy>>,
     proxies_maybe_http_auth: bool,
@@ -2637,7 +2637,7 @@ impl ClientRef {
 
         f.field("default_headers", &self.headers);
 
-        self.request_timeout.fmt_as_field(f);
+        self.total_timeout.fmt_as_field(f);
 
         if let Some(ref d) = self.read_timeout {
             f.field("read_timeout", d);

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -12,7 +12,7 @@ use super::client::{Client, Pending};
 #[cfg(feature = "multipart")]
 use super::multipart;
 use super::response::Response;
-use crate::config::{RequestConfig, RequestTimeout};
+use crate::config::{RequestConfig, TotalTimeout};
 #[cfg(feature = "multipart")]
 use crate::header::CONTENT_LENGTH;
 use crate::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
@@ -115,13 +115,13 @@ impl Request {
     /// Get the timeout.
     #[inline]
     pub fn timeout(&self) -> Option<&Duration> {
-        RequestConfig::<RequestTimeout>::get(&self.extensions)
+        RequestConfig::<TotalTimeout>::get(&self.extensions)
     }
 
     /// Get a mutable reference to the timeout.
     #[inline]
     pub fn timeout_mut(&mut self) -> &mut Option<Duration> {
-        RequestConfig::<RequestTimeout>::get_mut(&mut self.extensions)
+        RequestConfig::<TotalTimeout>::get_mut(&mut self.extensions)
     }
 
     /// Get the http version.

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,8 +103,8 @@ where
 // ================================
 
 #[derive(Clone, Copy)]
-pub(crate) struct RequestTimeout;
+pub(crate) struct TotalTimeout;
 
-impl RequestConfigValue for RequestTimeout {
+impl RequestConfigValue for TotalTimeout {
     type Value = Duration;
 }


### PR DESCRIPTION
This PR simply aligns the naming to match `TotalTimeout`. I used to think it was just for the request timeout, but actually, it controls the timeout for the entire request, including the response.