### PR TITLE
feat: consolidate TLS options with rustls-platform-verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
       - features
       - unstable
       - nightly
-      - msrv
+      - msrv_default
+      - msrv_oldest
       - android
       - wasm
       - docs
@@ -74,11 +75,9 @@ jobs:
           - windows / stable-i686-gnu
           - "feat.: default-tls disabled"
           - "feat.: rustls-tls"
-          - "feat.: rustls-tls-manual-roots"
-          - "feat.: rustls-tls-native-roots"
           - "feat.: rustls-tls-no-provider"
           - "feat.: native-tls"
-          - "feat.: default-tls and rustls-tls"
+          - "feat.: default-tls and native-tls"
           - "feat.: rustls-tls and rustls-tls-no-provider"
           - "feat.: cookies"
           - "feat.: blocking"
@@ -92,7 +91,7 @@ jobs:
           - "feat.: multipart"
           - "feat.: stream"
           - "feat.: socks/default-tls"
-          - "feat.: socks/rustls-tls"
+          - "feat.: socks/native-tls"
           - "feat.: hickory-dns"
 
         include:
@@ -134,18 +133,14 @@ jobs:
             features: "--no-default-features"
           - name: "feat.: rustls-tls"
             features: "--no-default-features --features rustls-tls"
-          - name: "feat.: rustls-tls-manual-roots"
-            features: "--no-default-features --features rustls-tls-manual-roots"
-          - name: "feat.: rustls-tls-native-roots"
-            features: "--no-default-features --features rustls-tls-native-roots"
           - name: "feat.: rustls-tls-no-provider"
             features: "--no-default-features --features rustls-tls-no-provider"
           - name: "feat.: native-tls"
             features: "--features native-tls"
           - name: "feat.: rustls-tls and rustls-tls-no-provider"
             features: "--features rustls-tls,rustls-tls-no-provider"
-          - name: "feat.: default-tls and rustls-tls"
-            features: "--features rustls-tls"
+          - name: "feat.: default-tls and native-tls"
+            features: "--features native-tls"
           - name: "feat.: cookies"
             features: "--features cookies"
           - name: "feat.: blocking"
@@ -172,8 +167,8 @@ jobs:
             features: "--features stream"
           - name: "feat.: socks/default-tls"
             features: "--features socks"
-          - name: "feat.: socks/rustls-tls"
-            features: "--features socks,rustls-tls"
+          - name: "feat.: socks/native-tls"
+            features: "--features socks,native-tls"
           - name: "feat.: hickory-dns"
             features: "--features hickory-dns"
 
@@ -241,7 +236,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: check --feature-powerset
-        run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip http3,__tls,__rustls,__rustls-ring,__rustls-aws-lc-rs,native-tls-vendored,trust-dns
+        run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip http3,__tls,__rustls,__rustls-aws-lc-rs,native-tls-vendored,trust-dns
         env:
           RUSTFLAGS: "-D dead_code -D unused_imports"
 
@@ -313,8 +308,35 @@ jobs:
           cargo check
           cargo check --all-features
 
-  msrv:
-    name: MSRV
+  msrv_default:
+    name: MSRV Default
+    needs: [style]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Resolve MSRV aware dependencies
+        run: cargo update
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
+
+      # required by rustls-platform-verifier
+      - name: Install rust (1.71.0)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check
+        run: cargo check
+
+  msrv_oldest:
+    name: MSRV Oldest
     needs: [style]
 
     runs-on: ubuntu-latest
@@ -341,7 +363,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check
-        run: cargo check
+        run: cargo check --no-default-features --features="http2,charset,native-tls"
 
   android:
     name: Android

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,20 +44,12 @@ default-tls = ["rustls-tls"]
 
 http2 = ["h2", "hyper/http2", "hyper-util/http2", "hyper-rustls?/http2"]
 
+rustls-tls = ["rustls-tls-no-provider", "__rustls-aws-lc-rs"]
+rustls-tls-no-provider = ["dep:rustls-platform-verifier", "__rustls"]
+
 native-tls = ["dep:hyper-tls", "dep:native-tls-crate", "__tls", "dep:tokio-native-tls"]
 native-tls-alpn = ["native-tls", "native-tls-crate?/alpn", "hyper-tls?/alpn"]
 native-tls-vendored = ["native-tls", "native-tls-crate?/vendored"]
