### PR TITLE
Allow the server_name_resolver to be overriden

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ native-tls-crate = { version = "0.2.16", optional = true, package = "native-tls"
 tokio-native-tls = { version = "0.3.0", optional = true }
 
 # default rustls
-hyper-rustls = { version = "0.27.0", default-features = false, optional = true, features = ["http1", "tls12"] }
+hyper-rustls = { version = "0.27.9", default-features = false, optional = true, features = ["http1", "tls12"] }
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 rustls-platform-verifier = { version = ">=0.6.0, <0.8.0", optional = true }

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -39,7 +39,7 @@ use crate::redirect::{self, TowerRedirectPolicy};
 #[cfg(feature = "__rustls")]
 use crate::tls::CertificateRevocationList;
 #[cfg(feature = "__tls")]
-use crate::tls::{self, TlsBackend};
+use crate::tls::{self, ResolveServerName, TlsBackend};
 #[cfg(feature = "__tls")]
 use crate::Certificate;
 #[cfg(any(feature = "__native-tls", feature = "__rustls"))]
@@ -193,6 +193,8 @@ struct Config {
     tls_certs_only: bool,
     #[cfg(feature = "__rustls")]
     crls: Vec<CertificateRevocationList>,
+    #[cfg(feature = "__tls")]
+    server_name_resolver: Option<Arc<dyn ResolveServerName>>,
     #[cfg(feature = "__tls")]
     min_tls_version: Option<tls::Version>,
     #[cfg(feature = "__tls")]
@@ -392,6 +394,8 @@ impl ClientBuilder {
                 unix_socket: None,
                 #[cfg(target_os = "windows")]
                 windows_named_pipe: None,
+                #[cfg(feature = "__tls")]
+                server_name_resolver: None,
             },
         }
     }
@@ -504,6 +508,7 @@ impl ClientBuilder {
                         local_address,
                         transport_config,
                         h3_client_config,
+                        config.server_name_resolver.clone(),
                     );
 
                     match res {
@@ -613,6 +618,7 @@ impl ClientBuilder {
                         config.interface.as_deref(),
                         config.nodelay,
                         config.tls_info,
+                        config.server_name_resolver,
                     )?
                 }
                 #[cfg(feature = "__native-tls")]
@@ -637,6 +643,7 @@ impl ClientBuilder {
                     config.interface.as_deref(),
                     config.nodelay,
                     config.tls_info,
+                    config.server_name_resolver,
                 ),
                 #[cfg(feature = "__rustls")]
                 TlsBackend::BuiltRustls(conn) => {
@@ -681,6 +688,7 @@ impl ClientBuilder {
                         config.interface.as_deref(),
                         config.nodelay,
                         config.tls_info,
+                        config.server_name_resolver,
                     )
                 }
                 #[cfg(feature = "__rustls")]
@@ -885,6 +893,7 @@ impl ClientBuilder {
                         config.interface.as_deref(),
                         config.nodelay,
                         config.tls_info,
+                        config.server_name_resolver,
                     )
                 }
                 #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
@@ -1744,6 +1753,16 @@ impl ClientBuilder {
     ))]
     pub fn interface(mut self, interface: &str) -> ClientBuilder {
         self.config.interface = Some(interface.to_string());
+        self
+    }
+
+    /// Sets the server name resolver.
+    #[cfg(feature = "__tls")]
+    pub fn with_server_name_resolver(
+        mut self,
+        server_name_resolver: Arc<dyn ResolveServerName>,
+    ) -> ClientBuilder {
+        self.config.server_name_resolver = Some(server_name_resolver);
         self
     }
 

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -1,6 +1,7 @@
 use crate::async_impl::h3_client::dns::resolve;
 use crate::dns::DynResolver;
 use crate::error::BoxError;
+use crate::tls::ResolveServerName;
 use bytes::Bytes;
 use h3::client::SendRequest;
 use h3_quinn::{Connection, OpenStreams};
@@ -8,6 +9,7 @@ use http::Uri;
 use hyper_util::client::legacy::connect::dns::Name;
 use quinn::crypto::rustls::QuicClientConfig;
 use quinn::{ClientConfig, Endpoint, TransportConfig};
