### PR TITLE
refactor(cookie): avoid duplicate cookie insertion

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2951,15 +2951,6 @@ impl Future for PendingRequest {
             },
         };
 
-        #[cfg(feature = "cookies")]
-        {
-            if let Some(ref cookie_store) = self.client.cookie_store {
-                let mut cookies = cookie::extract_response_cookie_headers(res.headers()).peekable();
-                if cookies.peek().is_some() {
-                    cookie_store.set_cookies(&mut cookies, &self.url);
-                }
-            }
-        }
         if let Some(url) = &res
             .extensions()
             .get::<tower_http::follow_redirect::RequestUri>()


### PR DESCRIPTION
Seems like a leftover issue from PR https://github.com/seanmonstar/reqwest/pull/2787.
The code inserts the cookie twice — it doesn’t break anything, but the extra insertion is unnecessary since it’s overwritten later.