### PR TITLE
feat: add rustls-platform-verifier-fallback to allow verification with either method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ rustls-tls-manual-roots = ["rustls-tls-manual-roots-no-provider", "__rustls-ring
 rustls-tls-webpki-roots = ["rustls-tls-webpki-roots-no-provider", "__rustls-ring"]
 rustls-tls-native-roots = ["rustls-tls-native-roots-no-provider", "__rustls-ring"]
 
+rustls-platform-verifier-fallback = ["__rustls", "dep:rustls-platform-verifier"]
+
 blocking = ["dep:futures-channel", "futures-channel?/sink", "dep:futures-util", "futures-util?/io", "futures-util?/sink", "tokio/sync"]
 
 charset = ["dep:encoding_rs", "dep:mime"]
@@ -153,6 +155,7 @@ rustls = { version = "0.23.4", optional = true, default-features = false, featur
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 webpki-roots = { version = "1", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
+rustls-platform-verifier = { version = "0.6", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }


### PR DESCRIPTION
https://github.com/seanmonstar/reqwest/issues/2159

Add a `FallbackPlatformVerifier`: when the existing verifier fails, if the `rust-platform-verifier` passes, the verification is considered successful.

Please review.