### PR TITLE
chore: Disable unused tokio-util codec feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,8 +158,8 @@ rustls-native-certs = { version = "0.8.0", optional = true }
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }
 cookie_store = { version = "0.22.0", optional = true }
 
-## compression
-tokio-util = { version = "0.7.9", default-features = false, features = ["codec", "io"], optional = true }
+## stream
+tokio-util = { version = "0.7.9", default-features = false, features = ["io"], optional = true }
 
 ## hickory-dns
 hickory-resolver = { version = "0.25", optional = true, features = ["tokio"] }


### PR DESCRIPTION
Disables the unused `tokio-util`'s codec feature.