### PR TITLE
feat: Add per request compression config

### DIFF
--- a/src/async_impl/decoder.rs
+++ b/src/async_impl/decoder.rs
@@ -61,7 +61,7 @@ use tokio_util::io::StreamReader;
 use super::body::ResponseBody;
 
 #[derive(Clone, Copy, Debug)]
-pub(super) struct Accepts {
+pub(crate) struct Accepts {
     #[cfg(feature = "gzip")]
     pub(super) gzip: bool,
     #[cfg(feature = "brotli")]

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -12,10 +12,11 @@ use super::client::{Client, Pending};
 #[cfg(feature = "multipart")]
 use super::multipart;
 use super::response::Response;
-use crate::config::{RequestConfig, RequestTimeout};
+use crate::config::{self, RequestConfig};
 #[cfg(feature = "multipart")]
 use crate::header::CONTENT_LENGTH;
 use crate::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
+
 use crate::{Method, Url};
 use http::{request::Parts, Extensions, Request as HttpRequest, Version};
 
@@ -115,13 +116,13 @@ impl Request {
     /// Get the timeout.
     #[inline]
     pub fn timeout(&self) -> Option<&Duration> {
-        RequestConfig::<RequestTimeout>::get(&self.extensions)
+        RequestConfig::<config::RequestTimeout>::get(&self.extensions)
     }
 
     /// Get a mutable reference to the timeout.
     #[inline]
     pub fn timeout_mut(&mut self) -> &mut Option<Duration> {
-        RequestConfig::<RequestTimeout>::get_mut(&mut self.extensions)
+        RequestConfig::<config::RequestTimeout>::get_mut(&mut self.extensions)
     }
 
     /// Get the http version.
@@ -134,6 +135,126 @@ impl Request {
     #[inline]
     pub fn version_mut(&mut self) -> &mut Version {
         &mut self.version
+    }
+
+    /// Get the `gzip` option on this request.
+    #[inline]
+    pub fn gzip(&self) -> Option<&bool> {
+        #[cfg(feature = "gzip")]
+        {
+            RequestConfig::<config::Accepts>::get(&self.extensions).map(|v| &v.gzip)
+        }
+        #[cfg(not(feature = "gzip"))]
+        {
+            None
+        }
+    }
+
+    /// Set auto gzip decompression by checking the `Content-Encoding` response header.
+    ///
+    /// Refer to [`reqwest::ClientBuilder::gzip`] for more details.
+    #[inline]
+    pub fn gzip_mut(&mut self) -> Option<&mut bool> {
+        #[cfg(feature = "gzip")]
+        {
+            RequestConfig::<config::Accepts>::get_mut(&mut self.extensions)
+                .as_mut()
+                .map(|v| &mut v.gzip)
+        }
+        #[cfg(not(feature = "gzip"))]
+        {
+            None
+        }
+    }
+
+    /// Get the `brotli` option on this request.
+    #[inline]
+    pub fn brotli(&self) -> Option<&bool> {
+        #[cfg(feature = "brotli")]
+        {
+            RequestConfig::<config::Accepts>::get(&self.extensions).map(|v| &v.brotli)
+        }
+        #[cfg(not(feature = "brotli"))]
+        {
+            None
+        }
+    }
+
+    /// Set auto brotli decompression by checking the `Content-Encoding` response header.
+    ///
+    /// Refer to [`reqwest::ClientBuilder::brotli`] for more details.
+    #[inline]
+    pub fn brotli_mut(&mut self) -> Option<&mut bool> {
+        #[cfg(feature = "brotli")]
+        {
+            RequestConfig::<config::Accepts>::get_mut(&mut self.extensions)
+                .as_mut()
+                .map(|v| &mut v.brotli)
+        }
+        #[cfg(not(feature = "brotli"))]
+        {
+            None
+        }
+    }
+
+    /// Get the `zstd` option on this request.
+    #[inline]
+    pub fn zstd(&self) -> Option<&bool> {
+        #[cfg(feature = "zstd")]
+        {
+            RequestConfig::<config::Accepts>::get(&self.extensions).map(|v| &v.zstd)
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            None
+        }
+    }
+
+    /// Set auto zstd decompression by checking the `Content-Encoding` response header.
+    ///
+    /// Refer to [`reqwest::ClientBuilder::zstd`] for more details.
+    #[inline]
+    pub fn zstd_mut(&mut self) -> Option<&mut bool> {
+        #[cfg(feature = "zstd")]
+        {
+            RequestConfig::<config::Accepts>::get_mut(&mut self.extensions)
+                .as_mut()
+                .map(|v| &mut v.zstd)
+        }
+        #[cfg(not(feature = "zstd"))]
+        {
+            None
+        }
+    }
+
+    /// Get the `deflate` option on this request.
+    #[inline]
+    pub fn deflate(&self) -> Option<&bool> {
+        #[cfg(feature = "deflate")]
+        {
+            RequestConfig::<config::Accepts>::get(&self.extensions).map(|v| &v.deflate)
+        }
+        #[cfg(not(feature = "deflate"))]
+        {
+            None
+        }
+    }
+
+    /// Enable auto deflate decompression by checking the `Content-Encoding` response header.
+    ///
+    /// Refer to [`reqwest::ClientBuilder::deflate`] for more details.
+    #[inline]
+    pub fn deflate_mut(&mut self) -> Option<&mut bool> {
+        #[cfg(feature = "deflate")]
+        {
+            RequestConfig::<config::Accepts>::get_mut(&mut self.extensions)
+                .as_mut()
+                .map(|v| &mut v.deflate)
+        }
+        #[cfg(not(feature = "deflate"))]
+        {
+            None
+        }
     }
 
     /// Attempt to clone the request.

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,17 @@ where
             .or(self.0.as_ref())
     }
 
+    /// Retrieve the owned value from the request-scoped configuration.
+    ///
+    /// If the request specifies a value, use that value; otherwise, attempt to retrieve it from the current instance (typically a client instance).
+    ///
+    /// This owned version of `fetch` can consume the config value directly to avoid extra clone.
+    pub(crate) fn fetch_owned<'request>(self, ext: &Extensions) -> Option<T::Value> {
+        ext.get::<RequestConfig<T>>()
+            .and_then(|v| v.0.clone())
+            .or(self.0)
+    }
+
     /// Retrieve the value from the request's Extensions.
     pub(crate) fn get(ext: &Extensions) -> Option<&T::Value> {
         ext.get::<RequestConfig<T>>().and_then(|v| v.0.as_ref())
@@ -107,4 +118,11 @@ pub(crate) struct RequestTimeout;
 
 impl RequestConfigValue for RequestTimeout {
     type Value = Duration;
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Accepts;
+
+impl RequestConfigValue for Accepts {
+    type Value = crate::async_impl::decoder::Accepts;
 }


### PR DESCRIPTION
This PR adds the per request compression config like gzip, zstd and so on.

- close https://github.com/seanmonstar/reqwest/issues/2616

---

This PR adds a number of new request-level APIs, all of which follow the same style as the existing ones. We will return `None` directly if the corresponding feature is not enabled, allowing users to call `req.gzip_mut.map(|v| *v = false)` to achieve the same effect as `no_gzip`.

I'm open to alternative API designs like `req.no_gzip()`.