### PR TITLE
proxy: allow setting dynamic headers at intercept time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,7 @@ if_hyper! {
     pub use self::async_impl::{
         Body, Client, ClientBuilder, Request, RequestBuilder, Response, Upgraded,
     };
-    pub use self::proxy::{Proxy,NoProxy};
+    pub use self::proxy::{Proxy, ProxyExtra, NoProxy};
     #[cfg(feature = "__tls")]
     // Re-exports, to be removed in a future release
     pub use tls::{Certificate, Identity};


### PR DESCRIPTION
My main use case here is to set a short-lived `Proxy-Authorization` Bearer auth token and dynamic trace id on a proxy connection.

To support this, the callback in `Proxy::custom` needs to be able to return auth/headers alongside a `Url`.

I've packaged the auth/headers as `ProxyExtra` (formerly `Extra`), which is now part of the public API.

Preserving backwards compat needed some minor trait contortions. Technically there's a new `Sized` trait bound on `IntoProxy`, but this _should_ be OK, since I'm not sure how you would impl the trait for an unsized type anyway. Existing callers should not need to change anything.

We've been running a (hacky) version of this patch for ~2 years. I just finally got around to cleaning this up so it's suitable for upstreaming : )

