### PR TITLE
feat: Make Rustls the default TLS provider.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: check --feature-powerset
-        run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip http3,__tls,__rustls,__rustls-ring,native-tls-vendored,trust-dns
+        run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip http3,__tls,__rustls,__rustls-ring,__rustls-aws-lc-rs,native-tls-vendored,trust-dns
         env:
           RUSTFLAGS: "-D dead_code -D unused_imports"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,8 @@ jobs:
           cargo update -p hyper-rustls --precise 0.27.2
           cargo update -p tokio-rustls --precise 0.26.0
           cargo update -p rustls --precise 0.23.19
+          cargo update -p aws-lc-rs --precise 1.13.1
+          cargo update -p aws-lc-sys --precise 0.29.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,8 @@ jobs:
           cargo update -p native-tls --precise 0.2.13
           cargo update -p once_cell --precise 1.20.3
           cargo update -p tracing-core --precise 0.1.33
+          cargo update -p rustls --precise 0.23.19
+          cargo update -p tokio-rustls --precise 0.26.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,9 +194,19 @@ jobs:
         run: pacman.exe -Sy --noconfirm mingw-w64-i686-clang mingw-w64-i686-nasm
         shell: bash
 
+      - name: Install x86_64 Clang & NASM
+        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
+        run: pacman.exe -Sy --noconfirm mingw-w64-x86_64-clang mingw-w64-x86_64-nasm
+        shell: bash
+
       - name: Add libclang to the environment for windows i686-gnu
         run: echo "LIBCLANG_PATH=C:\msys64\mingw32\bin" >> $env:GITHUB_ENV
         if: ${{ matrix.target == 'i686-pc-windows-gnu' }}
+        shell: bash
+
+      - name: Add libclang to the environment for windows x86_64-gnu
+        run: echo "LIBCLANG_PATH=C:\msys64\mingw64\bin" >> $env:GITHUB_ENV
+        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
         shell: bash
 
       - name: Update gcc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,7 @@ jobs:
           cargo clean
           cargo update -Z minimal-versions
           cargo update -p proc-macro2 --precise 1.0.87
+          cargo update -p aws-lc-rs --precise 1.13.1
           cargo update -p aws-lc-sys --precise 0.29.0
           cargo update -p openssl-sys
           cargo update -p openssl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,13 @@ jobs:
         if: matrix.mingw64_path
         shell: bash
 
