### PR TITLE
feat: add Default impl for wasm::Body

### DIFF
--- a/src/wasm/body.rs
+++ b/src/wasm/body.rs
@@ -182,6 +182,14 @@ impl fmt::Debug for Body {
     }
 }
 
+impl Default for Body {
+    fn default() -> Body {
+        Body {
+            inner: Inner::Single(Single::Bytes(Bytes::new())),
+        }
+    }
+}
+
 // Can use new methods in web-sys when requiring v0.2.93.
 // > `init.method(m)` to `init.set_method(m)`
 // For now, ignore their deprecation.


### PR DESCRIPTION
Pretty straightforward but the `Body` implementation doesn't implement `Default` like in `async_impl`