### PR TITLE
remove long-deprecated methods: trust-dns and non-wasm-cors

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -2205,15 +2205,6 @@ impl ClientBuilder {
         self
     }
 
-    #[doc(hidden)]
-    #[cfg(feature = "hickory-dns")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "hickory-dns")))]
-    #[deprecated(note = "use `hickory_dns` instead")]
-    pub fn trust_dns(mut self, enable: bool) -> ClientBuilder {
-        self.config.hickory_dns = enable;
-        self
-    }
-
     /// Enables the [hickory-dns](hickory_resolver) async resolver instead of a default threadpool
     /// using `getaddrinfo`.
     ///
@@ -2232,12 +2223,6 @@ impl ClientBuilder {
     pub fn hickory_dns(mut self, enable: bool) -> ClientBuilder {
         self.config.hickory_dns = enable;
         self
-    }
-
-    #[doc(hidden)]
-    #[deprecated(note = "use `no_hickory_dns` instead")]
-    pub fn no_trust_dns(self) -> ClientBuilder {
-        self.no_hickory_dns()
     }
 
     /// Disables the hickory-dns async resolver.

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -479,19 +479,6 @@ impl RequestBuilder {
         self
     }
 
-    // This was a shell only meant to help with rendered documentation.
-    // However, docs.rs can now show the docs for the wasm platforms, so this
-    // is no longer needed.
-    //
-    // You should not otherwise depend on this function. It's deprecation
-    // is just to nudge people to reduce breakage. It may be removed in a
-    // future patch version.
-    #[doc(hidden)]
-    #[cfg_attr(target_arch = "wasm32", deprecated)]
-    pub fn fetch_mode_no_cors(self) -> RequestBuilder {
-        self
-    }
-
     /// Build a `Request`, which can be inspected, modified and executed with
     /// `Client::execute()`.
     pub fn build(self) -> crate::Result<Request> {

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1078,32 +1078,8 @@ impl ClientBuilder {
     /// This requires the optional `hickory-dns` feature to be enabled
     #[cfg(feature = "hickory-dns")]
     #[cfg_attr(docsrs, doc(cfg(feature = "hickory-dns")))]
-    #[deprecated(note = "use `hickory_dns` instead", since = "0.12.0")]
-    pub fn trust_dns(self, enable: bool) -> ClientBuilder {
-        self.with_inner(|inner| inner.hickory_dns(enable))
-    }
-
-    /// Enables the [hickory-dns](hickory_resolver) async resolver instead of a default threadpool using `getaddrinfo`.
-    ///
-    /// If the `hickory-dns` feature is turned on, the default option is enabled.
-    ///
-    /// # Optional
-    ///
-    /// This requires the optional `hickory-dns` feature to be enabled
-    #[cfg(feature = "hickory-dns")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "hickory-dns")))]
     pub fn hickory_dns(self, enable: bool) -> ClientBuilder {
         self.with_inner(|inner| inner.hickory_dns(enable))
-    }
-
-    /// Disables the hickory-dns async resolver.
-    ///
-    /// This method exists even if the optional `hickory-dns` feature is not enabled.
-    /// This can be used to ensure a `Client` doesn't use the hickory-dns async resolver
-    /// even if another dependency were to enable the optional `hickory-dns` feature.
-    #[deprecated(note = "use `no_hickory_dns` instead", since = "0.12.0")]
-    pub fn no_trust_dns(self) -> ClientBuilder {
-        self.with_inner(|inner| inner.no_hickory_dns())
     }
 
     /// Disables the hickory-dns async resolver.


### PR DESCRIPTION
- `ClientBuilder::trust_dns()`
- `ClientBuilder::no_trust_dns()`
- `Request::fetch_mode_no_cors()` on non-WASM targets