### PR TITLE
Upgrade webpki-roots to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ hyper-rustls = { version = "0.27.0", default-features = false, optional = true, 
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
 rustls-pki-types = { version = "1.1.0", features = ["alloc"] ,optional = true }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
-webpki-roots = { version = "0.26.0", optional = true }
+webpki-roots = { version = "1", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
 
 ## cookies


### PR DESCRIPTION
This was also covered in #2652, but that seems bogged down in discussions about other crates and this is extremely simple/straightforward. 0.26 actually does the semver trick with 1, but it's nice to get rid of the duplicate crate.