### PR TITLE
fix: only check scheme after Policy return `follow`

### DIFF
--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -462,8 +462,8 @@ async fn test_scheme_only_check_after_policy_return_follow() {
         .send()
         .await;
 
-    assert!(res.is_err());
-    assert!(res.unwrap_err().is_builder());
+    assert!(res.is_ok());
+    assert_eq!(res.unwrap().status(), reqwest::StatusCode::FOUND);
 
     let res = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::custom(|attempt| {

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -442,3 +442,39 @@ async fn test_redirect_custom() {
     assert_eq!(res.url().as_str(), url);
     assert_eq!(res.status(), reqwest::StatusCode::FOUND);
 }
+
+#[tokio::test]
+async fn test_scheme_only_check_after_policy_return_follow() {
+    let server = server::http(move |_| async move {
+        http::Response::builder()
+            .status(302)
+            .header("location", "htt://www.yikes.com/")
+            .body(Body::default())
+            .unwrap()
+    });
+
+    let url = format!("http://{}/yikes", server.addr());
+    let res = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(|attempt| attempt.stop()))
+        .build()
+        .unwrap()
+        .get(&url)
+        .send()
+        .await;
+
+    assert!(res.is_err());
+    assert!(res.unwrap_err().is_builder());
+
+    let res = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            attempt.follow()
+        }))
+        .build()
+        .unwrap()
+        .get(&url)
+        .send()
+        .await;
+
+    assert!(res.is_err());
+    assert!(res.unwrap_err().is_builder());
+}


### PR DESCRIPTION
## Motivation

This is a patch for #2617. 

In #2617 refactoring PR,  the scheme check firstly before the `Policy` do redirection, this violates the logic before the refactoring.

## Solution

Move the `scheme` check logic only `policy` return `follow`

## About test

This PR add a test to prove that the old behavior should be follow.  

Without ssl/tls setup enviroment, the test about `https_only` do not include.