### PR TITLE
Document reqwest can make TLS and cookie requests with Wasm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@
 //! the usage is basically the same as the async api. Some of the features are disabled in wasm
 //! : [`tls`], [`cookie`], [`blocking`], as well as various `ClientBuilder` methods such as `timeout()` and `connector_layer()`.
 //!
+//! TLS and cookies are provided through the browser environment, so reqwest can issue TLS requests with cookies,
+//! but has limited configuration.
 //!
 //! ## Optional Features
 //!


### PR DESCRIPTION
This should hopefully clear up confusion. I had a colleague who believed reqwest could not make TLS and cookies requests in the browser due to the docs saying tls is disabled.