### PR TITLE
fix(ci): Use minimal-versions of deps to msrv check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 'stable'
+          toolchain: "stable"
 
       - name: Check
         run: cargo test --features http3
@@ -277,9 +277,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get MSRV package metadata
-        id: metadata
-        run: cargo metadata --no-deps --format-version 1 | jq -r '"msrv=" + .packages[0].rust_version' >> $GITHUB_OUTPUT
+      - name: Install rust (${{ steps.metadata.outputs.msrv }})
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
 
       - name: Install rust (${{ steps.metadata.outputs.msrv }})
         uses: dtolnay/rust-toolchain@master
@@ -288,14 +289,7 @@ jobs:
 
       - name: Fix log and tokio versions
         run: |
-          cargo update
-          cargo update -p log --precise 0.4.18
-          cargo update -p tokio --precise 1.29.1
-          cargo update -p tokio-util --precise 0.7.11
-          cargo update -p idna_adapter --precise 1.1.0
-          cargo update -p hashbrown@0.15.2 --precise 0.15.0
-          cargo update -p native-tls --precise 0.2.13
-          cargo update -p once_cell --precise 1.20.3
+          cargo +nightly generate-lockfile -Z minimal-versions
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,10 @@ jobs:
         with:
           toolchain: nightly
 
+      - name: Get MSRV package metadata
+        id: metadata
+        run: cargo metadata --no-deps --format-version 1 | jq -r '"msrv=" + .packages[0].rust_version' >> $GITHUB_OUTPUT
+
       - name: Install rust (${{ steps.metadata.outputs.msrv }})
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
This PR will use minimal-versions of deps to msrv check.

By using cargo's nightly feature `-Z minimal-versions`, we can avoid manully maintain our pin lists.