### PR TITLE
upgrade url to v2.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ __rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "qu
 [dependencies]
 base64 = "0.22"
 http = "1.1"
-url = "2.4"
+url = "2.5.4"
 bytes = "1.2"
 serde = "1.0"
 serde_urlencoded = "0.7.1"


### PR DESCRIPTION
Bump `url` to v2.5.4, clears security issue https://github.com/advisories/GHSA-h97m-ww89-6jmq.