### PR TITLE
Adds pool_max_connections_per_host client builder config option

### DIFF
--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -437,6 +437,17 @@ impl ClientBuilder {
         self.with_inner(move |inner| inner.pool_max_idle_per_host(max))
     }
 
+    /// Sets the maximum total connections per host allowed.
+    ///
+    /// This includes active, idle, and connecting connections.
+    /// When the limit is reached, new requests will wait for a connection
+    /// to become available.
+    ///
+    /// Default is 0 (no limit).
+    pub fn pool_max_connections_per_host(self, max: usize) -> ClientBuilder {
+        self.with_inner(move |inner| inner.pool_max_connections_per_host(max))
+    }
+
     /// Send headers as title case instead of lowercase.
     pub fn http1_title_case_headers(self) -> ClientBuilder {
         self.with_inner(|inner| inner.http1_title_case_headers())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,27 @@
 //! [`Client`][client] and reuse it, taking advantage of keep-alive connection
 //! pooling.
 //!
+//! ## Connection Limiting
+//!
+//! You can limit the maximum number of connections per host using the
+//! [`pool_max_connections_per_host`][ClientBuilder::pool_max_connections_per_host] method.
+//! This is useful to prevent overwhelming servers with too many concurrent connections.
+//!
+//! ```rust
+//! # async fn run() -> Result<(), reqwest::Error> {
+//! let client = reqwest::Client::builder()
+//!     .pool_max_connections_per_host(5) // Max 5 connections per host
+//!     .build()?;
+//!
+//! // When making concurrent requests to the same host,
+//! // only 5 connections will be active at a time
+//! let response = client.get("https://httpbin.org/get").send().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Setting the value to `0` (the default) means no limit.
+//!
 //! ## Making POST requests (or setting request bodies)
 //!
 //! There are several ways you can set the body of a request. The basic one is

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -411,3 +411,15 @@ fn test_response_no_tls_info_for_http() {
     let body = res.text().unwrap();
     assert_eq!(b"Hello", body.as_bytes());
 }
+
+#[test]
+fn test_blocking_client_builder_with_connection_limit() {
+    // Test that the blocking client builder accepts the connection limit configuration
+    let client = reqwest::blocking::Client::builder()
+        .pool_max_connections_per_host(3)
+        .build()
+        .unwrap();
+
+    // Just verify the client was created successfully
+    assert!(client.get("http://httpbin.org/get").build().is_ok());
+}

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -528,3 +528,27 @@ async fn error_has_url() {
     let err = reqwest::get(u).await.unwrap_err();
     assert_eq!(err.url().map(AsRef::as_ref), Some(u), "{err:?}");
 }
+
+#[tokio::test]
+async fn test_client_builder_with_connection_limit() {
+    // Test that the client builder accepts the connection limit configuration
+    let client = reqwest::Client::builder()
+        .pool_max_connections_per_host(5)
+        .build()
+        .unwrap();
+
+    // Just verify the client was created successfully
+    assert!(client.get("http://httpbin.org/get").build().is_ok());
+}
+
+#[tokio::test]
+async fn test_client_builder_with_no_limit() {
+    // Test that the client builder accepts 0 (no limit)
+    let client = reqwest::Client::builder()
+        .pool_max_connections_per_host(0)
+        .build()
+        .unwrap();
+
+    // Just verify the client was created successfully
+    assert!(client.get("http://httpbin.org/get").build().is_ok());
+}


### PR DESCRIPTION
This PR adds support for limiting the maximum number of concurrent connections per host, which was requested in #2445

Configuration example:
```rust
let client = reqwest::Client::builder()
    .pool_max_connections_per_host(5) // Max 5 connections per host
    .build()?;
```

Additional requests above the limit will wait for connections to become available.

This was implemented as a ConnectionLimitLayer via Tower middleware.  Uses tokio::sync::Semaphore for async coordination and cleans up as connections are released. The default `pool_max_connections_per_host` value is `0`, which does not enforce a limit and falls back to the current behavior.