### PR TITLE
Support streaming request body in HTTP/3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
           toolchain: 'stable'
 
       - name: Check
-        run: cargo test --features http3
+        run: cargo test --features http3,stream
         env:
           RUSTFLAGS: --cfg reqwest_unstable
           RUSTDOCFLAGS: --cfg reqwest_unstable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ once_cell = "1.18"
 log = "0.4.17"
 mime = "0.3.16"
 percent-encoding = "2.3"
-tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
+tokio = { version = "1.0", default-features = false, features = ["net", "time", "macros"] }
 tower = { version = "0.5.2", default-features = false, features = ["timeout", "util"] }
 pin-project-lite = "0.2.11"
 ipnet = "2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ socks = ["dep:tokio-socks"]
 macos-system-configuration = ["dep:system-configuration"]
 
 # Experimental HTTP/3 client.
-http3 = ["rustls-tls-manual-roots", "dep:h3", "dep:h3-quinn", "dep:quinn", "dep:slab", "dep:futures-channel"]
+http3 = ["rustls-tls-manual-roots", "dep:h3", "dep:h3-quinn", "dep:quinn", "dep:slab", "dep:futures-channel", "tokio/macros"]
 
 
 # Internal (PRIVATE!) features used to aid testing.
@@ -125,7 +125,7 @@ once_cell = "1.18"
 log = "0.4.17"
 mime = "0.3.16"
 percent-encoding = "2.3"
-tokio = { version = "1.0", default-features = false, features = ["net", "time", "macros"] }
+tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
 tower = { version = "0.5.2", default-features = false, features = ["timeout", "util"] }
 pin-project-lite = "0.2.11"
 ipnet = "2.3"

--- a/tests/http3.rs
+++ b/tests/http3.rs
@@ -213,3 +213,79 @@ async fn http3_test_reconnection() {
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     drop(server);
 }
+
+#[cfg(all(feature = "http3", feature = "stream"))]
+#[tokio::test]
+async fn http3_request_stream() {
+    use http_body_util::BodyExt;
+
+    let server = server::Http3::new().build(move |req| async move {
+        let reqb = req.collect().await.unwrap().to_bytes();
+        assert_eq!(reqb, "hello world");
+        http::Response::default()
+    });
+
+    let url = format!("https://{}", server.addr());
+    let body = reqwest::Body::wrap_stream(futures_util::stream::iter(vec![
+        Ok::<_, std::convert::Infallible>("hello"),
+        Ok::<_, std::convert::Infallible>(" "),
+        Ok::<_, std::convert::Infallible>("world"),
+    ]));
+
+    let res = reqwest::Client::builder()
+        .http3_prior_knowledge()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .expect("client builder")
+        .post(url)
+        .version(http::Version::HTTP_3)
+        .body(body)
+        .send()
+        .await
+        .expect("request");
+
+    assert_eq!(res.version(), http::Version::HTTP_3);
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+}
+
+#[cfg(all(feature = "http3", feature = "stream"))]
+#[tokio::test]
+async fn http3_request_stream_error() {
+    use http_body_util::BodyExt;
+
+    let server = server::Http3::new().build(move |req| async move {
+        // HTTP/3 response can start and finish before the entire request body has been received.
+        // To avoid prematurely terminating the session, collect full request body before responding.
+        let _ = req.collect().await;
+
+        http::Response::default()
+    });
+
+    let url = format!("https://{}", server.addr());
+    let body = reqwest::Body::wrap_stream(futures_util::stream::iter(vec![
+        Ok::<_, std::io::Error>("first chunk"),
+        Err::<_, std::io::Error>(std::io::Error::other("oh no!")),
+    ]));
+
+    let res = reqwest::Client::builder()
+        .http3_prior_knowledge()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .expect("client builder")
+        .post(url)
+        .version(http::Version::HTTP_3)
+        .body(body)
+        .send()
+        .await;
+
+    let err = res.unwrap_err();
+    assert!(err.is_request());
+    let err = err
+        .source()
+        .unwrap()
+        .source()
+        .unwrap()
+        .downcast_ref::<reqwest::Error>()
+        .unwrap();
+    assert!(err.is_body());
+}


### PR DESCRIPTION
This PR replaces `.as_bytes()` with `.poll_frame()` to support both `Inner::Reusable` and `Inner::Streaming` body variants.

Resolves another item in https://github.com/seanmonstar/reqwest/issues/2303