### PR TITLE
chore: update rustls-native-certs to 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ hyper-rustls = { version = "0.27.0", default-features = false, optional = true, 
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 webpki-roots = { version = "1", optional = true }
-rustls-native-certs = { version = "0.8.0", optional = true }
+rustls-native-certs = { version = "0.8.2", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }


### PR DESCRIPTION
rustls-pemfile is now unmaintained. The newer release of rustls-native-certs avoids rustls-pemfile.

Link: https://github.com/rustls/pemfile/issues/61
Link: https://rustsec.org/advisories/RUSTSEC-2025-0134