### PR TITLE
Minimize package size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.64.0"
 autotests = true
+include = [
+    "README.md",
+    "Cargo.toml",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "src/**/*.rs"
+]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This commit minimizes the published package size by explicitly including only relevant files. This reduces the package size from 195.2KiB to 148.3KiB.

Fixes #2758