### PR TITLE
docs: fix method name in changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.12.23
 
 - Add `ClientBuilder::unix_socket(path)` option that will force all requests over that Unix Domain Socket.
-- Add `ClientBuilder::retries(policy)` and `reqwest::retry::Builder` to configure automatic retries.
+- Add `ClientBuilder::retry(policy)` and `reqwest::retry::Builder` to configure automatic retries.
 - Add `ClientBuilder::dns_resolver2()` with more ergonomic argument bounds, allowing more resolver implementations.
 - Add `http3_*` options to `blocking::ClientBuilder`.
 - Fix default TCP timeout values to enabled and faster.


### PR DESCRIPTION
Fixes a simple typo in the changelog which lead to a bit of confusion.