### PR TITLE
chore: Use http_body_util::BodyDataStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ mime_guess = { version = "2.0", default-features = false, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 encoding_rs = { version = "0.8", optional = true }
 http-body = "1"
-http-body-util = "0.1"
+http-body-util = "0.1.2"
 hyper = { version = "1.1", features = ["http1", "client"] }
 hyper-util = { version = "0.1.12", features = ["http1", "client", "client-legacy", "client-proxy", "tokio"] }
 h2 = { version = "0.4", optional = true }

--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -46,10 +46,6 @@ pin_project! {
     }
 }
 
-/// Converts any `impl Body` into a `impl Stream` of just its DATA frames.
-#[cfg(any(feature = "stream", feature = "multipart", feature = "blocking"))]
-pub(crate) struct DataStream<B>(pub(crate) B);
-
 impl Body {
     /// Returns a reference to the internal data of the `Body`.
     ///
@@ -159,11 +155,6 @@ impl Body {
             Inner::Reusable(ref chunk) => Some(Body::reusable(chunk.clone())),
             Inner::Streaming { .. } => None,
         }
-    }
-
-    #[cfg(any(feature = "multipart", feature = "blocking"))]
-    pub(crate) fn into_stream(self) -> DataStream<Body> {
-        DataStream(self)
     }
 
     #[cfg(feature = "multipart")]
@@ -419,33 +410,6 @@ where
     E: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     err.into()
-}
-
-// ===== impl DataStream =====
-
-#[cfg(any(feature = "stream", feature = "multipart", feature = "blocking",))]
-impl<B> futures_core::Stream for DataStream<B>
-where
-    B: HttpBody<Data = Bytes> + Unpin,
-{
-    type Item = Result<Bytes, B::Error>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        loop {
-            return match ready!(Pin::new(&mut self.0).poll_frame(cx)) {
-                Some(Ok(frame)) => {
-                    // skip non-data frames
-                    if let Ok(buf) = frame.into_data() {
-                        Poll::Ready(Some(Ok(buf)))
-                    } else {
-                        continue;
-                    }
-                }
-                Some(Err(err)) => Poll::Ready(Some(Err(err))),
-                None => Poll::Ready(None),
-            };
-        }
-    }
 }
 
 // ===== impl IntoBytesBody =====

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -16,6 +16,7 @@ use tokio::fs::File;
 
 use futures_core::Stream;
 use futures_util::{future, stream, StreamExt};
+use http_body_util::BodyExt;
 
 use super::Body;
 use crate::header::HeaderMap;
@@ -201,7 +202,7 @@ impl Form {
         // then append form data followed by terminating CRLF
         boundary
             .chain(header)
-            .chain(part.value.into_stream())
+            .chain(part.value.into_data_stream())
             .chain(stream::once(future::ready(Ok("\r\n".into()))))
     }
 
@@ -614,7 +615,7 @@ mod tests {
             .enable_all()
             .build()
             .expect("new rt");
-        let body = form.stream().into_stream();
+        let body = form.stream().into_data_stream();
         let s = body.map_ok(|try_c| try_c.to_vec()).try_concat();
 
         let out = rt.block_on(s);
@@ -667,7 +668,7 @@ mod tests {
             .enable_all()
             .build()
             .expect("new rt");
-        let body = form.stream().into_stream();
+        let body = form.stream().into_data_stream();
         let s = body.map(|try_c| try_c.map(|r| r.to_vec())).try_concat();
 
         let out = rt.block_on(s).unwrap();
@@ -699,7 +700,7 @@ mod tests {
             .enable_all()
             .build()
             .expect("new rt");
-        let body = form.stream().into_stream();
+        let body = form.stream().into_data_stream();
         let s = body.map(|try_c| try_c.map(|r| r.to_vec())).try_concat();
 
         let out = rt.block_on(s).unwrap();

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -354,7 +354,7 @@ impl Response {
     #[cfg(feature = "stream")]
     #[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
     pub fn bytes_stream(self) -> impl futures_core::Stream<Item = crate::Result<Bytes>> {
-        super::body::DataStream(self.res.into_body().map_err(crate::error::decode))
+        http_body_util::BodyDataStream::new(self.res.into_body().map_err(crate::error::decode))
     }
 
     // util methods

--- a/src/blocking/response.rs
+++ b/src/blocking/response.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures_util::TryStreamExt;
 use http;
+use http_body_util::BodyExt;
 use hyper::header::HeaderMap;
 #[cfg(feature = "json")]
 use serde::de::DeserializeOwned;
@@ -422,7 +423,7 @@ impl Response {
 
             self.body = Some(Box::pin(
                 async_impl::body::Body::wrap(body)
-                    .into_stream()
+                    .into_data_stream()
                     .map_err(crate::error::Error::into_io)
                     .into_async_read(),
             ));


### PR DESCRIPTION
Uses the upstream `BodyDataStream` which was introduced at `http-body-util` 0.1.2.