### PR TITLE
Add tls_sslkeylogfile builder method

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -167,6 +167,8 @@ struct Config {
     certs_verification: bool,
     #[cfg(feature = "__tls")]
     tls_sni: bool,
+    #[cfg(feature = "__rustls")]
+    tls_sslkeylogfile: bool,
     connect_timeout: Option<Duration>,
     connection_verbose: bool,
     pool_idle_timeout: Option<Duration>,
@@ -292,6 +294,8 @@ impl ClientBuilder {
                 certs_verification: true,
                 #[cfg(feature = "__tls")]
                 tls_sni: true,
+                #[cfg(feature = "__rustls")]
+                tls_sslkeylogfile: false,
                 connect_timeout: None,
                 connection_verbose: false,
                 pool_idle_timeout: Some(Duration::from_secs(90)),
@@ -802,6 +806,10 @@ impl ClientBuilder {
                     };
 
                     tls.enable_sni = config.tls_sni;
+
+                    if config.tls_sslkeylogfile {
+                        tls.key_log = Arc::new(rustls::KeyLogFile::new());
+                    }
 
                     // ALPN protocol
                     match config.http_version_pref {
@@ -2020,6 +2028,24 @@ impl ClientBuilder {
         self
     }
 
+    /// Controls if the SSLKEYLOGFILE environment variable is respected.
+    ///
+    /// When enabled, if the environment variable `SSLKEYLOGFILE` is present at runtime,
+    /// TLS keys will be logged to the file at the path described in the variable.
+    /// This can be used by end-users to allow debugging TLS connections.
+    ///
+    /// Defaults to `false`.
+    ///
+    /// # Optional
+    ///
+    /// This requires the `rustls(-...)` Cargo feature enabled.
+    #[cfg(feature = "__rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
+    pub fn tls_sslkeylogfile(mut self, on: bool) -> ClientBuilder {
+        self.config.tls_sslkeylogfile = on;
+        self
+    }
+
     /// Set the minimum required TLS version for connections.
     ///
     /// By default, the TLS backend's own default is used.
@@ -2837,6 +2863,11 @@ impl Config {
             f.field("tls_sni", &self.tls_sni);
 
             f.field("tls_info", &self.tls_info);
+        }
+
+        #[cfg(feature = "__rustls")]
+        {
+            f.field("tls_sslkeylogfile", &self.tls_sslkeylogfile);
         }
 
         #[cfg(all(feature = "default-tls", feature = "__rustls"))]

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -946,6 +946,23 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.tls_sni(tls_sni))
     }
 
+    /// Controls if the SSLKEYLOGFILE environment variable is respected.
+    ///
+    /// When enabled, if the environment variable `SSLKEYLOGFILE` is present at runtime,
+    /// TLS keys will be logged to the file at the path described in the variable.
+    /// This can be used by end-users to allow debugging TLS connections.
+    ///
+    /// Defaults to `false`.
+    ///
+    /// # Optional
+    ///
+    /// This requires the `rustls(-...)` Cargo feature enabled.
+    #[cfg(feature = "__rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
+    pub fn tls_sslkeylogfile(self, on: bool) -> ClientBuilder {
+        self.with_inner(|inner| inner.tls_sslkeylogfile(on))
+    }
+
     /// Set the minimum required TLS version for connections.
     ///
     /// By default, the TLS backend's own default is used.


### PR DESCRIPTION
Fixes #2676
Ref #1016

Adds a tls_sslkeylogfile(bool) builder method that allows usage of the `SSLKEYLOGFILE` environment variable at runtime (for the rustls backend only).

I made it take a boolean so that if at some latter point the project wants to switch the default (currently `false`) it will be possible.