-
-rustls-tls = ["rustls-tls-webpki-roots"]
-rustls-tls-no-provider = ["rustls-tls-manual-roots-no-provider"]
-
-rustls-tls-manual-roots-no-provider = ["__rustls"]
-rustls-tls-webpki-roots-no-provider = ["dep:webpki-roots", "hyper-rustls?/webpki-tokio", "__rustls"]
-rustls-tls-native-roots-no-provider = ["dep:rustls-native-certs", "hyper-rustls?/native-tokio", "__rustls"]
-
-rustls-tls-manual-roots = ["rustls-tls-manual-roots-no-provider", "__rustls-aws-lc-rs"]
-rustls-tls-webpki-roots = ["rustls-tls-webpki-roots-no-provider", "__rustls-aws-lc-rs"]
-rustls-tls-native-roots = ["rustls-tls-native-roots-no-provider", "__rustls-aws-lc-rs"]
 
 blocking = ["dep:futures-channel", "futures-channel?/sink", "dep:futures-util", "futures-util?/io", "futures-util?/sink", "tokio/sync"]
 
@@ -94,7 +86,7 @@ system-proxy = ["hyper-util/client-proxy-system"]
 macos-system-configuration = ["system-proxy"]
 
 # Experimental HTTP/3 client.
-http3 = ["rustls-tls-manual-roots", "dep:h3", "dep:h3-quinn", "dep:quinn", "tokio/macros"]
+http3 = ["rustls-tls", "dep:h3", "dep:h3-quinn", "dep:quinn", "tokio/macros"]
 
 
 # Internal (PRIVATE!) features used to aid testing.
@@ -106,7 +98,6 @@ __tls = ["dep:rustls-pki-types", "tokio/io-util"]
 # Enables common rustls code.
 # Equivalent to rustls-tls-manual-roots but shorter :)
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls"]
-__rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "quinn?/ring"]
 __rustls-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/aws-lc-rs"]
 
 [dependencies]
