### PR TITLE
feat: WASM streaming body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ tower-service = "0.3"
 futures-core = { version = "0.3.28", default-features = false }
 futures-util = { version = "0.3.28", default-features = false, optional = true }
 sync_wrapper = { version = "1.0", features = ["futures"] }
+pin-project-lite = "0.2.11"
 
 # Optional deps...
 
@@ -129,7 +130,6 @@ percent-encoding = "2.3"
 tokio = { version = "1.0", default-features = false, features = ["net", "time"] }
 tower = { version = "0.5.2", default-features = false, features = ["timeout", "util"] }
 tower-http = { version = "0.6.5", default-features = false, features = ["follow-redirect"] }
-pin-project-lite = "0.2.11"
 
 # Optional deps...
 rustls-pki-types = { version = "1.9.0", features = ["std"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,8 +333,11 @@ fn _assert_impls() {
     assert_sync::<Client>();
     assert_clone::<Client>();
 
-    assert_send::<Request>();
-    assert_send::<RequestBuilder>();
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        assert_send::<Request>();
+        assert_send::<RequestBuilder>();
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -344,8 +347,11 @@ fn _assert_impls() {
     assert_send::<Error>();
     assert_sync::<Error>();
 
-    assert_send::<Body>();
-    assert_sync::<Body>();
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        assert_send::<Body>();
+        assert_sync::<Body>();
+    }
 }
 
 if_hyper! {


### PR DESCRIPTION
I started implementing this feature because I realized `RequestInit` takes a `ReadableStream` as a body but then I realized half way through that [the browser support isn't great](https://caniuse.com/mdn-api_request_request_request_body_readablestream). But I've finished it anyways if you want to use it or just for reference. I've tested it locally with

```rust
#[derive(serde::Deserialize, Debug)]
struct HttpBinResponse {
    data: String,
}

#[wasm_bindgen_test]
pub async fn test() {
    let chunks: Vec<Result<_, ::std::io::Error>> = vec![Ok("hello"), Ok(" "), Ok("world")];
    let stream = futures_util::stream::iter(chunks);
    let body = reqwest::Body::wrap_stream(stream);
    let res = reqwest::Client::new()
        .post("https://nghttp2.org/httpbin/post")
        .body(body)
        .send()
        .await
        .unwrap()
        .json::<HttpBinResponse>()
        .await
        .unwrap();
    assert_eq!(res.data, "hello world");
}
```