### PR TITLE
refactor: use hyper-util's proxy::Matcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 ]
 
 [features]
-default = ["default-tls", "charset", "http2", "macos-system-configuration"]
+default = ["default-tls", "charset", "http2", "system-proxy"]
 
 # Note: this doesn't enable the 'native-tls' feature, which adds specific
 # functionality for it.
@@ -78,7 +78,10 @@ stream = ["tokio/fs", "dep:tokio-util", "dep:wasm-streams"]
 socks = ["dep:tokio-socks"]
 
 # Use the system's proxy configuration.
-macos-system-configuration = ["dep:system-configuration"]
+system-proxy = ["hyper-util/client-proxy-system"]
+
+# Deprecated, switch to system-proxy.
+macos-system-configuration = ["system-proxy"]
 
 # Experimental HTTP/3 client.
 http3 = ["rustls-tls-manual-roots", "dep:h3", "dep:h3-quinn", "dep:quinn", "dep:slab", "dep:futures-channel"]
@@ -119,7 +122,7 @@ encoding_rs = { version = "0.8", optional = true }
 http-body = "1"
 http-body-util = "0.1"
 hyper = { version = "1.1", features = ["http1", "client"] }
-hyper-util = { version = "0.1.11", features = ["http1", "client", "client-legacy", "tokio"] }
+hyper-util = { version = "0.1.12", features = ["http1", "client", "client-legacy", "client-proxy", "tokio"] }
 h2 = { version = "0.4", optional = true }
 once_cell = "1.18"
 log = "0.4.17"
@@ -170,7 +173,7 @@ futures-channel = { version = "0.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 env_logger = "0.10"
 hyper = { version = "1.1.0", default-features = false, features = ["http1", "http2", "client", "server"] }
-hyper-util = { version = "0.1.10", features = ["http1", "http2", "client", "client-legacy", "server-auto", "tokio"] }
+hyper-util = { version = "0.1.12", features = ["http1", "http2", "client", "client-legacy", "server-auto", "tokio"] }
 serde = { version = "1.0", features = ["derive"] }
 flate2 = "1.0.13"
 brotli_crate = { package = "brotli", version = "7.0.0" }
@@ -179,12 +182,6 @@ doc-comment = "0.3"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 futures-util = { version = "0.3.28", default-features = false, features = ["std", "alloc"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-
-[target.'cfg(windows)'.dependencies]
-windows-registry = "0.4"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-system-configuration = { version = "0.6.0", optional = true }
 
 # wasm
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,8 @@
 //! - **socks**: Provides SOCKS5 proxy support.
 //! - **hickory-dns**: Enables a hickory-dns async resolver instead of default
 //!   threadpool using `getaddrinfo`.
+//! - **system-proxy** *(enabled by default)*: Use Windows and macOS system
+//!   proxy settings automatically.
 //!
 //! ## Unstable Features
 //!

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -110,7 +110,7 @@ async fn system_http_proxy_basic_auth_parsed() {
         assert_eq!(req.headers()["host"], "hyper.rs");
         assert_eq!(
             req.headers()["proxy-authorization"],
-            "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+            "Basic QWxhZGRpbjpvcGVuc2VzYW1l"
         );
 
         async { http::Response::default() }
@@ -125,7 +125,7 @@ async fn system_http_proxy_basic_auth_parsed() {
     // set-up http proxy.
     env::set_var(
         "http_proxy",
-        format!("http://Aladdin:open sesame@{}", server.addr()),
+        format!("http://Aladdin:opensesame@{}", server.addr()),
     );
 
     let res = reqwest::Client::builder()


### PR DESCRIPTION
The types that were in reqwest have been refactored out into hyper-util, with some changes (see https://github.com/hyperium/hyper/issues/3850). Now that those are available, this PR replaces the implementation internally with the one from hyper-util.

Closes #2682 