### PR TITLE
feat: Add request level redirect policy config

### DIFF
--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -12,11 +12,11 @@ use super::client::{Client, Pending};
 #[cfg(feature = "multipart")]
 use super::multipart;
 use super::response::Response;
-use crate::config::{RequestConfig, RequestTimeout};
+use crate::config::{self, RequestConfig};
 #[cfg(feature = "multipart")]
 use crate::header::CONTENT_LENGTH;
 use crate::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
-use crate::{Method, Url};
+use crate::{redirect, Method, Url};
 use http::{request::Parts, Extensions, Request as HttpRequest, Version};
 
 /// A request which can be executed with `Client::execute()`.
@@ -62,6 +62,18 @@ impl Request {
     #[inline]
     pub fn method_mut(&mut self) -> &mut Method {
         &mut self.method
+    }
+
+    /// Get the http version.
+    #[inline]
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    /// Get a mutable reference to the http version.
+    #[inline]
+    pub fn version_mut(&mut self) -> &mut Version {
+        &mut self.version
     }
 
     /// Get the url.
@@ -115,25 +127,25 @@ impl Request {
     /// Get the timeout.
     #[inline]
     pub fn timeout(&self) -> Option<&Duration> {
-        RequestConfig::<RequestTimeout>::get(&self.extensions)
+        RequestConfig::<config::RequestTimeout>::get(&self.extensions)
     }
 
     /// Get a mutable reference to the timeout.
     #[inline]
     pub fn timeout_mut(&mut self) -> &mut Option<Duration> {
-        RequestConfig::<RequestTimeout>::get_mut(&mut self.extensions)
+        RequestConfig::<config::RequestTimeout>::get_mut(&mut self.extensions)
     }
 
-    /// Get the http version.
+    /// Get the redirect policy.
     #[inline]
-    pub fn version(&self) -> Version {
-        self.version
+    pub fn redirect(&self) -> Option<&redirect::Policy> {
+        RequestConfig::<config::RedirectPolicy>::get(&self.extensions)
     }
 
-    /// Get a mutable reference to the http version.
+    /// Get a mutable reference to the redirect policy.
     #[inline]
-    pub fn version_mut(&mut self) -> &mut Version {
-        &mut self.version
+    pub fn redirect_mut(&mut self) -> &mut Option<redirect::Policy> {
+        RequestConfig::<config::RedirectPolicy>::get_mut(&mut self.extensions)
     }
 
     /// Attempt to clone the request.


### PR DESCRIPTION
This PR is part of https://github.com/seanmonstar/reqwest/issues/2641, and will close https://github.com/seanmonstar/reqwest/pull/2440 and https://github.com/seanmonstar/reqwest/issues/353, maybe relate to https://github.com/seanmonstar/reqwest/pull/2617

- close https://github.com/seanmonstar/reqwest/pull/2440
- close https://github.com/seanmonstar/reqwest/issues/353

---

This PR has the following changes:

- Change `PolicyKind::Custom` from `Box` to `Arc` to make it `Clone`. That's required by inserting into `http::Extensions`
- Introduce `config::RedirectPolicy`
- Add public API `Request::redirect` and `Request::redirect_mut`

There are some chore changes (I'm open to move them to a seperate PR)

- Change all usage of config from `Xxx` to `config::Xxx` to make it more clear.
- Move `Request::version` to front for better API organization.