### PR TITLE
Remove some unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,6 @@ tokio = { version = "1.0", default-features = false, features = ["net", "time"] 
 tower = { version = "0.5.2", default-features = false, features = ["timeout", "util"] }
 tower-http = { version = "0.6.5", default-features = false, features = ["follow-redirect"] }
 pin-project-lite = "0.2.11"
-ipnet = "2.3"
 
 # Optional deps...
 rustls-pki-types = { version = "1.9.0", features = ["std"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ system-proxy = ["hyper-util/client-proxy-system"]
 macos-system-configuration = ["system-proxy"]
 
 # Experimental HTTP/3 client.
-http3 = ["rustls-tls-manual-roots", "dep:h3", "dep:h3-quinn", "dep:quinn", "dep:slab", "dep:futures-channel", "tokio/macros"]
+http3 = ["rustls-tls-manual-roots", "dep:h3", "dep:h3-quinn", "dep:quinn", "dep:slab", "tokio/macros"]
 
 
 # Internal (PRIVATE!) features used to aid testing.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ multipart = ["dep:mime_guess", "dep:futures-util"]
 
 # Deprecated, remove this feature while bumping minor versions.
 trust-dns = []
-hickory-dns = ["dep:hickory-resolver"]
+hickory-dns = ["dep:hickory-resolver", "dep:once_cell"]
 
 stream = ["tokio/fs", "dep:futures-util", "dep:tokio-util", "dep:wasm-streams"]
 
@@ -124,7 +124,6 @@ http-body-util = "0.1"
 hyper = { version = "1.1", features = ["http1", "client"] }
 hyper-util = { version = "0.1.12", features = ["http1", "client", "client-legacy", "client-proxy", "tokio"] }
 h2 = { version = "0.4", optional = true }
-once_cell = "1.18"
 log = "0.4.17"
 mime = "0.3.16"
 percent-encoding = "2.3"
@@ -161,6 +160,7 @@ tokio-socks = { version = "0.5.2", optional = true }
 
 ## hickory-dns
 hickory-resolver = { version = "0.24", optional = true, features = ["tokio-runtime"] }
+once_cell = { version = "1.18", optional = true }
 
 # HTTP/3 experimental support
 h3 = { version = "0.0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rustls-tls-native-roots = ["rustls-tls-native-roots-no-provider", "__rustls-ring
 
 blocking = ["dep:futures-channel", "futures-channel?/sink", "dep:futures-util", "futures-util?/io", "futures-util?/sink", "tokio/sync"]
 
-charset = ["dep:encoding_rs"]
+charset = ["dep:encoding_rs", "dep:mime"]
 
 cookies = ["dep:cookie_crate", "dep:cookie_store"]
 
@@ -125,7 +125,6 @@ hyper = { version = "1.1", features = ["http1", "client"] }
 hyper-util = { version = "0.1.12", features = ["http1", "client", "client-legacy", "client-proxy", "tokio"] }
 h2 = { version = "0.4", optional = true }
 log = "0.4.17"
-mime = "0.3.16"
 percent-encoding = "2.3"
 tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
 tower = { version = "0.5.2", default-features = false, features = ["timeout", "util"] }
@@ -134,6 +133,7 @@ pin-project-lite = "0.2.11"
 
 # Optional deps...
 rustls-pki-types = { version = "1.9.0", features = ["std"], optional = true }
+mime = { version = "0.3.16", optional = true }
 
 ## default-tls
 hyper-tls = { version = "0.6", optional = true }

--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use bytes::Bytes;
 use http_body::Body as HttpBody;
 use http_body_util::combinators::BoxBody;
-//use sync_wrapper::SyncWrapper;
 use pin_project_lite::pin_project;
 #[cfg(feature = "stream")]
 use tokio::fs::File;

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -603,6 +603,7 @@ mod tests {
     use super::*;
     use futures_util::stream;
     use futures_util::TryStreamExt;
+    use mime_guess::mime;
     use std::future;
     use tokio::{self, runtime};
 

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -603,7 +603,6 @@ mod tests {
     use super::*;
     use futures_util::stream;
     use futures_util::TryStreamExt;
-    use mime_guess::mime;
     use std::future;
     use tokio::{self, runtime};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,9 +255,13 @@ compile_error!(
 "
 );
 
+// Ignore `unused_crate_dependencies` warnings.
 // Used to pin the version.
 #[cfg(feature = "http3")]
 use slab as _;
+// Used in many features that they're not worth making it optional.
+use futures_core as _;
+use sync_wrapper as _;
 
 macro_rules! if_wasm {
     ($($item:item)*) => {$(
@@ -281,7 +285,7 @@ pub use url::Url;
 // universal mods
 #[macro_use]
 mod error;
-// TODO: remove `if_hyper` if wasm has been mirgated to new config system.
+// TODO: remove `if_hyper` if wasm has been migrated to new config system.
 if_hyper! {
     mod config;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,10 @@ compile_error!(
 "
 );
 
+// Used to pin the version.
+#[cfg(feature = "http3")]
+use slab as _;
+
 macro_rules! if_wasm {
     ($($item:item)*) => {$(
         #[cfg(target_arch = "wasm32")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(test, deny(warnings))]
 
 //! # reqwest

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2,7 +2,7 @@
 #![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
 mod support;
 
-use support::server::{self, low_level_with_response};
+use support::server;
 
 use http::header::{CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING};
 #[cfg(feature = "json")]

--- a/tests/gzip.rs
+++ b/tests/gzip.rs
@@ -4,8 +4,8 @@ use flate2::Compression;
 use support::server;
 
 use std::io::Write;
+use std::time::Duration;
 use tokio::io::AsyncWriteExt;
-use tokio::time::Duration;
 
 #[tokio::test]
 async fn gzip_response() {
@@ -197,9 +197,8 @@ async fn test_non_chunked_non_fragmented_response() {
 
 #[tokio::test]
 async fn test_chunked_fragmented_response_1() {
-    const DELAY_BETWEEN_RESPONSE_PARTS: tokio::time::Duration =
-        tokio::time::Duration::from_millis(1000);
-    const DELAY_MARGIN: tokio::time::Duration = tokio::time::Duration::from_millis(50);
+    const DELAY_BETWEEN_RESPONSE_PARTS: Duration = Duration::from_millis(1000);
+    const DELAY_MARGIN: Duration = Duration::from_millis(50);
 
     let server = server::low_level_with_response(|_raw_request, client_socket| {
         Box::new(async move {
@@ -251,9 +250,8 @@ async fn test_chunked_fragmented_response_1() {
 
 #[tokio::test]
 async fn test_chunked_fragmented_response_2() {
-    const DELAY_BETWEEN_RESPONSE_PARTS: tokio::time::Duration =
-        tokio::time::Duration::from_millis(1000);
-    const DELAY_MARGIN: tokio::time::Duration = tokio::time::Duration::from_millis(50);
+    const DELAY_BETWEEN_RESPONSE_PARTS: Duration = Duration::from_millis(1000);
+    const DELAY_MARGIN: Duration = Duration::from_millis(50);
 
     let server = server::low_level_with_response(|_raw_request, client_socket| {
         Box::new(async move {
@@ -306,9 +304,8 @@ async fn test_chunked_fragmented_response_2() {
 
 #[tokio::test]
 async fn test_chunked_fragmented_response_with_extra_bytes() {
-    const DELAY_BETWEEN_RESPONSE_PARTS: tokio::time::Duration =
-        tokio::time::Duration::from_millis(1000);
-    const DELAY_MARGIN: tokio::time::Duration = tokio::time::Duration::from_millis(50);
+    const DELAY_BETWEEN_RESPONSE_PARTS: Duration = Duration::from_millis(1000);
+    const DELAY_MARGIN: Duration = Duration::from_millis(50);
 
     let server = server::low_level_with_response(|_raw_request, client_socket| {
         Box::new(async move {

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -5,11 +5,11 @@ use support::server;
 
 use std::env;
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use tokio::sync::Mutex;
 
 // serialize tests that read from / write to environment variables
-static HTTP_PROXY_ENV_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static HTTP_PROXY_ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[tokio::test]
 async fn http_proxy() {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub mod delay_layer;
 pub mod delay_server;
 pub mod error;


### PR DESCRIPTION
Remove an unused dependency, and make others optional to only the feature they're needed for.

This is achieved through enabling the `unused_crate_dependencies` lint (only for non-dev-deps), and checking with `cargo hack check --each-feature`.

Towards https://github.com/seanmonstar/reqwest/issues/2712.

See individual commits for the full list of changes.