### PR TITLE
fix: fallback to hickory_resolver's default config if reading /etc/resolv.conf fails

### DIFF
--- a/src/dns/hickory.rs
+++ b/src/dns/hickory.rs
@@ -55,7 +55,11 @@ impl Iterator for SocketAddrs {
 /// The options are overridden to look up for both IPv4 and IPv6 addresses
 /// to work with "happy eyeballs" algorithm.
 fn new_resolver() -> TokioResolver {
-    let mut builder = TokioResolver::builder_tokio().unwrap_or_else(|_| {
+    let mut builder = TokioResolver::builder_tokio().unwrap_or_else(|err| {
+        log::debug!(
+            "hickory-dns: failed to load system DNS configuration; falling back to hickory_resolver defaults: {:?}",
+            err
+        );
         TokioResolver::builder_with_config(
             ResolverConfig::default(),
             TokioConnectionProvider::default(),


### PR DESCRIPTION
On some platforms, for example Android, /etc/resolv.conf does not exist, so it becomes difficult to use hickory-dns with reqwest. This PR fixes this.

hickory-resolver's default is Google DNS, though I would suggest using Cloudflare DNS instead. Please let me know what you think.

Related hickory-dns issue: <https://github.com/hickory-dns/hickory-dns/issues/652>.