### PR TITLE
Accept `Arc<dyn Resolve>` to override `dns_resolver` in `ClientBuilder`

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2218,6 +2218,15 @@ impl ClientBuilder {
         self
     }
 
+    /// Similar to [`dns_resolver`], but takes a dynamic trait object.
+    ///
+    /// This enables dynamic dispatch for the resolver, allowing you to pass any type that
+    /// implements the `Resolve` trait.
+    pub fn dns_resolver_dyn(mut self, resolver: Arc<dyn Resolve>) -> ClientBuilder {
+        self.config.dns_resolver = Some(resolver);
+        self
+    }
+
     /// Whether to send data on the first flight ("early data") in TLS 1.3 handshakes
     /// for HTTP/3 connections.
     ///


### PR DESCRIPTION
Previously, `dns_resolver` forbids passing `Arc<dyn Resolve>` because the type is not determined at compile time. My project involves dynamically selecting DNS implementation, and `dns_resolver` makes it very difficult to use.