### PR TITLE
feat: make Rustls the default TLS provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
 
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
 
+    env:
+      AWS_LC_SYS_PREBUILT_NASM: ${{ matrix.aws_lc_sys_prebuilt_nasm || 0 }}
+
     # The build matrix does not yet support 'allow failures' at job level.
     # See `jobs.nightly` for the active nightly job definition.
     strategy:
@@ -105,10 +108,12 @@ jobs:
             os: windows-latest
             target: x86_64-pc-windows-msvc
             features: "--features blocking,gzip,brotli,zstd,deflate,query,form,json,multipart,stream"
+            aws_lc_sys_prebuilt_nasm: 1
           - name: windows / stable-i686-msvc
             os: windows-latest
             target: i686-pc-windows-msvc
             features: "--features blocking,gzip,brotli,zstd,deflate,query,form,json,multipart,stream"
+            aws_lc_sys_prebuilt_nasm: 1
           - name: windows / stable-x86_64-gnu
             os: windows-latest
             rust: stable-x86_64-pc-windows-gnu
@@ -116,11 +121,12 @@ jobs:
             features: "--features blocking,gzip,brotli,zstd,deflate,query,form,json,multipart,stream"
             package_name: mingw-w64-x86_64-gcc
             mingw64_path: "C:\\msys64\\mingw64\\bin"
+            aws_lc_sys_prebuilt_nasm: 1
           - name: windows / stable-i686-gnu
             os: windows-latest
             rust: stable-i686-pc-windows-gnu
             target: i686-pc-windows-gnu
-            features: "--features blocking,gzip,brotli,zstd,deflate,query,form,json,multipart,stream"
+            features: "--no-default-features --features blocking,gzip,brotli,zstd,deflate,query,form,json,multipart,stream,native-tls,http2"
             package_name: mingw-w64-i686-gcc
             mingw64_path: "C:\\msys64\\mingw32\\bin"
 
@@ -188,6 +194,16 @@ jobs:
         if: matrix.mingw64_path
         shell: bash
 
+      - name: Install x86_64 Clang & NASM
+        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
+        run: pacman.exe -Sy --noconfirm mingw-w64-x86_64-clang mingw-w64-x86_64-nasm
+        shell: bash
+
+      - name: Add libclang to the environment for windows x86_64-gnu
+        run: echo "LIBCLANG_PATH=C:\msys64\mingw64\bin" >> $env:GITHUB_ENV
+        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
+        shell: bash
+
       - name: Update gcc
         if: matrix.package_name
         run: pacman.exe -Sy --noconfirm ${{ matrix.package_name }}
@@ -225,7 +241,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: check --feature-powerset
-        run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip http3,__tls,__rustls,__rustls-ring,native-tls-vendored,trust-dns
+        run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip http3,__tls,__rustls,__rustls-ring,__rustls-aws-lc-rs,native-tls-vendored,trust-dns
         env:
           RUSTFLAGS: "-D dead_code -D unused_imports"
 
@@ -290,6 +306,8 @@ jobs:
           cargo clean
           cargo update -Z minimal-versions
           cargo update -p proc-macro2 --precise 1.0.87