+use std::borrow::Cow;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -63,6 +65,7 @@ pub(crate) struct H3Connector {
     endpoint: Endpoint,
     client_config: H3ClientConfig,
     local_addr: Option<IpAddr>,
+    server_name_resolver: Option<Arc<dyn ResolveServerName>>,
 }
 
 impl H3Connector {
@@ -72,6 +75,7 @@ impl H3Connector {
         local_addr: Option<IpAddr>,
         transport_config: TransportConfig,
         client_config: H3ClientConfig,
+        server_name_resolver: Option<Arc<dyn ResolveServerName>>,
     ) -> Result<H3Connector, BoxError> {
         let quic_client_config = Arc::new(QuicClientConfig::try_from(tls)?);
         let mut config = ClientConfig::new(quic_client_config);
@@ -92,6 +96,7 @@ impl H3Connector {
             endpoint,
             client_config,
             local_addr,
+            server_name_resolver,
         })
     }
 
@@ -102,6 +107,12 @@ impl H3Connector {
             .trim_start_matches('[')
             .trim_end_matches(']');
         let port = dest.port_u16().unwrap_or(443);
+
+        let tls_host = if let Some(server_name_resolver) = &self.server_name_resolver {
+            Cow::Owned(server_name_resolver.resolve(&dest)?.to_string())
+        } else {
+            Cow::Borrowed(host)
+        };
 
         let addrs = if let Some(addr) = IpAddr::from_str(host).ok() {
             // If the host is already an IP address, skip resolving.
@@ -115,7 +126,7 @@ impl H3Connector {
             addrs.collect()
         };
 
-        self.remote_connect(addrs, host).await
+        self.remote_connect(addrs, &tls_host).await
     }
 
     async fn remote_connect(

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -14,6 +14,8 @@ use tower::util::{BoxCloneSyncServiceLayer, MapRequestLayer};
 use tower::{timeout::TimeoutLayer, util::BoxCloneSyncService, ServiceBuilder};
 use tower_service::Service;
 
+#[cfg(feature = "native-tls")]
+use std::borrow::Cow;
 use std::future::Future;
 use std::io::{self, IoSlice};
 use std::net::IpAddr;
@@ -29,6 +31,8 @@ use self::rustls_tls_conn::RustlsTlsConn;
 use crate::dns::DynResolver;
 use crate::error::{cast_to_internal_error, BoxError};
 use crate::proxy::{Intercepted, Matcher as ProxyMatcher};
+#[cfg(feature = "__tls")]
+use crate::tls::ResolveServerName;
 use sealed::{Conn, Unnameable};
 
 pub(crate) type HttpConnector = hyper_util::client::legacy::connect::HttpConnector<DynResolver>;
@@ -244,6 +248,7 @@ where {
         interface: Option<&str>,
         nodelay: bool,
         tls_info: bool,
+        server_name_resolver: Option<Arc<dyn ResolveServerName>>,
     ) -> crate::Result<ConnectorBuilder>
     where
         T: Into<Option<IpAddr>>,
@@ -270,6 +275,7 @@ where {
             interface,
             nodelay,
             tls_info,
+            server_name_resolver,
         ))
     }
 
@@ -295,6 +301,7 @@ where {
         interface: Option<&str>,
         nodelay: bool,
         tls_info: bool,
+        server_name_resolver: Option<Arc<dyn ResolveServerName>>,
     ) -> ConnectorBuilder
     where
         T: Into<Option<IpAddr>>,
