### PR TITLE
Enable ALPN by default in native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,10 @@ http2 = ["h2", "hyper/http2", "hyper-util/http2", "hyper-rustls?/http2"]
 rustls = ["__rustls-aws-lc-rs", "dep:rustls-platform-verifier", "__rustls"]
 rustls-no-provider = ["dep:rustls-platform-verifier", "__rustls"]
 
-native-tls = ["dep:hyper-tls", "dep:native-tls-crate", "__tls", "dep:tokio-native-tls"]
-native-tls-alpn = ["native-tls", "native-tls-crate?/alpn", "hyper-tls?/alpn"]
-native-tls-vendored = ["native-tls", "native-tls-crate?/vendored"]
+native-tls = ["__native-tls", "__native-tls-alpn"]
+native-tls-no-alpn = ["__native-tls"]
+native-tls-vendored = ["__native-tls", "native-tls-crate?/vendored", "__native-tls-alpn"]
+native-tls-vendored-no-alpn = ["__native-tls", "native-tls-crate?/vendored"]
 
 blocking = ["dep:futures-channel", "futures-channel?/sink", "dep:futures-util", "futures-util?/io", "futures-util?/sink", "tokio/sync"]
 
@@ -88,6 +89,10 @@ __tls = ["dep:rustls-pki-types", "tokio/io-util"]
 # Enables common rustls code.
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls"]
 __rustls-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/aws-lc-rs"]
+
+# Enables common native-tls code.
+__native-tls = ["dep:hyper-tls", "dep:native-tls-crate", "__tls", "dep:tokio-native-tls"]
+__native-tls-alpn = ["native-tls-crate?/alpn", "hyper-tls?/alpn"]
 
 [dependencies]
 base64 = "0.22"

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "native-tls", feature = "__rustls",))]
+#[cfg(any(feature = "__native-tls", feature = "__rustls",))]
 use std::any::Any;
 use std::future::Future;
 use std::net::IpAddr;
@@ -42,7 +42,7 @@ use crate::tls::CertificateRevocationList;
 use crate::tls::{self, TlsBackend};
 #[cfg(feature = "__tls")]
 use crate::Certificate;
-#[cfg(any(feature = "native-tls", feature = "__rustls"))]
+#[cfg(any(feature = "__native-tls", feature = "__rustls"))]
 use crate::Identity;
 use crate::{IntoUrl, Method, Proxy, Url};
 
