### PR TITLE
Implement `retry::always` for a retry policy that applies to all domains

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -78,6 +78,13 @@ where
     scoped(move |req| host == req.uri().host().unwrap_or(""))
 }
 
+/// Create a retry policy that will retry any request.
+///
+/// This is useful for creating a client with a standard retry policy
+pub fn always() -> Builder {
+    scoped(|_| true).no_budget()
+}
+
 /// Create a retry policy that will never retry any request.
 ///
 /// This is useful for disabling the `Client`s default behavior of retrying


### PR DESCRIPTION
This is useful because in my case I want to have a global client for sharing the connection pool but I don't know the domains ahead of time for the retry policy as our application allows dynamic URLs. I know that I want all requests on this specific `reqwest::Client` to use the retry policy.

This functionality could theoretically be implemented in userspace in the future but currently the `Scope` trait is sealed making that impossible so this would need to exist in `reqwest` from my current understanding.

This is an opposite of the existing [`reqwest::never`](https://docs.rs/reqwest/latest/reqwest/retry/fn.never.html) method.