+      # This is required to build aws-lc-sys on windows GNU
+      # See https://github.com/actions/runner-images/issues/3316
+      - name: Add libclang to the path for windows GNU
+        run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' || matrix.target == 'i686-pc-windows-gnu' }}
+        shell: bash
+
       - name: Update gcc
         if: matrix.package_name
         run: pacman.exe -Sy --noconfirm ${{ matrix.package_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,7 @@ jobs:
           cargo clean
           cargo update -Z minimal-versions
           cargo update -p proc-macro2 --precise 1.0.87
+          cargo update -p aws-lc-sys --precise 0.29.0
           cargo update -p openssl-sys
           cargo update -p openssl
           cargo check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
         with:
           toolchain: ${{ steps.metadata.outputs.msrv }}
 
-      - name: Fix log and tokio versions
+      - name: Fix dependency versions
         run: |
           cargo update
           cargo update -p log --precise 0.4.18
@@ -319,6 +319,7 @@ jobs:
           cargo update -p native-tls --precise 0.2.13
           cargo update -p once_cell --precise 1.20.3
           cargo update -p tracing-core --precise 0.1.33
+          cargo update -p hyper-rustls --precise 0.27.2
           cargo update -p tokio-rustls --precise 0.26.0
           cargo update -p rustls --precise 0.23.19
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,8 +319,8 @@ jobs:
           cargo update -p native-tls --precise 0.2.13
           cargo update -p once_cell --precise 1.20.3
           cargo update -p tracing-core --precise 0.1.33
-          cargo update -p rustls --precise 0.23.19
           cargo update -p tokio-rustls --precise 0.26.0
+          cargo update -p rustls --precise 0.23.19
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,10 @@ jobs:
           toolchain: ${{ matrix.rust || 'stable' }}
           targets: ${{ matrix.target }}
 
+      - name: Install i686 Clang & NASM
+        if: ${{ matrix.target == 'i686-pc-windows-gnu' }}
+        run: pacman.exe -Sy --noconfirm mingw-w64-i686-clang mingw-w64-i686-nasm
+
       - name: Add mingw-w64 to path for i686-gnu
         run: |
           echo "${{ matrix.mingw64_path }}" >> $GITHUB_PATH
@@ -189,11 +193,9 @@ jobs:
         if: matrix.mingw64_path
         shell: bash
 
-      # This is required to build aws-lc-sys on windows GNU
-      # See https://github.com/actions/runner-images/issues/3316
-      - name: Add libclang to the path for windows GNU
-        run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' || matrix.target == 'i686-pc-windows-gnu' }}
+      - name: Add libclang to the environment for windows i686-gnu
+        run: echo "LIBCLANG_PATH=C:\msys64\mingw32\bin" >> $env:GITHUB_ENV
+        if: ${{ matrix.target == 'i686-pc-windows-gnu' }}
         shell: bash
 
       - name: Update gcc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,12 @@ jobs:
             os: windows-latest
             target: x86_64-pc-windows-msvc
             features: "--features blocking,gzip,brotli,zstd,deflate,json,multipart,stream"
+            aws_lc_sys_prebuilt_nasm: 1
           - name: windows / stable-i686-msvc
             os: windows-latest
             target: i686-pc-windows-msvc
             features: "--features blocking,gzip,brotli,zstd,deflate,json,multipart,stream"
+            aws_lc_sys_prebuilt_nasm: 1
           - name: windows / stable-x86_64-gnu
             os: windows-latest
             rust: stable-x86_64-pc-windows-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,15 +182,16 @@ jobs:
           toolchain: ${{ matrix.rust || 'stable' }}
           targets: ${{ matrix.target }}
 
-      - name: Install i686 Clang & NASM
-        if: ${{ matrix.target == 'i686-pc-windows-gnu' }}
-        run: pacman.exe -Sy --noconfirm mingw-w64-i686-clang mingw-w64-i686-nasm
-
       - name: Add mingw-w64 to path for i686-gnu
         run: |
           echo "${{ matrix.mingw64_path }}" >> $GITHUB_PATH
           echo "C:\msys64\usr\bin" >> $GITHUB_PATH
         if: matrix.mingw64_path
+        shell: bash
+
+      - name: Install i686 Clang & NASM
+        if: ${{ matrix.target == 'i686-pc-windows-gnu' }}
+        run: pacman.exe -Sy --noconfirm mingw-w64-i686-clang mingw-w64-i686-nasm
         shell: bash
 
       - name: Add libclang to the environment for windows i686-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
 
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
 
+    env:
+      AWS_LC_SYS_PREBUILT_NASM: ${{ matrix.aws_lc_sys_prebuilt_nasm || 0 }}
+
     # The build matrix does not yet support 'allow failures' at job level.
     # See `jobs.nightly` for the active nightly job definition.
     strategy:
@@ -114,6 +117,7 @@ jobs:
             features: "--features blocking,gzip,brotli,zstd,deflate,json,multipart,stream"
             package_name: mingw-w64-x86_64-gcc
             mingw64_path: "C:\\msys64\\mingw64\\bin"
+            aws_lc_sys_prebuilt_nasm: 1
           - name: windows / stable-i686-gnu
             os: windows-latest
             rust: stable-i686-pc-windows-gnu
@@ -121,6 +125,7 @@ jobs:
             features: "--features blocking,gzip,brotli,zstd,deflate,json,multipart,stream"
             package_name: mingw-w64-i686-gcc
             mingw64_path: "C:\\msys64\\mingw32\\bin"
+            aws_lc_sys_prebuilt_nasm: 1
 
           - name: "feat.: default-tls disabled"
             features: "--no-default-features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ features = [
 [features]
 default = ["default-tls", "charset", "http2", "system-proxy"]
 
-default-tls = ["dep:hyper-tls", "rustls-tls"]
+default-tls = ["rustls-tls"]
 
 http2 = ["h2", "hyper/http2", "hyper-util/http2", "hyper-rustls?/http2"]
 
@@ -133,12 +133,12 @@ pin-project-lite = "0.2.11"
 rustls-pki-types = { version = "1.9.0", features = ["std"], optional = true }
 mime = { version = "0.3.16", optional = true }
 
-## default-tls
+# native-tls
 hyper-tls = { version = "0.6", optional = true }
 native-tls-crate = { version = "0.2.10", optional = true, package = "native-tls" }
 tokio-native-tls = { version = "0.3.0", optional = true }
 
-# rustls-tls
+# default-tls and rustls-tls
 hyper-rustls = { version = "0.27.0", default-features = false, optional = true, features = ["http1", "tls12"] }
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,11 @@ features = [
 [features]
 default = ["default-tls", "charset", "http2", "system-proxy"]
 
-# Note: this doesn't enable the 'native-tls' feature, which adds specific
-# functionality for it.
-default-tls = ["dep:hyper-tls", "dep:native-tls-crate", "__tls", "dep:tokio-native-tls"]
+default-tls = ["dep:hyper-tls", "rustls-tls"]
 
 http2 = ["h2", "hyper/http2", "hyper-util/http2", "hyper-rustls?/http2"]
 
-# Enables native-tls specific functionality not available by default.
-native-tls = ["default-tls"]
+native-tls = ["dep:hyper-tls", "dep:native-tls-crate", "__tls", "dep:tokio-native-tls"]
 native-tls-alpn = ["native-tls", "native-tls-crate?/alpn", "hyper-tls?/alpn"]
 native-tls-vendored = ["native-tls", "native-tls-crate?/vendored"]
 
@@ -47,9 +44,9 @@ rustls-tls-manual-roots-no-provider = ["__rustls"]
 rustls-tls-webpki-roots-no-provider = ["dep:webpki-roots", "hyper-rustls?/webpki-tokio", "__rustls"]
 rustls-tls-native-roots-no-provider = ["dep:rustls-native-certs", "hyper-rustls?/native-tokio", "__rustls"]
 
-rustls-tls-manual-roots = ["rustls-tls-manual-roots-no-provider", "__rustls-ring"]
-rustls-tls-webpki-roots = ["rustls-tls-webpki-roots-no-provider", "__rustls-ring"]
-rustls-tls-native-roots = ["rustls-tls-native-roots-no-provider", "__rustls-ring"]
+rustls-tls-manual-roots = ["rustls-tls-manual-roots-no-provider", "__rustls-aws-lc-rs"]
+rustls-tls-webpki-roots = ["rustls-tls-webpki-roots-no-provider", "__rustls-aws-lc-rs"]
+rustls-tls-native-roots = ["rustls-tls-native-roots-no-provider", "__rustls-aws-lc-rs"]
 
 blocking = ["dep:futures-channel", "futures-channel?/sink", "dep:futures-util", "futures-util?/io", "futures-util?/sink", "tokio/sync"]
 
@@ -97,6 +94,7 @@ __tls = ["dep:rustls-pki-types", "tokio/io-util"]
 # Equivalent to rustls-tls-manual-roots but shorter :)
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls"]
 __rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "quinn?/ring"]
+__rustls-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/aws-lc-rs"]
 
 [dependencies]
 base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ __tls = ["dep:rustls-pki-types", "tokio/io-util"]
 # Equivalent to rustls-tls-manual-roots but shorter :)
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls"]
 __rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "quinn?/ring"]
-__rustls-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/aws-lc-rs"]
+__rustls-aws-lc-rs = ["dep:aws-lc-sys", "hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/aws-lc-rs"]
 
 [dependencies]
 base64 = "0.22"
@@ -144,6 +144,9 @@ rustls = { version = "0.23.4", optional = true, default-features = false, featur
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 webpki-roots = { version = "1", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
+
+## explicit minimal version dependency to build on stable and nightly
+aws-lc-sys = { version = "0.29.0", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ __tls = ["dep:rustls-pki-types", "tokio/io-util"]
 # Equivalent to rustls-tls-manual-roots but shorter :)
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls"]
 __rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "quinn?/ring"]
-__rustls-aws-lc-rs = ["dep:aws-lc-sys", "hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/aws-lc-rs"]
+__rustls-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/aws-lc-rs"]
 
 [dependencies]
 base64 = "0.22"
@@ -144,9 +144,6 @@ rustls = { version = "0.23.4", optional = true, default-features = false, featur
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 webpki-roots = { version = "1", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
-
-## explicit minimal version dependency to build on stable and nightly
-aws-lc-sys = { version = "0.29.0", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -575,7 +575,7 @@ impl ClientBuilder {
                         tls.max_protocol_version(Some(protocol));
                     }
 
-                    ConnectorBuilder::new_default_tls(
+                    ConnectorBuilder::new_native_tls(
                         http,
                         tls,
                         proxies.clone(),
@@ -599,7 +599,7 @@ impl ClientBuilder {
                     )?
                 }
                 #[cfg(feature = "native-tls")]
-                TlsBackend::BuiltNativeTls(conn) => ConnectorBuilder::from_built_default_tls(
+                TlsBackend::BuiltNativeTls(conn) => ConnectorBuilder::from_built_native_tls(
                     http,
                     conn,
                     proxies.clone(),
@@ -621,7 +621,7 @@ impl ClientBuilder {
                     config.nodelay,
                     config.tls_info,
                 ),
-                #[cfg(feature = "default-tls")]
+                #[cfg(feature = "__rustls")]
                 TlsBackend::BuiltRustls(conn) => {
                     #[cfg(feature = "http3")]
                     {
@@ -663,7 +663,7 @@ impl ClientBuilder {
                         config.tls_info,
                     )
                 }
-                #[cfg(feature = "default-tls")]
+                #[cfg(feature = "__rustls")]
                 TlsBackend::Rustls => {
                     use crate::tls::{IgnoreHostname, NoVerifier};
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2331,10 +2331,7 @@ impl Default for Client {
 }
 
 fn default_rustls_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
-    #[cfg(not(any(
-        feature = "__rustls-ring",
-        feature = "__rustls-aws-lc-rs"
-    )))]
+    #[cfg(not(any(feature = "__rustls-ring", feature = "__rustls-aws-lc-rs")))]
     panic!("No provider set");
 
     #[cfg(all(feature = "__rustls-ring", not(feature = "__rustls-aws-lc-rs")))]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -509,7 +509,7 @@ impl ClientBuilder {
             #[cfg(feature = "__tls")]
             match config.tls {
                 #[cfg(feature = "native-tls")]
-                TlsBackend::Default => {
+                TlsBackend::NativeTls => {
                     let mut tls = TlsConnector::builder();
 
                     #[cfg(all(feature = "native-tls-alpn", not(feature = "http3")))]
@@ -664,7 +664,7 @@ impl ClientBuilder {
                     )
                 }
                 #[cfg(feature = "default-tls")]
-                TlsBackend::Default | TlsBackend::Rustls => {
+                TlsBackend::Rustls => {
                     use crate::tls::{IgnoreHostname, NoVerifier};
 
                     // Set root certificates.
@@ -2003,7 +2003,7 @@ impl ClientBuilder {
     #[cfg(feature = "native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     pub fn use_native_tls(mut self) -> ClientBuilder {
-        self.config.tls = TlsBackend::Default;
+        self.config.tls = TlsBackend::NativeTls;
         self
     }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2330,6 +2330,7 @@ impl Default for Client {
     }
 }
 
+#[cfg(feature = "__rustls")]
 fn default_rustls_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
     #[cfg(not(any(feature = "__rustls-ring", feature = "__rustls-aws-lc-rs")))]
     panic!("No provider set");

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -7,7 +7,7 @@ use hyper::rt::{Read, ReadBufCursor, Write};
 use hyper_util::client::legacy::connect::{Connected, Connection};
 #[cfg(any(feature = "socks", feature = "__tls"))]
 use hyper_util::rt::TokioIo;
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 use native_tls_crate::{TlsConnector, TlsConnectorBuilder};
 use pin_project_lite::pin_project;
 use tower::util::{BoxCloneSyncServiceLayer, MapRequestLayer};
@@ -22,9 +22,9 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 use self::native_tls_conn::NativeTlsConn;
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "default-tls")]
 use self::rustls_tls_conn::RustlsTlsConn;
 use crate::dns::DynResolver;
 use crate::error::{cast_to_internal_error, BoxError};
@@ -199,7 +199,7 @@ where {
         }
     }
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     pub(crate) fn new_default_tls<T>(
         http: HttpConnector,
         tls: TlsConnectorBuilder,
@@ -250,7 +250,7 @@ where {
         ))
     }
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     pub(crate) fn from_built_default_tls<T>(
         mut http: HttpConnector,
         tls: TlsConnector,
@@ -308,7 +308,7 @@ where {
         }
     }
 
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     pub(crate) fn new_rustls_tls<T>(
         mut http: HttpConnector,
         tls: rustls::ClientConfig,
@@ -389,9 +389,9 @@ where {
 
     pub(crate) fn set_keepalive(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             Inner::DefaultTls(http, _tls) => http.set_keepalive(dur),
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive(dur),
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => http.set_keepalive(dur),
@@ -400,9 +400,9 @@ where {
 
     pub(crate) fn set_keepalive_interval(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             Inner::DefaultTls(http, _tls) => http.set_keepalive_interval(dur),
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive_interval(dur),
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => http.set_keepalive_interval(dur),
@@ -411,9 +411,9 @@ where {
 
     pub(crate) fn set_keepalive_retries(&mut self, retries: Option<u32>) {
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             Inner::DefaultTls(http, _tls) => http.set_keepalive_retries(retries),
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive_retries(retries),
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => http.set_keepalive_retries(retries),
@@ -428,9 +428,9 @@ where {
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     pub(crate) fn set_tcp_user_timeout(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             Inner::DefaultTls(http, _tls) => http.set_tcp_user_timeout(dur),
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             Inner::RustlsTls { http, .. } => http.set_tcp_user_timeout(dur),
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => http.set_tcp_user_timeout(dur),
@@ -463,9 +463,9 @@ pub(crate) struct ConnectorService {
 enum Inner {
     #[cfg(not(feature = "__tls"))]
     Http(HttpConnector),
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     DefaultTls(HttpConnector, TlsConnector),
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     RustlsTls {
         http: HttpConnector,
         tls: Arc<rustls::ClientConfig>,
@@ -477,9 +477,9 @@ impl Inner {
     #[cfg(feature = "socks")]
     fn get_http_connector(&mut self) -> &mut crate::connect::HttpConnector {
         match self {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             Inner::DefaultTls(http, _) => http,
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             Inner::RustlsTls { http, .. } => http,
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => http,
@@ -499,7 +499,7 @@ impl ConnectorService {
         };
 
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             Inner::DefaultTls(http, tls) => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     let host = dst.host().ok_or("no host in url")?.to_string();
@@ -516,7 +516,7 @@ impl ConnectorService {
                     });
                 }
             }
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             Inner::RustlsTls { http, tls, .. } => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     use std::convert::TryFrom;
@@ -575,7 +575,7 @@ impl ConnectorService {
                     tls_info: false,
                 })
             }
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             Inner::DefaultTls(http, tls) => {
                 let mut http = http.clone();
 
@@ -614,7 +614,7 @@ impl ConnectorService {
                     })
                 }
             }
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             Inner::RustlsTls { http, tls, .. } => {
                 let mut http = http.clone();
 
@@ -668,7 +668,7 @@ impl ConnectorService {
         let misc = proxy.custom_headers().clone();
 
         match &self.inner {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             Inner::DefaultTls(http, tls) => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     log::trace!("tunneling HTTPS over proxy");
@@ -706,7 +706,7 @@ impl ConnectorService {
                     });
                 }
             }
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             Inner::RustlsTls {
                 http,
                 tls,
@@ -823,7 +823,7 @@ impl<T: TlsInfoFactory> TlsInfoFactory for TokioIo<T> {
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::TcpStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
@@ -836,7 +836,7 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
         TokioIo<hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>>>,
@@ -853,7 +853,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         match self {
@@ -863,7 +863,7 @@ impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStrea
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "default-tls")]
 impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::net::TcpStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
@@ -876,7 +876,7 @@ impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::n
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "default-tls")]
 impl TlsInfoFactory
     for tokio_rustls::client::TlsStream<
         TokioIo<hyper_rustls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>>>,
@@ -893,7 +893,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "default-tls")]
 impl TlsInfoFactory for hyper_rustls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         match self {
@@ -1008,7 +1008,7 @@ pub(crate) mod sealed {
 
 pub(crate) type Connecting = Pin<Box<dyn Future<Output = Result<Conn, BoxError>> + Send>>;
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 mod native_tls_conn {
     use super::TlsInfoFactory;
     use hyper::rt::{Read, ReadBufCursor, Write};
@@ -1132,7 +1132,7 @@ mod native_tls_conn {
     }
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "default-tls")]
 mod rustls_tls_conn {
     use super::TlsInfoFactory;
     use hyper::rt::{Read, ReadBufCursor, Write};

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -69,13 +69,13 @@ pub struct CertificateRevocationList {
 /// Represents a server X509 certificate.
 #[derive(Clone)]
 pub struct Certificate {
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     native: native_tls_crate::Certificate,
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     original: Cert,
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "default-tls")]
 #[derive(Clone)]
 enum Cert {
     Der(Vec<u8>),
@@ -94,7 +94,7 @@ enum ClientCert {
     Pkcs12(native_tls_crate::Identity),
     #[cfg(feature = "native-tls")]
     Pkcs8(native_tls_crate::Identity),
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     Pem {
         key: rustls_pki_types::PrivateKeyDer<'static>,
         certs: Vec<rustls_pki_types::CertificateDer<'static>>,
@@ -141,9 +141,9 @@ impl Certificate {
     /// ```
     pub fn from_der(der: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             native: native_tls_crate::Certificate::from_der(der).map_err(crate::error::builder)?,
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             original: Cert::Der(der.to_owned()),
         })
     }
@@ -166,9 +166,9 @@ impl Certificate {
     /// ```
     pub fn from_pem(pem: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             native: native_tls_crate::Certificate::from_pem(pem).map_err(crate::error::builder)?,
-            #[cfg(feature = "__rustls")]
+            #[cfg(feature = "default-tls")]
             original: Cert::Pem(pem.to_owned()),
         })
     }
@@ -199,12 +199,12 @@ impl Certificate {
             .collect::<crate::Result<Vec<Certificate>>>()
     }
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     pub(crate) fn add_to_native_tls(self, tls: &mut native_tls_crate::TlsConnectorBuilder) {
         tls.add_root_certificate(self.native);
     }
 
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     pub(crate) fn add_to_rustls(
         self,
         root_cert_store: &mut rustls::RootCertStore,
@@ -529,7 +529,7 @@ impl Version {
     /// Version 1.3 of the TLS protocol.
     pub const TLS_1_3: Version = Version(InnerVersion::Tls1_3);
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     pub(crate) fn to_native_tls(self) -> Option<native_tls_crate::Protocol> {
         match self.0 {
             InnerVersion::Tls1_0 => Some(native_tls_crate::Protocol::Tlsv10),
@@ -539,7 +539,7 @@ impl Version {
         }
     }
 
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     pub(crate) fn from_rustls(version: rustls::ProtocolVersion) -> Option<Self> {
         match version {
             rustls::ProtocolVersion::SSLv2 => None,
@@ -746,13 +746,13 @@ impl std::fmt::Debug for TlsInfo {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     #[test]
     fn certificate_from_der_invalid() {
         Certificate::from_der(b"not der").unwrap_err();
     }
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     #[test]
     fn certificate_from_pem_invalid() {
         Certificate::from_pem(b"not pem").unwrap_err();
@@ -770,13 +770,13 @@ mod tests {
         Identity::from_pkcs8_pem(b"not pem", b"not key").unwrap_err();
     }
 
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     #[test]
     fn identity_from_pem_invalid() {
         Identity::from_pem(b"not pem").unwrap_err();
     }
 
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     #[test]
     fn identity_from_pem_pkcs1_key() {
         let pem = b"-----BEGIN CERTIFICATE-----\n\
@@ -821,7 +821,7 @@ mod tests {
         assert!(Certificate::from_pem_bundle(PEM_BUNDLE).is_ok())
     }
 
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     #[test]
     fn crl_from_pem() {
         let pem = b"-----BEGIN X509 CRL-----\n-----END X509 CRL-----\n";
@@ -829,7 +829,7 @@ mod tests {
         CertificateRevocationList::from_pem(pem).unwrap();
     }
 
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "default-tls")]
     #[test]
     fn crl_from_pem_bundle() {
         let pem_bundle = std::fs::read("tests/support/crl.pem").unwrap();

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -556,8 +556,8 @@ impl Version {
 pub(crate) enum TlsBackend {
     // This is the default and HTTP/3 feature does not use it so suppress it.
     #[allow(dead_code)]
-    #[cfg(feature = "default-tls")]
-    Default,
+    #[cfg(feature = "native-tls")]
+    NativeTls,
     #[cfg(feature = "native-tls")]
     BuiltNativeTls(native_tls_crate::TlsConnector),
     #[cfg(feature = "__rustls")]
@@ -571,8 +571,8 @@ pub(crate) enum TlsBackend {
 impl fmt::Debug for TlsBackend {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            #[cfg(feature = "default-tls")]
-            TlsBackend::Default => write!(f, "Default"),
+            #[cfg(feature = "native-tls")]
+            TlsBackend::NativeTls => write!(f, "NativeTls"),
             #[cfg(feature = "native-tls")]
             TlsBackend::BuiltNativeTls(_) => write!(f, "BuiltNativeTls"),
             #[cfg(feature = "__rustls")]
@@ -588,17 +588,17 @@ impl fmt::Debug for TlsBackend {
 #[allow(clippy::derivable_impls)]
 impl Default for TlsBackend {
     fn default() -> TlsBackend {
-        #[cfg(all(feature = "default-tls", not(feature = "http3")))]
-        {
-            TlsBackend::Default
-        }
-
         #[cfg(any(
-            all(feature = "__rustls", not(feature = "default-tls")),
+            all(feature = "__rustls", not(feature = "native-tls")),
             feature = "http3"
         ))]
         {
             TlsBackend::Rustls
+        }
+
+        #[cfg(all(feature = "native-tls", not(feature = "http3")))]
+        {
+            TlsBackend::NativeTls
         }
     }
 }


### PR DESCRIPTION
This switches the default TLS provider to Rustls. It keeps the `native-tls` feature with the same configuration it had before as the default TLS provider.

I'm new to the codebase, so let me know all the things I've missed. I've done the minimal work to see what the level or effort was to change the TLS provider. Tests seem to pass.

## Todo:

- [ ] Integrate with `rustls-platform-verifier`. See https://github.com/seanmonstar/reqwest/issues/2025#issuecomment-2956991896. WIP
- [x] Update documentation
- [ ] Other??

@seanmonstar I'll really appreciate the feedback and guidance. This was the number 1 problem people bumped into when using Reqwest on AWS Lambda functions written in Rust when I maintained the Rust Runtime for Lambda.

Fixes https://github.com/seanmonstar/reqwest/issues/2723