@@ -50,7 +50,7 @@ use http::header::{Entry, HeaderMap, HeaderValue, ACCEPT, PROXY_AUTHORIZATION, U
 use http::uri::Scheme;
 use http::Uri;
 use hyper_util::client::legacy::connect::HttpConnector;
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 use native_tls_crate::TlsConnector;
 use pin_project_lite::pin_project;
 #[cfg(feature = "http3")]
@@ -176,7 +176,7 @@ struct Config {
     tcp_keepalive_retries: Option<u32>,
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     tcp_user_timeout: Option<Duration>,
-    #[cfg(any(feature = "native-tls", feature = "__rustls"))]
+    #[cfg(any(feature = "__native-tls", feature = "__rustls"))]
     identity: Option<Identity>,
     proxies: Vec<ProxyMatcher>,
     auto_sys_proxy: bool,
@@ -312,7 +312,7 @@ impl ClientBuilder {
                 root_certs: Vec::new(),
                 #[cfg(feature = "__tls")]
                 tls_certs_only: false,
-                #[cfg(any(feature = "native-tls", feature = "__rustls"))]
+                #[cfg(any(feature = "__native-tls", feature = "__rustls"))]
                 identity: None,
                 #[cfg(feature = "__rustls")]
                 crls: vec![],
@@ -516,11 +516,11 @@ impl ClientBuilder {
 
             #[cfg(feature = "__tls")]
             match config.tls {
-                #[cfg(feature = "native-tls")]
+                #[cfg(feature = "__native-tls")]
                 TlsBackend::NativeTls => {
                     let mut tls = TlsConnector::builder();
 
-                    #[cfg(all(feature = "native-tls-alpn", not(feature = "http3")))]
+                    #[cfg(all(feature = "__native-tls-alpn", not(feature = "http3")))]
                     {
                         match config.http_version_pref {
                             HttpVersionPref::Http1 => {
@@ -548,13 +548,13 @@ impl ClientBuilder {
                         cert.add_to_native_tls(&mut tls);
                     }
 
-                    #[cfg(feature = "native-tls")]
+                    #[cfg(feature = "__native-tls")]
                     {
                         if let Some(id) = config.identity {
                             id.add_to_native_tls(&mut tls)?;
                         }
                     }
-                    #[cfg(all(feature = "__rustls", not(feature = "native-tls")))]
+                    #[cfg(all(feature = "__rustls", not(feature = "__native-tls")))]
                     {
                         // Default backend + rustls Identity doesn't work.
                         if let Some(_id) = config.identity {
@@ -606,7 +606,7 @@ impl ClientBuilder {
                         config.tls_info,
                     )?
                 }
-                #[cfg(feature = "native-tls")]
+                #[cfg(feature = "__native-tls")]
                 TlsBackend::BuiltNativeTls(conn) => ConnectorBuilder::from_built_native_tls(
                     http,
                     conn,
@@ -861,7 +861,7 @@ impl ClientBuilder {
                         config.tls_info,
                     )
                 }
-                #[cfg(any(feature = "native-tls", feature = "__rustls",))]
+                #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
                 TlsBackend::UnknownPreconfigured => {
                     return Err(crate::error::builder(
                         "Unknown TLS backend passed to `use_preconfigured_tls`",
@@ -1918,7 +1918,7 @@ impl ClientBuilder {
     ///
     /// This requires the optional `native-tls` or `rustls(-...)` feature to be
     /// enabled.
-    #[cfg(any(feature = "native-tls", feature = "__rustls"))]
+    #[cfg(any(feature = "__native-tls", feature = "__rustls"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls"))))]
     pub fn identity(mut self, identity: Identity) -> ClientBuilder {
         self.config.identity = Some(identity);
@@ -2087,7 +2087,7 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// This requires the optional `native-tls` feature to be enabled.
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     pub fn tls_backend_native(mut self) -> ClientBuilder {
         self.config.tls = TlsBackend::NativeTls;
@@ -2095,7 +2095,7 @@ impl ClientBuilder {
     }
 
     /// Deprecated: use [`ClientBuilder::tls_backend_native()`] instead.
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub fn use_native_tls(self) -> ClientBuilder {
         self.tls_backend_native()
     }
@@ -2147,11 +2147,11 @@ impl ClientBuilder {
     ///
     /// This requires one of the optional features `native-tls` or
     /// `rustls(-...)` to be enabled.
-    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
+    #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls"))))]
     pub fn tls_backend_preconfigured(mut self, tls: impl Any) -> ClientBuilder {
         let mut tls = Some(tls);
-        #[cfg(feature = "native-tls")]
+        #[cfg(feature = "__native-tls")]
         {
             if let Some(conn) = (&mut tls as &mut dyn Any).downcast_mut::<Option<TlsConnector>>() {
                 let tls = conn.take().expect("is definitely Some");
@@ -2178,7 +2178,7 @@ impl ClientBuilder {
     }
 
     /// Deprecated: use [`ClientBuilder::tls_backend_preconfigured()`] instead.
-    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
+    #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
     pub fn use_preconfigured_tls(self, tls: impl Any) -> ClientBuilder {
         self.tls_backend_preconfigured(tls)
     }

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "native-tls", feature = "__rustls",))]
+#[cfg(any(feature = "__native-tls", feature = "__rustls",))]
 use std::any::Any;
 use std::convert::TryInto;
 use std::fmt;
@@ -31,7 +31,7 @@ use crate::tls;
 use crate::tls::CertificateRevocationList;
 #[cfg(feature = "__tls")]
 use crate::Certificate;
-#[cfg(any(feature = "native-tls", feature = "__rustls"))]
+#[cfg(any(feature = "__native-tls", feature = "__rustls"))]
 use crate::Identity;
 use crate::{async_impl, header, redirect, IntoUrl, Method, Proxy};
 
@@ -864,7 +864,7 @@ impl ClientBuilder {
     ///
     /// This requires the optional `native-tls` or `rustls(-...)` feature to be
     /// enabled.
-    #[cfg(any(feature = "native-tls", feature = "__rustls"))]
+    #[cfg(any(feature = "__native-tls", feature = "__rustls"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls"))))]
     pub fn identity(self, identity: Identity) -> ClientBuilder {
         self.with_inner(move |inner| inner.identity(identity))
@@ -1014,14 +1014,14 @@ impl ClientBuilder {
     /// # Optional
     ///
     /// This requires the optional `native-tls` feature to be enabled.
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     pub fn tls_backend_native(self) -> ClientBuilder {
         self.with_inner(move |inner| inner.tls_backend_native())
     }
 
     /// Deprecated: use [`ClientBuilder::tls_backend_native()`] instead.
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub fn use_native_tls(self) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_native_tls())
     }
@@ -1080,14 +1080,14 @@ impl ClientBuilder {
     ///
     /// This requires one of the optional features `native-tls` or
     /// `rustls(-...)` to be enabled.
-    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
+    #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls"))))]
     pub fn tls_backend_preconfigured(self, tls: impl Any) -> ClientBuilder {
         self.with_inner(move |inner| inner.tls_backend_preconfigured(tls))
     }
 
     /// Deprecated: use [`ClientBuilder::tls_backend_preconfigured()`] instead.
-    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
+    #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
     pub fn use_preconfigured_tls(self, tls: impl Any) -> ClientBuilder {
         self.with_inner(move |inner| inner.use_preconfigured_tls(tls))
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -7,7 +7,7 @@ use hyper::rt::{Read, ReadBufCursor, Write};
 use hyper_util::client::legacy::connect::{Connected, Connection};
 #[cfg(any(feature = "socks", feature = "__tls", unix, target_os = "windows"))]
 use hyper_util::rt::TokioIo;
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 use native_tls_crate::{TlsConnector, TlsConnectorBuilder};
 use pin_project_lite::pin_project;
 use tower::util::{BoxCloneSyncServiceLayer, MapRequestLayer};
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 use self::native_tls_conn::NativeTlsConn;
 #[cfg(feature = "__rustls")]
 use self::rustls_tls_conn::RustlsTlsConn;
@@ -222,7 +222,7 @@ where {
         }
     }
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub(crate) fn new_native_tls<T>(
         http: HttpConnector,
         tls: TlsConnectorBuilder,
@@ -273,7 +273,7 @@ where {
         ))
     }
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub(crate) fn from_built_native_tls<T>(
         mut http: HttpConnector,
         tls: TlsConnector,
@@ -420,7 +420,7 @@ where {
 
     pub(crate) fn set_keepalive(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, _tls) => http.set_keepalive(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive(dur),
@@ -431,7 +431,7 @@ where {
 
     pub(crate) fn set_keepalive_interval(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, _tls) => http.set_keepalive_interval(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive_interval(dur),
@@ -442,7 +442,7 @@ where {
 
     pub(crate) fn set_keepalive_retries(&mut self, retries: Option<u32>) {
         match &mut self.inner {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, _tls) => http.set_keepalive_retries(retries),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_keepalive_retries(retries),
@@ -459,7 +459,7 @@ where {
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     pub(crate) fn set_tcp_user_timeout(&mut self, dur: Option<Duration>) {
         match &mut self.inner {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, _tls) => http.set_tcp_user_timeout(dur),
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http.set_tcp_user_timeout(dur),
@@ -509,7 +509,7 @@ pub(crate) struct ConnectorService {
 enum Inner {
     #[cfg(not(feature = "__tls"))]
     Http(HttpConnector),
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     NativeTls(HttpConnector, TlsConnector),
     #[cfg(any(feature = "__rustls"))]
     RustlsTls {
@@ -523,7 +523,7 @@ impl Inner {
     #[cfg(feature = "socks")]
     fn get_http_connector(&mut self) -> &mut crate::connect::HttpConnector {
         match self {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, _) => http,
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, .. } => http,
@@ -545,7 +545,7 @@ impl ConnectorService {
         };
 
         match &mut self.inner {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, tls) => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     let host = dst.host().ok_or("no host in url")?.to_string();
@@ -621,7 +621,7 @@ impl ConnectorService {
                     tls_info: false,
                 })
             }
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, tls) => {
                 let mut http = http.clone();
 
@@ -738,7 +738,7 @@ impl ConnectorService {
                     tls_info: false,
                 })
             }
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(_, tls) => {
                 let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
                 let mut http = hyper_tls::HttpsConnector::from((svc, tls_connector));
@@ -799,7 +799,7 @@ impl ConnectorService {
         let misc = proxy.custom_headers().clone();
 
         match &self.inner {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, tls) => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     log::trace!("tunneling HTTPS over proxy");
@@ -975,7 +975,7 @@ impl TlsInfoFactory for tokio::net::TcpStream {
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::TcpStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         let peer_certificate = self
@@ -988,7 +988,7 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
         TokioIo<hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>>>,
@@ -1005,7 +1005,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStream>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
         match self {
@@ -1065,7 +1065,7 @@ impl TlsInfoFactory for tokio::net::UnixStream {
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 #[cfg(unix)]
 impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::UnixStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
@@ -1079,7 +1079,7 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 #[cfg(unix)]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
@@ -1097,7 +1097,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 #[cfg(unix)]
 impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::UnixStream>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
@@ -1161,7 +1161,7 @@ impl TlsInfoFactory for tokio::net::windows::named_pipe::NamedPipeClient {
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 #[cfg(target_os = "windows")]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
@@ -1179,7 +1179,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 #[cfg(target_os = "windows")]
 impl TlsInfoFactory
     for tokio_native_tls::TlsStream<
@@ -1199,7 +1199,7 @@ impl TlsInfoFactory
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 #[cfg(target_os = "windows")]
 impl TlsInfoFactory
     for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::windows::named_pipe::NamedPipeClient>>
@@ -1452,7 +1452,7 @@ pub(crate) mod windows_named_pipe {
 
 pub(crate) type Connecting = Pin<Box<dyn Future<Output = Result<Conn, BoxError>> + Send>>;
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 mod native_tls_conn {
     use super::TlsInfoFactory;
     use hyper::rt::{Read, ReadBufCursor, Write};
@@ -1485,12 +1485,12 @@ mod native_tls_conn {
                 .get_ref()
                 .inner()
                 .connected();
-            #[cfg(feature = "native-tls-alpn")]
+            #[cfg(feature = "__native-tls-alpn")]
             match self.inner.inner().get_ref().negotiated_alpn().ok() {
                 Some(Some(alpn_protocol)) if alpn_protocol == b"h2" => connected.negotiated_h2(),
                 _ => connected,
             }
-            #[cfg(not(feature = "native-tls-alpn"))]
+            #[cfg(not(feature = "__native-tls-alpn"))]
             connected
         }
     }
@@ -1505,12 +1505,12 @@ mod native_tls_conn {
                 .get_ref()
                 .inner()
                 .connected();
-            #[cfg(feature = "native-tls-alpn")]
+            #[cfg(feature = "__native-tls-alpn")]
             match self.inner.inner().get_ref().negotiated_alpn().ok() {
                 Some(Some(alpn_protocol)) if alpn_protocol == b"h2" => connected.negotiated_h2(),
                 _ => connected,
             }
-            #[cfg(not(feature = "native-tls-alpn"))]
+            #[cfg(not(feature = "__native-tls-alpn"))]
             connected
         }
     }
@@ -1519,12 +1519,12 @@ mod native_tls_conn {
     impl Connection for NativeTlsConn<TokioIo<TokioIo<tokio::net::UnixStream>>> {
         fn connected(&self) -> Connected {
             let connected = Connected::new();
-            #[cfg(feature = "native-tls-alpn")]
+            #[cfg(feature = "__native-tls-alpn")]
             match self.inner.inner().get_ref().negotiated_alpn().ok() {
                 Some(Some(alpn_protocol)) if alpn_protocol == b"h2" => connected.negotiated_h2(),
                 _ => connected,
             }
-            #[cfg(not(feature = "native-tls-alpn"))]
+            #[cfg(not(feature = "__native-tls-alpn"))]
             connected
         }
     }
@@ -1533,12 +1533,12 @@ mod native_tls_conn {
     impl Connection for NativeTlsConn<TokioIo<MaybeHttpsStream<TokioIo<tokio::net::UnixStream>>>> {
         fn connected(&self) -> Connected {
             let connected = Connected::new();
-            #[cfg(feature = "native-tls-alpn")]
+            #[cfg(feature = "__native-tls-alpn")]
             match self.inner.inner().get_ref().negotiated_alpn().ok() {
                 Some(Some(alpn_protocol)) if alpn_protocol == b"h2" => connected.negotiated_h2(),
                 _ => connected,
             }
-            #[cfg(not(feature = "native-tls-alpn"))]
+            #[cfg(not(feature = "__native-tls-alpn"))]
             connected
         }
     }
@@ -1549,12 +1549,12 @@ mod native_tls_conn {
     {
         fn connected(&self) -> Connected {
             let connected = Connected::new();
-            #[cfg(feature = "native-tls-alpn")]
+            #[cfg(feature = "__native-tls-alpn")]
             match self.inner.inner().get_ref().negotiated_alpn().ok() {
                 Some(Some(alpn_protocol)) if alpn_protocol == b"h2" => connected.negotiated_h2(),
                 _ => connected,
             }
-            #[cfg(not(feature = "native-tls-alpn"))]
+            #[cfg(not(feature = "__native-tls-alpn"))]
             connected
         }
     }
@@ -1567,12 +1567,12 @@ mod native_tls_conn {
     {
         fn connected(&self) -> Connected {
             let connected = Connected::new();
-            #[cfg(feature = "native-tls-alpn")]
+            #[cfg(feature = "__native-tls-alpn")]
             match self.inner.inner().get_ref().negotiated_alpn().ok() {
                 Some(Some(alpn_protocol)) if alpn_protocol == b"h2" => connected.negotiated_h2(),
                 _ => connected,
             }
-            #[cfg(not(feature = "native-tls-alpn"))]
+            #[cfg(not(feature = "__native-tls-alpn"))]
             connected
         }
     }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -68,7 +68,7 @@ pub struct CertificateRevocationList {
 /// Represents a server X509 certificate.
 #[derive(Clone)]
 pub struct Certificate {
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     native: native_tls_crate::Certificate,
     #[cfg(feature = "__rustls")]
     original: Cert,
@@ -84,14 +84,17 @@ enum Cert {
 /// Represents a private key and X509 cert as a client certificate.
 #[derive(Clone)]
 pub struct Identity {
-    #[cfg_attr(not(any(feature = "native-tls", feature = "__rustls")), allow(unused))]
+    #[cfg_attr(
+        not(any(feature = "__native-tls", feature = "__rustls")),
+        allow(unused)
+    )]
     inner: ClientCert,
 }
 
 enum ClientCert {
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     Pkcs12(native_tls_crate::Identity),
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     Pkcs8(native_tls_crate::Identity),
     #[cfg(feature = "__rustls")]
     Pem {
@@ -103,9 +106,9 @@ enum ClientCert {
 impl Clone for ClientCert {
     fn clone(&self) -> Self {
         match self {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Self::Pkcs8(i) => Self::Pkcs8(i.clone()),
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             Self::Pkcs12(i) => Self::Pkcs12(i.clone()),
             #[cfg(feature = "__rustls")]
             ClientCert::Pem { key, certs } => ClientCert::Pem {
@@ -113,7 +116,7 @@ impl Clone for ClientCert {
                 certs: certs.clone(),
             },
             #[cfg_attr(
-                any(feature = "native-tls", feature = "__rustls"),
+                any(feature = "__native-tls", feature = "__rustls"),
                 allow(unreachable_patterns)
             )]
             _ => unreachable!(),
@@ -140,7 +143,7 @@ impl Certificate {
     /// ```
     pub fn from_der(der: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             native: native_tls_crate::Certificate::from_der(der).map_err(crate::error::builder)?,
             #[cfg(feature = "__rustls")]
             original: Cert::Der(der.to_owned()),
@@ -165,7 +168,7 @@ impl Certificate {
     /// ```
     pub fn from_pem(pem: &[u8]) -> crate::Result<Certificate> {
         Ok(Certificate {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             native: native_tls_crate::Certificate::from_pem(pem).map_err(crate::error::builder)?,
             #[cfg(feature = "__rustls")]
             original: Cert::Pem(pem.to_owned()),
@@ -205,7 +208,7 @@ impl Certificate {
     }
     */
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub(crate) fn add_to_native_tls(self, tls: &mut native_tls_crate::TlsConnectorBuilder) {
         tls.add_root_certificate(self.native);
     }
@@ -276,7 +279,7 @@ impl Identity {
     /// # Optional
     ///
     /// This requires the `native-tls` Cargo feature enabled.
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub fn from_pkcs12_der(der: &[u8], password: &str) -> crate::Result<Identity> {
         Ok(Identity {
             inner: ClientCert::Pkcs12(
@@ -310,7 +313,7 @@ impl Identity {
     /// # Optional
     ///
     /// This requires the `native-tls` Cargo feature enabled.
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub fn from_pkcs8_pem(pem: &[u8], key: &[u8]) -> crate::Result<Identity> {
         Ok(Identity {
             inner: ClientCert::Pkcs8(
@@ -388,7 +391,7 @@ impl Identity {
         })
     }
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub(crate) fn add_to_native_tls(
         self,
         tls: &mut native_tls_crate::TlsConnectorBuilder,
@@ -416,7 +419,7 @@ impl Identity {
             ClientCert::Pem { key, certs } => config_builder
                 .with_client_auth_cert(certs, key)
                 .map_err(crate::error::builder),
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             ClientCert::Pkcs12(..) | ClientCert::Pkcs8(..) => {
                 Err(crate::error::builder("incompatible TLS identity type"))
             }
@@ -535,7 +538,7 @@ impl Version {
     /// Version 1.3 of the TLS protocol.
     pub const TLS_1_3: Version = Version(InnerVersion::Tls1_3);
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     pub(crate) fn to_native_tls(self) -> Option<native_tls_crate::Protocol> {
         match self.0 {
             InnerVersion::Tls1_0 => Some(native_tls_crate::Protocol::Tlsv10),
@@ -562,30 +565,30 @@ impl Version {
 pub(crate) enum TlsBackend {
     // This is the default and HTTP/3 feature does not use it so suppress it.
     #[allow(dead_code)]
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     NativeTls,
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     BuiltNativeTls(native_tls_crate::TlsConnector),
     #[cfg(feature = "__rustls")]
     Rustls,
     #[cfg(feature = "__rustls")]
     BuiltRustls(rustls::ClientConfig),
-    #[cfg(any(feature = "native-tls", feature = "__rustls",))]
+    #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
     UnknownPreconfigured,
 }
 
 impl fmt::Debug for TlsBackend {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             TlsBackend::NativeTls => write!(f, "NativeTls"),
-            #[cfg(feature = "native-tls")]
+            #[cfg(feature = "__native-tls")]
             TlsBackend::BuiltNativeTls(_) => write!(f, "BuiltNativeTls"),
             #[cfg(feature = "__rustls")]
             TlsBackend::Rustls => write!(f, "Rustls"),
             #[cfg(feature = "__rustls")]
             TlsBackend::BuiltRustls(_) => write!(f, "BuiltRustls"),
-            #[cfg(any(feature = "native-tls", feature = "__rustls",))]
+            #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
             TlsBackend::UnknownPreconfigured => write!(f, "UnknownPreconfigured"),
         }
     }
@@ -595,14 +598,14 @@ impl fmt::Debug for TlsBackend {
 impl Default for TlsBackend {
     fn default() -> TlsBackend {
         #[cfg(any(
-            all(feature = "__rustls", not(feature = "native-tls")),
+            all(feature = "__rustls", not(feature = "__native-tls")),
             feature = "http3"
         ))]
         {
             TlsBackend::Rustls
         }
 
-        #[cfg(all(feature = "native-tls", not(feature = "http3")))]
+        #[cfg(all(feature = "__native-tls", not(feature = "http3")))]
         {
             TlsBackend::NativeTls
         }
@@ -782,25 +785,25 @@ impl std::fmt::Debug for TlsInfo {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     #[test]
     fn certificate_from_der_invalid() {
         Certificate::from_der(b"not der").unwrap_err();
     }
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     #[test]
     fn certificate_from_pem_invalid() {
         Certificate::from_pem(b"not pem").unwrap_err();
     }
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     #[test]
     fn identity_from_pkcs12_der_invalid() {
         Identity::from_pkcs12_der(b"not der", "nope").unwrap_err();
     }
 
-    #[cfg(feature = "native-tls")]
+    #[cfg(feature = "__native-tls")]
     #[test]
     fn identity_from_pkcs8_pem_invalid() {
         Identity::from_pkcs8_pem(b"not pem", b"not key").unwrap_err();

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -53,7 +53,7 @@ async fn test_badssl_no_built_in_roots() {
     assert!(result.is_err());
 }
 
-#[cfg(any(feature = "native-tls"))]
+#[cfg(any(feature = "__native-tls"))]
 #[tokio::test]
 async fn test_badssl_wrong_host() {
     let text = reqwest::Client::builder()

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -325,7 +325,7 @@ async fn overridden_dns_resolution_with_hickory_dns_multiple() {
     assert_eq!("Hello", text);
 }
 
-#[cfg(any(feature = "native-tls", feature = "__rustls",))]
+#[cfg(any(feature = "__native-tls", feature = "__rustls",))]
 #[test]
 fn use_preconfigured_tls_with_bogus_backend() {
     struct DefinitelyNotTls;
@@ -336,7 +336,7 @@ fn use_preconfigured_tls_with_bogus_backend() {
         .expect_err("definitely is not TLS");
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(feature = "__native-tls")]
 #[test]
 fn use_preconfigured_native_tls_default() {
     extern crate native_tls_crate;


### PR DESCRIPTION
Also adds `native-tls-no-alpn` and `native-tls-vendored-no-alpn` for opting out of ALPN

Resolves [#2902](https://github.com/seanmonstar/reqwest/issues/2902)
