### PR TITLE
chore(ci): make dependabot tell us of breaking changes we could upgrade to

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # only tell us if there's a new 'breaking' change we could upgrade to
+    versioning-strategy: increase-if-necessary
     # disable regular version updates, security updates are unaffected
-    open-pull-requests-limit: 0
+    # open-pull-requests-limit: 0


### PR DESCRIPTION
I don't need dependabot telling me about very single point release. We purposefully keep the minimum range down, to allow people to use older versions of dependencies if they need it. There's a `minimal-versions` check for that even.

But this change _should_ make it so we get notified when a dependency has a breaking change. That won't be automatically pulled in, but we probably want to upgrade to it. It's likely dependabot can't fix the breakage, but at least we'll be alerted that we should upgrade. And who knows, sometimes major release don't cause us any breakage at all!