### PR TITLE
fix: send `proxy-authorization` even with empty `password`

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -452,7 +452,8 @@ impl Proxy {
 }
 
 fn cache_maybe_has_http_auth(url: &Url, extra: &Option<HeaderValue>) -> bool {
-    url.scheme() == "http" && (url.username().len() > 0 || url.password().is_some() || extra.is_some())
+    url.scheme() == "http"
+        && (url.username().len() > 0 || url.password().is_some() || extra.is_some())
 }
 
 fn cache_maybe_has_http_custom_headers(url: &Url, extra: &Option<HeaderMap>) -> bool {
@@ -918,14 +919,10 @@ mod tests {
             .into_matcher();
         assert!(m.maybe_has_http_auth(), "http forwards");
 
-        let m = Proxy::all("http://:in@yo.local")
-            .unwrap()
-            .into_matcher();
+        let m = Proxy::all("http://:in@yo.local").unwrap().into_matcher();
         assert!(m.maybe_has_http_auth(), "http forwards with empty username");
 
-        let m = Proxy::all("http://letme:@yo.local")
-            .unwrap()
-            .into_matcher();
+        let m = Proxy::all("http://letme:@yo.local").unwrap().into_matcher();
         assert!(m.maybe_has_http_auth(), "http forwards with empty password");
     }
 


### PR DESCRIPTION
Reqwest should try authenticating with the proxy on URLs with only `username` or only `password`. E.g. `curl` works like this, see example below:

```bash
# ---------------------vvvv----- only username, no password
$ curl -vvvv -x http://user@127.0.0.1:44199 http://httpbin.org/get
*   Trying 127.0.0.1:44199...
* Connected to (nil) (127.0.0.1) port 44199 (#0)
#-----------------------------------vvvv---- curl understands the credentials correctly
* Proxy auth using Basic with user 'user'
> GET http://httpbin.org/get HTTP/1.1
> Host: httpbin.org
#----------------------vvvvvvvvvvvvvv base64-encoded "user"
> Proxy-Authorization: Basic dXNlcjo=
> User-Agent: curl/7.81.0
> Accept: */*
> Proxy-Connection: Keep-Alive
```

Prerequisite for https://github.com/apify/impit/issues/324