+          cargo update -p aws-lc-rs --precise 1.13.1
+          cargo update -p aws-lc-sys --precise 0.29.0
           cargo update -p openssl-sys
           cargo update -p openssl
           cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,11 @@ features = [
 [features]
 default = ["default-tls", "charset", "http2", "system-proxy"]
 
-# Note: this doesn't enable the 'native-tls' feature, which adds specific
-# functionality for it.
-default-tls = ["dep:hyper-tls", "dep:native-tls-crate", "__tls", "dep:tokio-native-tls"]
+default-tls = ["rustls-tls"]
 
 http2 = ["h2", "hyper/http2", "hyper-util/http2", "hyper-rustls?/http2"]
 
-# Enables native-tls specific functionality not available by default.
-native-tls = ["default-tls"]
+native-tls = ["dep:hyper-tls", "dep:native-tls-crate", "__tls", "dep:tokio-native-tls"]
 native-tls-alpn = ["native-tls", "native-tls-crate?/alpn", "hyper-tls?/alpn"]
 native-tls-vendored = ["native-tls", "native-tls-crate?/vendored"]
 
@@ -58,9 +55,9 @@ rustls-tls-manual-roots-no-provider = ["__rustls"]
 rustls-tls-webpki-roots-no-provider = ["dep:webpki-roots", "hyper-rustls?/webpki-tokio", "__rustls"]
 rustls-tls-native-roots-no-provider = ["dep:rustls-native-certs", "hyper-rustls?/native-tokio", "__rustls"]
 
-rustls-tls-manual-roots = ["rustls-tls-manual-roots-no-provider", "__rustls-ring"]
-rustls-tls-webpki-roots = ["rustls-tls-webpki-roots-no-provider", "__rustls-ring"]
-rustls-tls-native-roots = ["rustls-tls-native-roots-no-provider", "__rustls-ring"]
+rustls-tls-manual-roots = ["rustls-tls-manual-roots-no-provider", "__rustls-aws-lc-rs"]
+rustls-tls-webpki-roots = ["rustls-tls-webpki-roots-no-provider", "__rustls-aws-lc-rs"]
+rustls-tls-native-roots = ["rustls-tls-native-roots-no-provider", "__rustls-aws-lc-rs"]
 
 blocking = ["dep:futures-channel", "futures-channel?/sink", "dep:futures-util", "futures-util?/io", "futures-util?/sink", "tokio/sync"]
 
@@ -110,6 +107,7 @@ __tls = ["dep:rustls-pki-types", "tokio/io-util"]
 # Equivalent to rustls-tls-manual-roots but shorter :)
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls"]
 __rustls-ring = ["hyper-rustls?/ring", "tokio-rustls?/ring", "rustls?/ring", "quinn?/ring"]
+__rustls-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/aws-lc-rs"]
 
 [dependencies]
 base64 = "0.22"
@@ -149,12 +147,12 @@ pin-project-lite = "0.2.11"
 rustls-pki-types = { version = "1.9.0", features = ["std"], optional = true }
 mime = { version = "0.3.16", optional = true }
 
-## default-tls
+# native-tls
 hyper-tls = { version = "0.6", optional = true }
 native-tls-crate = { version = "0.2.10", optional = true, package = "native-tls" }
 tokio-native-tls = { version = "0.3.0", optional = true }
 
-# rustls-tls
+# default-tls and rustls-tls
 hyper-rustls = { version = "0.27.0", default-features = false, optional = true, features = ["http1", "tls12"] }
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -7,7 +7,7 @@ use hyper::rt::{Read, ReadBufCursor, Write};
 use hyper_util::client::legacy::connect::{Connected, Connection};
 #[cfg(any(feature = "socks", feature = "__tls", unix, target_os = "windows"))]
 use hyper_util::rt::TokioIo;
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 use native_tls_crate::{TlsConnector, TlsConnectorBuilder};
 use pin_project_lite::pin_project;
 use tower::util::{BoxCloneSyncServiceLayer, MapRequestLayer};
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 use self::native_tls_conn::NativeTlsConn;
 #[cfg(feature = "__rustls")]
 use self::rustls_tls_conn::RustlsTlsConn;
@@ -222,8 +222,8 @@ where {
         }
     }
 
