### PR TITLE
Add default headers as request is built in `Client::request`

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2442,7 +2442,14 @@ impl Client {
     ///
     /// This method fails whenever the supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
-        let req = url.into_url().map(move |url| Request::new(method, url));
+        let req = url.into_url().map(move |url| {
+            let mut req = Request::new(method, url);
+            let headers = req.headers_mut();
+            for (key, value) in &self.inner.headers {
+                headers.insert(key, value.clone());
+            }
+            req
+        });
         RequestBuilder::new(self.clone(), req)
     }
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1289,7 +1289,14 @@ impl Client {
     ///
     /// This method fails whenever supplied `Url` cannot be parsed.
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
-        let req = url.into_url().map(move |url| Request::new(method, url));
+        let req = url.into_url().map(move |url| {
+            let mut req = Request::new(method, url);
+            let headers = req.headers_mut();
+            for (key, value) in &self.inner.headers {
+                headers.insert(key, value.clone());
+            }
+            req
+        });
         RequestBuilder::new(self.clone(), req)
     }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -4,7 +4,10 @@ mod support;
 
 use support::server;
 
-use http::header::{CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING};
+use http::{
+    header::{CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING},
+    HeaderMap, HeaderValue,
+};
 #[cfg(feature = "json")]
 use std::collections::HashMap;
 
@@ -527,4 +530,22 @@ async fn error_has_url() {
     let u = "http://does.not.exist.local/ever";
     let err = reqwest::get(u).await.unwrap_err();
     assert_eq!(err.url().map(AsRef::as_ref), Some(u), "{err:?}");
+}
+
+#[test]
+fn client_request_builder_includes_default_headers() {
+    let mut headers = HeaderMap::new();
+    headers.insert("X-MY-HEADER", HeaderValue::from_static("value"));
+    let client = Client::builder()
+        .default_headers(headers)
+        .build()
+        .expect("build client");
+    let req = client
+        .get("http://google.com")
+        .build()
+        .expect("build request");
+    assert!(req
+        .headers()
+        .get("X-MY-HEADER")
+        .is_some_and(|v| v == HeaderValue::from_static("value")));
 }


### PR DESCRIPTION
# Motivation 
As a few people have pointed out in issues it's a bit surprising that the default headers from a `Client` are not added to a `Request` built by `Client::request` until the request is sent. I personally would consider this a bug, not sure about everyone else though! :)

My particular use case is using `reqwest` both for sending HTTP requests but also in-memory only during testing (without actually executing the request). 

# Implementation

The implementation is based on piecing together a few comments throughout various issues.

I added the headers in during `Client::request`. If the duplication in the async/blocking client is annoying then I could add `Request::new_with_headers` or something? 

I've left the existing merge from `execute_request` for the code path where someone doesn't use a builder and just passes in a `Request` object directly to `Client::execute`.

I've added a test to `tests/client.rs` which asserts this new behaviour. The header values are copied from the docs.