### PR TITLE
feat(response): preserve URL when converting `Response` to `http::Response`

### DIFF
--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -528,9 +528,9 @@ mod tests {
         assert_eq!(response.status(), 200);
         assert_eq!(*response.url(), url);
 
-        let mut http_response = http::Response::from(response);
+        let http_response = http::Response::from(response);
         let resp_url = http_response.url();
         assert_eq!(http_response.status(), 200);
-        assert_eq!(resp_url, Some(url));
+        assert_eq!(resp_url, Some(&url));
     }
 }

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -484,16 +484,20 @@ impl<T: Into<Body>> From<http::Response<T>> for Response {
 // It's supposed to be the inverse of the conversion above.
 impl From<Response> for http::Response<Body> {
     fn from(r: Response) -> http::Response<Body> {
+        use crate::response::ResponseUrl;
+
         let (parts, body) = r.res.into_parts();
         let body = Body::wrap(body);
-        http::Response::from_parts(parts, body)
+        let mut response = http::Response::from_parts(parts, body);
+        response.extensions_mut().insert(ResponseUrl(*r.url));
+        response
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::Response;
-    use crate::ResponseBuilderExt;
+    use crate::{response::ResponseUrl, ResponseBuilderExt};
     use http::response::Builder;
     use url::Url;
 
@@ -509,5 +513,27 @@ mod tests {
 
         assert_eq!(response.status(), 200);
         assert_eq!(*response.url(), url);
+    }
+
+    #[test]
+    fn test_from_http_response_with_url() {
+        let url = Url::parse("http://example.com").unwrap();
+        let response = Builder::new()
+            .status(200)
+            .url(url.clone())
+            .body("foo")
+            .unwrap();
+        let response = Response::from(response);
+
+        assert_eq!(response.status(), 200);
+        assert_eq!(*response.url(), url);
+
+        let mut http_response = http::Response::from(response);
+        let resp_url = http_response
+            .extensions_mut()
+            .remove::<ResponseUrl>()
+            .expect("ResponseUrl should be present");
+        assert_eq!(http_response.status(), 200);
+        assert_eq!(resp_url.0, url);
     }
 }

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -497,7 +497,7 @@ impl From<Response> for http::Response<Body> {
 #[cfg(test)]
 mod tests {
     use super::Response;
-    use crate::{response::ResponseUrl, ResponseBuilderExt};
+    use crate::{ResponseBuilderExt, ResponseExt};
     use http::response::Builder;
     use url::Url;
 
@@ -529,11 +529,8 @@ mod tests {
         assert_eq!(*response.url(), url);
 
         let mut http_response = http::Response::from(response);
-        let resp_url = http_response
-            .extensions_mut()
-            .remove::<ResponseUrl>()
-            .expect("ResponseUrl should be present");
+        let resp_url = http_response.url();
         assert_eq!(http_response.status(), 200);
-        assert_eq!(resp_url.0, url);
+        assert_eq!(resp_url, Some(url));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ mod response;
 
 pub use self::error::{Error, Result};
 pub use self::into_url::IntoUrl;
-pub use self::response::ResponseBuilderExt;
+pub use self::response::{ResponseBuilderExt, ResponseExt};
 
 /// Shortcut method to quickly make a `GET` request.
 ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,7 @@
 use url::Url;
 
+use crate::Body;
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ResponseUrl(pub Url);
 
@@ -12,9 +14,23 @@ pub trait ResponseBuilderExt {
     fn url(self, url: Url) -> Self;
 }
 
+/// Extension trait for http::Response objects
+///
+/// Provides methods to extract URL information from HTTP responses
+pub trait ResponseExt {
+    /// Extracts and removes the URL associated with this response
+    fn url(&mut self) -> Option<Url>;
+}
+
 impl ResponseBuilderExt for http::response::Builder {
     fn url(self, url: Url) -> Self {
         self.extension(ResponseUrl(url))
+    }
+}
+
+impl ResponseExt for http::Response<Body> {
+    fn url(&mut self) -> Option<Url> {
+        self.extensions_mut().remove::<ResponseUrl>().map(|r| r.0)
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -36,7 +36,7 @@ impl ResponseExt for http::Response<Body> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ResponseBuilderExt, ResponseExt, ResponseUrl};
+    use super::{ResponseBuilderExt, ResponseUrl};
     use http::response::Builder;
     use url::Url;
 
@@ -58,6 +58,7 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_response_ext() {
+        use super::ResponseExt;
         let url = Url::parse("http://example.com").unwrap();
         let response = http::Response::builder()
             .status(200)

--- a/src/response.rs
+++ b/src/response.rs
@@ -55,6 +55,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_response_ext() {
         let url = Url::parse("http://example.com").unwrap();


### PR DESCRIPTION
Add URL preservation in the From<Response> for http::Response<Body> conversion by
inserting the response URL as a ResponseUrl extension. This ensures that the original
URL information is not lost during the conversion and can be accessed later.

This change maintains consistency with the inverse conversion (From<http::Response>
for Response) which expects the ResponseUrl extension to be present.