@@ -156,6 +147,7 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 hyper-rustls = { version = "0.27.0", default-features = false, optional = true, features = ["http1", "tls12"] }
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
+rustls-platform-verifier = { version = "0.6", optional = true }
 webpki-roots = { version = "1", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -676,7 +676,7 @@ impl TryFrom<Request> for HttpRequest<Body> {
 
 #[cfg(test)]
 mod tests {
-    #![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+    #![cfg(not(feature = "rustls-tls-no-provider"))]
 
     use super::*;
     #[cfg(feature = "query")]

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -752,7 +752,7 @@ impl ClientBuilder {
 
     // TLS options
 
-    /// Add a custom root certificate.
+    /// Add custom root certificates.
     ///
     /// This allows connecting to a server that has a self-signed
     /// certificate for example. This **does not** replace the existing
@@ -772,7 +772,7 @@ impl ClientBuilder {
     ///
     /// // get a client builder
     /// let client = reqwest::blocking::Client::builder()
-    ///     .add_root_certificate(cert)
+    ///     .tls_certs_merge([cert])
     ///     .build()?;
     /// # drop(client);
     /// # Ok(())
@@ -792,40 +792,17 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
-    pub fn add_root_certificate(self, cert: Certificate) -> ClientBuilder {
-        self.with_inner(move |inner| inner.add_root_certificate(cert))
+    pub fn tls_certs_merge(self, certs: impl IntoIterator<Item = Certificate>) -> ClientBuilder {
+        self.with_inner(move |inner| inner.tls_certs_merge(certs))
     }
 
-    /// Add a certificate revocation list.
+    /// Use only the provided certificate roots.
     ///
+    /// This can be used to connect to a server that has a self-signed
+    /// certificate for example.
     ///
-    /// # Optional
-    ///
-    /// This requires the `rustls-tls(-...)` Cargo feature enabled.
-    #[cfg(feature = "__rustls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
-    pub fn add_crl(self, crl: CertificateRevocationList) -> ClientBuilder {
-        self.with_inner(move |inner| inner.add_crl(crl))
-    }
-
-    /// Add multiple certificate revocation lists.
-    ///
-    ///
-    /// # Optional
-    ///
-    /// This requires the `rustls-tls(-...)` Cargo feature enabled.
-    #[cfg(feature = "__rustls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
-    pub fn add_crls(
-        self,
-        crls: impl IntoIterator<Item = CertificateRevocationList>,
-    ) -> ClientBuilder {
-        self.with_inner(move |inner| inner.add_crls(crls))
-    }
-
-    /// Controls the use of built-in system certificates during certificate validation.
-    ///
-    /// Defaults to `true` -- built-in system certs will be used.
+    /// This option disables any native or built-in roots, and **only** uses
+    /// the roots provided to this method.
     ///
     /// # Optional
     ///
@@ -840,26 +817,53 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
-    pub fn tls_built_in_root_certs(self, tls_built_in_root_certs: bool) -> ClientBuilder {
-        self.with_inner(move |inner| inner.tls_built_in_root_certs(tls_built_in_root_certs))
+    pub fn tls_certs_only(self, certs: impl IntoIterator<Item = Certificate>) -> ClientBuilder {
+        self.with_inner(move |inner| inner.tls_certs_only(certs))
     }
 
-    /// Sets whether to load webpki root certs with rustls.
-    ///
-    /// If the feature is enabled, this value is `true` by default.
-    #[cfg(feature = "rustls-tls-webpki-roots-no-provider")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls-webpki-roots-no-provider")))]
-    pub fn tls_built_in_webpki_certs(self, enabled: bool) -> ClientBuilder {
-        self.with_inner(move |inner| inner.tls_built_in_webpki_certs(enabled))
+    /// Deprecated: use [`ClientBuilder::tls_certs_merge()`] or [`ClientBuilder::tls_certs_only()`] instead.
+    #[cfg(feature = "__tls")]
+    pub fn add_root_certificate(self, cert: Certificate) -> ClientBuilder {
+        self.with_inner(move |inner| inner.add_root_certificate(cert))
     }
 
-    /// Sets whether to load native root certs with rustls.
+    /// Add multiple certificate revocation lists.
     ///
-    /// If the feature is enabled, this value is `true` by default.
-    #[cfg(feature = "rustls-tls-native-roots-no-provider")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls-native-roots-no-provider")))]
-    pub fn tls_built_in_native_certs(self, enabled: bool) -> ClientBuilder {
-        self.with_inner(move |inner| inner.tls_built_in_native_certs(enabled))
+    /// # Errors
+    ///
+    /// This only works if also using only provided root certificates. This
+    /// cannot work with the native verifier.
+    ///
+    /// If CRLs are added but `tls_certs_only()` is not called, the builder
+    /// will return an error.
+    ///
+    /// # Optional
+    ///
+    /// This requires the `rustls-tls(-...)` Cargo feature enabled.
+    #[cfg(feature = "__rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    pub fn tls_crls_only(
+        self,
+        crls: impl IntoIterator<Item = CertificateRevocationList>,
+    ) -> ClientBuilder {
+        self.with_inner(move |inner| inner.tls_crls_only(crls))
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_crls_only()`] instead.
+    #[cfg(feature = "__rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    pub fn add_crl(self, crl: CertificateRevocationList) -> ClientBuilder {
+        self.with_inner(move |inner| inner.add_crl(crl))
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_crls_only()`] instead.
+    #[cfg(feature = "__rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    pub fn add_crls(
+        self,
+        crls: impl IntoIterator<Item = CertificateRevocationList>,
+    ) -> ClientBuilder {
+        self.with_inner(move |inner| inner.add_crls(crls))
     }
 
     /// Sets the identity to be used for client certificate authentication.
@@ -885,6 +889,11 @@ impl ClientBuilder {
     /// site will be trusted for use from any other. This introduces a
     /// significant vulnerability to man-in-the-middle attacks.
     ///
+    /// # Errors
+    ///
+    /// Depending on the TLS backend and verifier, this might not work with
+    /// native certificates, only those added with [`ClientBuilder::tls_certs_only()`].
+    ///
     /// # Optional
     ///
     /// This requires the optional `default-tls`, `native-tls`, or `rustls-tls(-...)`
@@ -898,6 +907,15 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
+    pub fn tls_danger_accept_invalid_hostnames(
+        self,
+        accept_invalid_hostname: bool,
+    ) -> ClientBuilder {
+        self.with_inner(|inner| inner.tls_danger_accept_invalid_hostnames(accept_invalid_hostname))
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_danger_accept_invalid_hostnames()`] instead.
+    #[cfg(feature = "__tls")]
     pub fn danger_accept_invalid_hostnames(self, accept_invalid_hostname: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.danger_accept_invalid_hostnames(accept_invalid_hostname))
     }
@@ -922,6 +940,12 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
+    pub fn tls_danger_accept_invalid_certs(self, accept_invalid_certs: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.tls_danger_accept_invalid_certs(accept_invalid_certs))
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_danger_accept_invalid_certs()`] instead.
+    #[cfg(feature = "__tls")]
     pub fn danger_accept_invalid_certs(self, accept_invalid_certs: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.danger_accept_invalid_certs(accept_invalid_certs))
     }
@@ -949,7 +973,7 @@ impl ClientBuilder {
     /// # Errors
     ///
     /// A value of `tls::Version::TLS_1_3` will cause an error with the
-    /// `native-tls`/`default-tls` backend. This does not mean the version
+    /// `native-tls` backend. This does not mean the version
     /// isn't supported, just that it can't be set as a minimum due to
     /// technical limitations.
     ///
@@ -966,6 +990,12 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
+    pub fn tls_version_min(self, version: tls::Version) -> ClientBuilder {
+        self.with_inner(|inner| inner.tls_version_min(version))
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_version_min()`] instead.
+    #[cfg(feature = "__tls")]
     pub fn min_tls_version(self, version: tls::Version) -> ClientBuilder {
         self.with_inner(|inner| inner.min_tls_version(version))
     }
@@ -977,7 +1007,7 @@ impl ClientBuilder {
     /// # Errors
     ///
     /// A value of `tls::Version::TLS_1_3` will cause an error with the
-    /// `native-tls`/`default-tls` backend. This does not mean the version
+    /// `native-tls` backend. This does not mean the version
     /// isn't supported, just that it can't be set as a maximum due to
     /// technical limitations.
     ///
@@ -994,6 +1024,12 @@ impl ClientBuilder {
             feature = "rustls-tls"
         )))
     )]
+    pub fn tls_version_max(self, version: tls::Version) -> ClientBuilder {
+        self.with_inner(|inner| inner.tls_version_max(version))
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_version_max()`] instead.
+    #[cfg(feature = "__tls")]
     pub fn max_tls_version(self, version: tls::Version) -> ClientBuilder {
         self.with_inner(|inner| inner.max_tls_version(version))
     }
@@ -1008,6 +1044,12 @@ impl ClientBuilder {
     /// This requires the optional `native-tls` feature to be enabled.
     #[cfg(feature = "native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
+    pub fn tls_backend_native(self) -> ClientBuilder {
+        self.with_inner(move |inner| inner.tls_backend_native())
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_backend_native()`] instead.
+    #[cfg(feature = "native-tls")]
     pub fn use_native_tls(self) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_native_tls())
     }
@@ -1020,6 +1062,13 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// This requires the optional `rustls-tls(-...)` feature to be enabled.
+    #[cfg(feature = "__rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    pub fn tls_backend_rustls(self) -> ClientBuilder {
+        self.with_inner(move |inner| inner.tls_backend_rustls())
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_backend_rustls()`] instead.
     #[cfg(feature = "__rustls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     pub fn use_rustls_tls(self) -> ClientBuilder {
@@ -1065,6 +1114,12 @@ impl ClientBuilder {
     /// `rustls-tls(-...)` to be enabled.
     #[cfg(any(feature = "native-tls", feature = "__rustls",))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
+    pub fn tls_backend_preconfigured(self, tls: impl Any) -> ClientBuilder {
+        self.with_inner(move |inner| inner.tls_backend_preconfigured(tls))
+    }
+
+    /// Deprecated: use [`ClientBuilder::tls_backend_preconfigured()`] instead.
+    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
     pub fn use_preconfigured_tls(self, tls: impl Any) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,13 +196,6 @@
 //! - **native-tls-vendored**: Enables the `vendored` feature of `native-tls`.
 //! - **native-tls-alpn**: Enables the `alpn` feature of `native-tls`.
 //! - **rustls-tls**: Enables TLS functionality provided by `rustls`.
-//!   Equivalent to `rustls-tls-webpki-roots`.
-//! - **rustls-tls-manual-roots**: Enables TLS functionality provided by `rustls`,
-//!   without setting any root certificates. Roots have to be specified manually.
-//! - **rustls-tls-webpki-roots**: Enables TLS functionality provided by `rustls`,
-//!   while using root certificates from the `webpki-roots` crate.
-//! - **rustls-tls-native-roots**: Enables TLS functionality provided by `rustls`,
-//!   while using root certificates from the `rustls-native-certs` crate.
 //! - **blocking**: Provides the [blocking][] client API.
 //! - **charset** *(enabled by default)*: Improved support for decoding text.
 //! - **cookies**: Provides cookie session support.

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -1,32 +1,10 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 
-#[cfg(all(feature = "__tls", not(feature = "rustls-tls-manual-roots")))]
+#[cfg(all(feature = "__tls"))]
 #[tokio::test]
 async fn test_badssl_modern() {
     let text = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .unwrap()
-        .get("https://mozilla-modern.badssl.com/")
-        .send()
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
-
-    assert!(text.contains("<title>mozilla-modern.badssl.com</title>"));
-}
-
-#[cfg(any(
-    feature = "rustls-tls-webpki-roots-no-provider",
-    feature = "rustls-tls-native-roots-no-provider"
-))]
-#[tokio::test]
-async fn test_rustls_badssl_modern() {
-    let text = reqwest::Client::builder()
-        .use_rustls_tls()
         .no_proxy()
         .build()
         .unwrap()
@@ -45,7 +23,7 @@ async fn test_rustls_badssl_modern() {
 #[tokio::test]
 async fn test_badssl_self_signed() {
     let text = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
+        .tls_danger_accept_invalid_certs(true)
         .no_proxy()
         .build()
         .unwrap()
@@ -64,7 +42,7 @@ async fn test_badssl_self_signed() {
 #[tokio::test]
 async fn test_badssl_no_built_in_roots() {
     let result = reqwest::Client::builder()
-        .tls_built_in_root_certs(false)
+        .tls_certs_only([])
         .no_proxy()
         .build()
         .unwrap()
@@ -79,7 +57,7 @@ async fn test_badssl_no_built_in_roots() {
 #[tokio::test]
 async fn test_badssl_wrong_host() {
     let text = reqwest::Client::builder()
-        .danger_accept_invalid_hostnames(true)
+        .tls_danger_accept_invalid_hostnames(true)
         .no_proxy()
         .build()
         .unwrap()
@@ -94,7 +72,7 @@ async fn test_badssl_wrong_host() {
     assert!(text.contains("<title>wrong.host.badssl.com</title>"));
 
     let result = reqwest::Client::builder()
-        .danger_accept_invalid_hostnames(true)
+        .tls_danger_accept_invalid_hostnames(true)
         .build()
         .unwrap()
         .get("https://self-signed.badssl.com/")

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 mod support;
 use support::server;
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 mod support;
 
 use support::server;
@@ -375,8 +375,8 @@ async fn http2_upgrade() {
 
     let url = format!("https://localhost:{}", server.addr().port());
     let res = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .use_rustls_tls()
+        .tls_danger_accept_invalid_certs(true)
+        .tls_backend_rustls()
         .build()
         .expect("client builder")
         .get(&url)
@@ -443,7 +443,7 @@ fn update_json_content_type_if_set_manually() {
     assert_eq!("application/json", req.headers().get(CONTENT_TYPE).unwrap());
 }
 
-#[cfg(all(feature = "__tls", not(feature = "rustls-tls-manual-roots")))]
+#[cfg(all(feature = "__tls", not(feature = "rustls-tls-no-provider")))]
 #[tokio::test]
 async fn test_tls_info() {
     let resp = reqwest::Client::builder()

--- a/tests/connector_layers.rs
+++ b/tests/connector_layers.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 mod support;
 
 use std::time::Duration;

--- a/tests/not_tcp.rs
+++ b/tests/not_tcp.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 #![cfg(unix)]
 
 mod support;

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 mod support;
 use support::server;
 

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 mod support;
 use http_body_util::BodyExt;
 use reqwest::Body;
@@ -364,8 +364,8 @@ async fn test_redirect_https_only_enforced_gh1312() {
     let url = format!("https://{}/yikes", server.addr());
 
     let res = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .use_rustls_tls()
+        .tls_danger_accept_invalid_certs(true)
+        .tls_backend_rustls()
         .https_only(true)
         .build()
         .expect("client builder")

--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 mod support;
 use support::server;
 

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 mod support;
 use support::server;
 

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-tls-manual-roots-no-provider"))]
+#![cfg(not(feature = "rustls-tls-no-provider"))]
 mod support;
 use support::server;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};


### PR DESCRIPTION
This includes two logical change groups, done together because the intermediate step is not really useful.

1. This makes rustls-platform-verifier the default verifier, and removes the ability to use rustls with webpki or native roots directly.
2. This soft-deprecates many of the TLS-related builder methods, providing better names that are clearer and autocomplete better.

This greatly simplifies the configuration matrix of what could be enabled, but also means the removal of some parts that some people may have been using. The consolidated API should still _allow_ users to do these things.

For example, instead of adding webpki-roots with a feature flag, you should use the webpki-roots crate yourself, and pass them into `tls_certs_only(certs)`.

Closes #2885 