### PR TITLE
v0.13.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest"
-version = "0.13.0-dev"
+version = "0.13.0-rc.1"
 description = "higher level HTTP client library"
 keywords = ["http", "request", "client"]
 categories = ["web-programming::http-client", "wasm"]
@@ -19,8 +19,6 @@ include = [
     "LICENSE-MIT",
     "src/**/*.rs"
 ]
-
-publish = false
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Main changes:

- rustls is now default instead of native-tls
- rustls provider defaults to aws-lc instead of ring (`rustls-no-provider` exists if you want to enable a different one)
- rustls-tls renamed to rustls
- rustls roots features removed, platform-verifier is used instead
    - To use different roots instead, use `tls_certs_only(your_roots)`.
- Many TLS-related methods renamed, but previous name left in place with a "soft" deprecated (just documented, no warnings).
- query and form are now crate features, disabled by default
- Long-deprecated methods and crate features have been removed.