@@ -319,7 +326,7 @@ where {
         http.enforce_http(false);
 
         ConnectorBuilder {
-            inner: Inner::NativeTls(http, tls),
+            inner: Inner::NativeTls(http, tls, server_name_resolver),
             proxies,
             verbose: verbose::OFF,
             nodelay,
@@ -357,6 +364,7 @@ where {
         interface: Option<&str>,
         nodelay: bool,
         tls_info: bool,
+        server_name_resolver: Option<Arc<dyn ResolveServerName>>,
     ) -> ConnectorBuilder
     where
         T: Into<Option<IpAddr>>,
@@ -389,11 +397,21 @@ where {
             (Arc::new(tls), Arc::new(tls_proxy))
         };
 
+        let server_name_resolver: Arc<dyn hyper_rustls::ResolveServerName + Send + Sync> =
+            if let Some(server_name_resolver) = server_name_resolver {
+                Arc::new(crate::tls::RustlsResolveServerNameWrapper(
+                    server_name_resolver,
+                ))
+            } else {
+                Arc::new(hyper_rustls::DefaultServerNameResolver::default())
+            };
+
         ConnectorBuilder {
             inner: Inner::RustlsTls {
                 http,
                 tls,
                 tls_proxy,
+                server_name_resolver,
             },
             proxies,
             verbose: verbose::OFF,
@@ -421,7 +439,7 @@ where {
     pub(crate) fn set_keepalive(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(http, _tls) => http.set_keepalive(dur),
+            Inner::NativeTls(http, _tls, _resolver) => http.set_keepalive(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive(dur),
             #[cfg(not(feature = "__tls"))]
@@ -432,7 +450,7 @@ where {
     pub(crate) fn set_keepalive_interval(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(http, _tls) => http.set_keepalive_interval(dur),
+            Inner::NativeTls(http, _tls, _resolver) => http.set_keepalive_interval(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive_interval(dur),
             #[cfg(not(feature = "__tls"))]
@@ -443,7 +461,7 @@ where {
     pub(crate) fn set_keepalive_retries(&mut self, retries: Option<u32>) {
         match &mut self.inner {
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(http, _tls) => http.set_keepalive_retries(retries),
+            Inner::NativeTls(http, _tls, _resolver) => http.set_keepalive_retries(retries),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive_retries(retries),
             #[cfg(not(feature = "__tls"))]
@@ -460,7 +478,7 @@ where {
     pub(crate) fn set_tcp_user_timeout(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(http, _tls) => http.set_tcp_user_timeout(dur),
+            Inner::NativeTls(http, _tls, _resolver) => http.set_tcp_user_timeout(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_tcp_user_timeout(dur),
             #[cfg(not(feature = "__tls"))]
@@ -510,12 +528,17 @@ enum Inner {
     #[cfg(not(feature = "__tls"))]
     Http(HttpConnector),
     #[cfg(feature = "__native-tls")]
-    NativeTls(HttpConnector, TlsConnector),
+    NativeTls(
+        HttpConnector,
+        TlsConnector,
+        Option<Arc<dyn ResolveServerName>>,
+    ),
     #[cfg(any(feature = "__rustls"))]
     RustlsTls {
         http: HttpConnector,
         tls: Arc<rustls::ClientConfig>,
         tls_proxy: Arc<rustls::ClientConfig>,
+        server_name_resolver: Arc<dyn hyper_rustls::ResolveServerName + Send + Sync>,
     },
 }
 
@@ -622,7 +645,7 @@ impl ConnectorService {
                 })
             }
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(http, tls) => {
+            Inner::NativeTls(http, tls, server_name_resolver) => {
                 let mut http = http.clone();
 
                 // Disable Nagle's algorithm for TLS handshake
@@ -633,9 +656,21 @@ impl ConnectorService {
                 }
 
                 let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
-                let mut http = hyper_tls::HttpsConnector::from((http, tls_connector));
-                let io = http.call(dst).await?;
-
+                let io = if let Some(server_name_resolver) = server_name_resolver {
+                    let servername = server_name_resolver.resolve(&dst)?.to_string();
+                    let is_https = dst.scheme() == Some(&Scheme::HTTPS);
+                    let tcp = http.call(dst).await?;
+                    if is_https {
+                        let stream = TokioIo::new(tcp);
+                        let tls = TokioIo::new(tls_connector.connect(&servername, stream).await?);
+                        hyper_tls::MaybeHttpsStream::Https(tls)
+                    } else {
+                        hyper_tls::MaybeHttpsStream::Http(tcp)
+                    }
+                } else {
+                    let mut http = hyper_tls::HttpsConnector::from((http, tls_connector));
+                    http.call(dst).await?
+                };
                 if let hyper_tls::MaybeHttpsStream::Https(stream) = io {
                     if !self.nodelay {
                         stream
@@ -661,7 +696,12 @@ impl ConnectorService {
                 }
             }
             #[cfg(feature = "__rustls")]
-            Inner::RustlsTls { http, tls, .. } => {
+            Inner::RustlsTls {
+                http,
+                tls,
+                server_name_resolver,
+                ..
+            } => {
                 let mut http = http;
 
                 // Disable Nagle's algorithm for TLS handshake
@@ -671,7 +711,12 @@ impl ConnectorService {
                     http.set_nodelay(true);
                 }
 
-                let mut http = hyper_rustls::HttpsConnector::from((http, tls));
+                let mut http = hyper_rustls::HttpsConnector::new(
+                    http,
+                    tls,
+                    false,
+                    server_name_resolver,
+                );
                 let io = http.call(dst).await?;
 
                 if let hyper_rustls::MaybeHttpsStream::Https(stream) = io {
@@ -739,10 +784,25 @@ impl ConnectorService {
                 })
             }
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(_, tls) => {
+            Inner::NativeTls(_, tls, server_name_resolver) => {
                 let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
-                let mut http = hyper_tls::HttpsConnector::from((svc, tls_connector));
-                let io = http.call(dst).await?;
+                let io = if let Some(server_name_resolver) = server_name_resolver {
+                    let mut svc = svc;
+
+                    let servername = server_name_resolver.resolve(&dst)?.to_string();
+                    let is_https = dst.scheme() == Some(&Scheme::HTTPS);
+                    let tcp = svc.call(dst).await?;
+                    if is_https {
+                        let stream = TokioIo::new(tcp);
+                        let tls = TokioIo::new(tls_connector.connect(&servername, stream).await?);
+                        hyper_tls::MaybeHttpsStream::Https(tls)
+                    } else {
+                        hyper_tls::MaybeHttpsStream::Http(tcp)
+                    }
+                } else {
+                    let mut http = hyper_tls::HttpsConnector::from((svc, tls_connector));
+                    http.call(dst).await?
+                };
 
                 if let hyper_tls::MaybeHttpsStream::Https(stream) = io {
                     Ok(Conn {
@@ -800,7 +860,7 @@ impl ConnectorService {
 
         match &self.inner {
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(http, tls) => {
+            Inner::NativeTls(http, tls, server_name_resolver) => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     log::trace!("tunneling HTTPS over proxy");
                     let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
@@ -825,8 +885,15 @@ impl ConnectorService {
                     // and we know this is definitely HTTPS.
                     let tunneled = tunnel.call(dst.clone()).await?;
                     let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
+
+                    let tls_host = if let Some(server_name_resolver) = server_name_resolver {
+                        Cow::Owned(server_name_resolver.resolve(&dst)?.to_string())
+                    } else {
+                        Cow::Borrowed(dst.host().ok_or("no host in url")?)
+                    };
+
                     let io = tls_connector
-                        .connect(dst.host().ok_or("no host in url")?, TokioIo::new(tunneled))
+                        .connect(&tls_host, TokioIo::new(tunneled))
                         .await?;
                     return Ok(Conn {
                         inner: self.verbose.wrap(NativeTlsConn {
@@ -842,6 +909,7 @@ impl ConnectorService {
                 http,
                 tls,
                 tls_proxy,
+                ..
             } => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     use rustls_pki_types::ServerName;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -74,10 +74,12 @@ use rustls::{
 };
 use rustls_pki_types::pem::PemObject;
 #[cfg(feature = "__rustls")]
-use rustls_pki_types::{ServerName, UnixTime};
+use rustls_pki_types::UnixTime;
 use std::{
-    fmt,
+    error::Error,
+    fmt::{self, Display},
     io::{BufRead, BufReader},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
 /// Represents a X509 certificate revocation list.
@@ -675,7 +677,7 @@ impl ServerCertVerifier for NoVerifier {
         &self,
         _end_entity: &rustls_pki_types::CertificateDer,
         _intermediates: &[rustls_pki_types::CertificateDer],
-        _server_name: &ServerName,
+        _server_name: &rustls_pki_types::ServerName,
         _ocsp_response: &[u8],
         _now: UnixTime,
     ) -> Result<ServerCertVerified, TLSError> {
@@ -745,7 +747,7 @@ impl ServerCertVerifier for IgnoreHostname {
         &self,
         end_entity: &rustls_pki_types::CertificateDer<'_>,
         intermediates: &[rustls_pki_types::CertificateDer<'_>],
-        _server_name: &ServerName<'_>,
+        _server_name: &rustls_pki_types::ServerName<'_>,
         _ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, TLSError> {
@@ -801,6 +803,129 @@ impl TlsInfo {
 impl std::fmt::Debug for TlsInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("TlsInfo").finish()
+    }
+}
+
+/// Represents a valid server name.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ServerName {
+    /// The server is identified by a DNS name. The name is sent in the TLS Server Name Indication (SNI) extension.
+    DnsName(DnsName),
+    /// The server is identified by an IP address. SNI is not done.
+    IpAddress(IpAddr),
+}
+
+/// Represents a valid DNS name.
+#[derive(Debug)]
+pub struct DnsName {
+    #[cfg(feature = "__rustls")]
+    inner: rustls_pki_types::DnsName<'static>,
+    #[cfg(not(feature = "__rustls"))]
+    inner: String,
+}
+
+/// The provided input could not be parsed because it is not a syntactically-valid DNS Name.
+#[derive(Debug)]
+pub struct InvalidDnsNameError;
+
+impl std::fmt::Display for InvalidDnsNameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("invalid dns name")
+    }
+}
+
+impl std::error::Error for InvalidDnsNameError {}
+
+impl TryFrom<String> for DnsName {
+    type Error = InvalidDnsNameError;
+
+    #[cfg(feature = "__rustls")]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        rustls_pki_types::DnsName::try_from(value)
+            .map(|inner| Self { inner })
+            .map_err(|_err| InvalidDnsNameError)
+    }
+
+    #[cfg(not(feature = "__rustls"))]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.len() > 253
+            || value.split('.').any(|label| {
+                label.is_empty()
+                    || label.starts_with('-')
+                    || label.ends_with('-')
+                    || label.len() >= 63
+                    || label.chars().all(|c| matches!(c, '0'..='9'))
+                    || label
+                        .chars()
+                        .any(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-'))
+            })
+        {
+            return Err(InvalidDnsNameError);
+        }
+        Ok(Self { inner: value })
+    }
+}
+
+/// Trait to resolve the server name used in a tls connection.
+pub trait ResolveServerName: Send + Sync + 'static {
+    /// Resolves the server name for a tls connection.
+    fn resolve(&self, uri: &http::Uri) -> Result<ServerName, Box<dyn Error + Send + Sync>>;
+}
+
+#[cfg(feature = "__rustls")]
+impl From<DnsName> for rustls_pki_types::DnsName<'static> {
+    fn from(value: DnsName) -> Self {
+        value.inner
+    }
+}
+
+#[cfg(feature = "__rustls")]
+impl From<ServerName> for rustls_pki_types::ServerName<'static> {
+    fn from(value: ServerName) -> Self {
+        match value {
+            ServerName::DnsName(dns) => rustls_pki_types::ServerName::DnsName(dns.into()),
+            ServerName::IpAddress(ip) => rustls_pki_types::ServerName::IpAddress(ip.into()),
+        }
+    }
+}
+
+#[cfg(feature = "__rustls")]
+#[repr(transparent)]
+pub(crate) struct RustlsResolveServerNameWrapper(pub(crate) std::sync::Arc<dyn ResolveServerName>);
+
+#[cfg(feature = "__rustls")]
+impl hyper_rustls::ResolveServerName for RustlsResolveServerNameWrapper {
+    fn resolve(
+        &self,
+        uri: &http::Uri,
+    ) -> Result<rustls_pki_types::ServerName<'static>, Box<dyn std::error::Error + Sync + Send>>
+    {
+        self.0.resolve(uri).map(From::from)
+    }
+}
+
+impl Display for ServerName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DnsName(dns) => <DnsName as Display>::fmt(dns, f),
+            Self::IpAddress(IpAddr::V4(ipv4)) => <Ipv4Addr as Display>::fmt(ipv4, f),
+            Self::IpAddress(IpAddr::V6(ipv6)) => <Ipv6Addr as Display>::fmt(ipv6, f),
+        }
+    }
+}
+
+#[cfg(feature = "__rustls")]
+impl Display for DnsName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.inner.as_ref())
+    }
+}
+
+#[cfg(not(feature = "__rustls"))]
+impl Display for DnsName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.inner)
     }
 }
 


### PR DESCRIPTION
This adds the
```
with_server_name_resolver(mut self, server_name_resolver: Arc<dyn hyper_rustls::ResolveServerName + Send + Sync>)
```
to ClientBuilder (if rustls is used).

It allows to override, which name is used for tls instead of using the one from the url.