-    #[cfg(feature = "default-tls")]
-    pub(crate) fn new_default_tls<T>(
+    #[cfg(feature = "native-tls")]
+    pub(crate) fn new_native_tls<T>(
         http: HttpConnector,
         tls: TlsConnectorBuilder,
         proxies: Arc<Vec<ProxyMatcher>>,
@@ -249,7 +249,7 @@ where {
         T: Into<Option<IpAddr>>,
     {
         let tls = tls.build().map_err(crate::error::builder)?;
-        Ok(Self::from_built_default_tls(
+        Ok(Self::from_built_native_tls(
             http,
             tls,
             proxies,
@@ -273,8 +273,8 @@ where {
         ))
     }
 
-    #[cfg(feature = "default-tls")]
-    pub(crate) fn from_built_default_tls<T>(
+    #[cfg(feature = "native-tls")]
+    pub(crate) fn from_built_native_tls<T>(
         mut http: HttpConnector,
         tls: TlsConnector,
         proxies: Arc<Vec<ProxyMatcher>>,
@@ -319,7 +319,7 @@ where {
         http.enforce_http(false);
 
         ConnectorBuilder {
-            inner: Inner::DefaultTls(http, tls),
+            inner: Inner::NativeTls(http, tls),
             proxies,
             verbose: verbose::OFF,
             nodelay,
@@ -420,8 +420,8 @@ where {
 
     pub(crate) fn set_keepalive(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(http, _tls) => http.set_keepalive(dur),
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(http, _tls) => http.set_keepalive(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive(dur),
             #[cfg(not(feature = "__tls"))]
@@ -431,8 +431,8 @@ where {
 
     pub(crate) fn set_keepalive_interval(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(http, _tls) => http.set_keepalive_interval(dur),
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(http, _tls) => http.set_keepalive_interval(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive_interval(dur),
             #[cfg(not(feature = "__tls"))]
@@ -442,8 +442,8 @@ where {
 
     pub(crate) fn set_keepalive_retries(&mut self, retries: Option<u32>) {
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(http, _tls) => http.set_keepalive_retries(retries),
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(http, _tls) => http.set_keepalive_retries(retries),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive_retries(retries),
             #[cfg(not(feature = "__tls"))]
@@ -459,8 +459,8 @@ where {
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     pub(crate) fn set_tcp_user_timeout(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(http, _tls) => http.set_tcp_user_timeout(dur),
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(http, _tls) => http.set_tcp_user_timeout(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_tcp_user_timeout(dur),
             #[cfg(not(feature = "__tls"))]
@@ -509,9 +509,9 @@ pub(crate) struct ConnectorService {
 enum Inner {
     #[cfg(not(feature = "__tls"))]
     Http(HttpConnector),
-    #[cfg(feature = "default-tls")]
-    DefaultTls(HttpConnector, TlsConnector),
-    #[cfg(feature = "__rustls")]
+    #[cfg(feature = "native-tls")]
+    NativeTls(HttpConnector, TlsConnector),
+    #[cfg(any(feature = "__rustls"))]
     RustlsTls {
         http: HttpConnector,
         tls: Arc<rustls::ClientConfig>,
@@ -523,8 +523,8 @@ impl Inner {
     #[cfg(feature = "socks")]
     fn get_http_connector(&mut self) -> &mut crate::connect::HttpConnector {
         match self {
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(http, _) => http,
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(http, _) => http,
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http,
             #[cfg(not(feature = "__tls"))]
@@ -545,8 +545,8 @@ impl ConnectorService {
         };
 
         match &mut self.inner {
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(http, tls) => {
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(http, tls) => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     let host = dst.host().ok_or("no host in url")?.to_string();
                     let conn = socks::connect(proxy, dst, dns, &self.resolver, http).await?;
@@ -621,8 +621,8 @@ impl ConnectorService {
                     tls_info: false,
                 })
             }
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(http, tls) => {
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(http, tls) => {
                 let mut http = http.clone();
 
                 // Disable Nagle's algorithm for TLS handshake
@@ -738,8 +738,8 @@ impl ConnectorService {
                     tls_info: false,
                 })
             }
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(_, tls) => {
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(_, tls) => {
                 let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
                 let mut http = hyper_tls::HttpsConnector::from((svc, tls_connector));
                 let io = http.call(dst).await?;
@@ -799,8 +799,8 @@ impl ConnectorService {
         let misc = proxy.custom_headers().clone();
 
         match &self.inner {
-            #[cfg(feature = "default-tls")]
-            Inner::DefaultTls(http, tls) => {
+            #[cfg(feature = "native-tls")]
+            Inner::NativeTls(http, tls) => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     log::trace!("tunneling HTTPS over proxy");
                     let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
@@ -975,7 +975,7 @@ impl TlsInfoFactory for tokio::net::TcpStream {
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::TcpStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
@@ -988,7 +988,7 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
         TokioIo<hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>>>,
@@ -1005,7 +1005,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         match self {
@@ -1065,7 +1065,7 @@ impl TlsInfoFactory for tokio::net::UnixStream {
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 #[cfg(unix)]
 impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::UnixStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
@@ -1079,7 +1079,7 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 #[cfg(unix)]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
@@ -1097,7 +1097,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 #[cfg(unix)]
 impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::UnixStream>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
@@ -1161,7 +1161,7 @@ impl TlsInfoFactory for tokio::net::windows::named_pipe::NamedPipeClient {
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 #[cfg(target_os = "windows")]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
@@ -1179,7 +1179,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 #[cfg(target_os = "windows")]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
@@ -1199,7 +1199,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 #[cfg(target_os = "windows")]
 impl TlsInfoFactory
     for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::windows::named_pipe::NamedPipeClient>>
@@ -1452,7 +1452,7 @@ pub(crate) mod windows_named_pipe {
 
 pub(crate) type Connecting = Pin<Box<dyn Future<Output = Result<Conn, BoxError>> + Send>>;
 
-#[cfg(feature = "default-tls")]
+#[cfg(feature = "native-tls")]
 mod native_tls_conn {
     use super::TlsInfoFactory;
     use hyper::rt::{Read, ReadBufCursor, Write};

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -12,10 +12,9 @@
 //! reqwest will pick a TLS backend by default. This is true when the
 //! `default-tls` feature is enabled.
 //!
-//! While it currently uses `native-tls`, the feature set is designed to only
+//! While it currently uses `rustls-tls`, the feature set is designed to only
 //! enable configuration that is shared among available backends. This allows
-//! reqwest to change the default to `rustls` (or another) at some point in the
-//! future.
+//! reqwest to change the default to `native-tls` (or another) by configuration.
 //!
 //! <div class="warning">This feature is enabled by default, and takes
 //! precedence if any other crate enables it. This is true even if you declare
@@ -69,7 +68,7 @@ pub struct CertificateRevocationList {
 /// Represents a server X509 certificate.
 #[derive(Clone)]
 pub struct Certificate {
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     native: native_tls_crate::Certificate,
     #[cfg(feature = "__rustls")]
     original: Cert,
@@ -141,7 +140,7 @@ impl Certificate {
     /// ```
     pub fn from_der(der: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             native: native_tls_crate::Certificate::from_der(der).map_err(crate::error::builder)?,
             #[cfg(feature = "__rustls")]
             original: Cert::Der(der.to_owned()),
@@ -166,7 +165,7 @@ impl Certificate {
     /// ```
     pub fn from_pem(pem: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
-            #[cfg(feature = "default-tls")]
+            #[cfg(feature = "native-tls")]
             native: native_tls_crate::Certificate::from_pem(pem).map_err(crate::error::builder)?,
             #[cfg(feature = "__rustls")]
             original: Cert::Pem(pem.to_owned()),
@@ -199,7 +198,7 @@ impl Certificate {
             .collect::<crate::Result<Vec<Certificate>>>()
     }
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     pub(crate) fn add_to_native_tls(self, tls: &mut native_tls_crate::TlsConnectorBuilder) {
         tls.add_root_certificate(self.native);
     }
@@ -529,7 +528,7 @@ impl Version {
     /// Version 1.3 of the TLS protocol.
     pub const TLS_1_3: Version = Version(InnerVersion::Tls1_3);
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     pub(crate) fn to_native_tls(self) -> Option<native_tls_crate::Protocol> {
         match self.0 {
             InnerVersion::Tls1_0 => Some(native_tls_crate::Protocol::Tlsv10),
@@ -556,8 +555,8 @@ impl Version {
 pub(crate) enum TlsBackend {
     // This is the default and HTTP/3 feature does not use it so suppress it.
     #[allow(dead_code)]
-    #[cfg(feature = "default-tls")]
-    Default,
+    #[cfg(feature = "native-tls")]
+    NativeTls,
     #[cfg(feature = "native-tls")]
     BuiltNativeTls(native_tls_crate::TlsConnector),
     #[cfg(feature = "__rustls")]
@@ -571,8 +570,8 @@ pub(crate) enum TlsBackend {
 impl fmt::Debug for TlsBackend {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            #[cfg(feature = "default-tls")]
-            TlsBackend::Default => write!(f, "Default"),
+            #[cfg(feature = "native-tls")]
+            TlsBackend::NativeTls => write!(f, "NativeTls"),
             #[cfg(feature = "native-tls")]
             TlsBackend::BuiltNativeTls(_) => write!(f, "BuiltNativeTls"),
             #[cfg(feature = "__rustls")]
@@ -588,17 +587,17 @@ impl fmt::Debug for TlsBackend {
 #[allow(clippy::derivable_impls)]
 impl Default for TlsBackend {
     fn default() -> TlsBackend {
-        #[cfg(all(feature = "default-tls", not(feature = "http3")))]
-        {
-            TlsBackend::Default
-        }
-
         #[cfg(any(
-            all(feature = "__rustls", not(feature = "default-tls")),
+            all(feature = "__rustls", not(feature = "native-tls")),
             feature = "http3"
         ))]
         {
             TlsBackend::Rustls
+        }
+
+        #[cfg(all(feature = "native-tls", not(feature = "http3")))]
+        {
+            TlsBackend::NativeTls
         }
     }
 }
@@ -746,13 +745,13 @@ impl std::fmt::Debug for TlsInfo {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     #[test]
     fn certificate_from_der_invalid() {
         Certificate::from_der(b"not der").unwrap_err();
     }
 
-    #[cfg(feature = "default-tls")]
+    #[cfg(feature = "native-tls")]
     #[test]
     fn certificate_from_pem_invalid() {
         Certificate::from_pem(b"not pem").unwrap_err();

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -11,6 +11,9 @@ use tokio::net::TcpStream;
 use tokio::runtime;
 use tokio::sync::oneshot;
 
+#[cfg(feature = "http3")]
+static CRYPTO_PROVIDER_INSTALLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
 pub struct Server {
     addr: net::SocketAddr,
     panic_rx: std_mpsc::Receiver<()>,
@@ -196,6 +199,8 @@ impl Http3 {
             let cert = std::fs::read("tests/support/server.cert").unwrap().into();
             let key = std::fs::read("tests/support/server.key").unwrap().try_into().unwrap();
 
+            CRYPTO_PROVIDER_INSTALLED.get_or_init(install_default_crypto_provider);
+
             let mut tls_config = rustls::ServerConfig::builder()
                 .with_no_client_auth()
                 .with_single_cert(vec![cert], key)
@@ -283,6 +288,24 @@ impl Http3 {
         .join()
         .unwrap()
     }
+}
+
+#[cfg(feature = "http3")]
+fn install_default_crypto_provider() -> bool {
+    #[cfg(not(any(feature = "__rustls-ring", feature = "__rustls-aws-lc-rs")))]
+    panic!("No provider set");
+
+    #[cfg(all(feature = "__rustls-ring", not(feature = "__rustls-aws-lc-rs")))]
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install the default Ring TLS provider");
+
+    #[cfg(feature = "__rustls-aws-lc-rs")]
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install the default TLS provider");
+
+    true
 }
 
 pub fn low_level_with_response<F>(do_response: F) -> Server


### PR DESCRIPTION
This switches the default TLS provider to Rustls. It keeps the native-tls feature with the same configuration it had before as the default TLS provider.

A note here since the original PR: I had to disable testing rustls with windows-i686-gnu, it's no longer supported. I changed the test to use native-tls, and that still works, for now.

(This merges the rustls-default branch in master, now that 0.13 dev has started. See #2752 for original PR.)