### PR TITLE
fix http2 feature is not enabled for "native-tls"

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -531,7 +531,11 @@ impl ClientBuilder {
                                 tls.request_alpns(&["h2"]);
                             }
                             HttpVersionPref::All => {
-                                tls.request_alpns(&["h2", "http/1.1"]);
+                                tls.request_alpns(&[
+                                    #[cfg(feature = "http2")]
+                                    "h2",
+                                    "http/1.1",
+                                ]);
                             }
                         }
                     }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -371,6 +371,21 @@ fn use_preconfigured_rustls_default() {
         .expect("preconfigured rustls tls");
 }
 
+#[cfg(all(feature = "__tls", not(any(feature = "http2", feature = "http3")),))]
+#[tokio::test]
+async fn http1_only() {
+    let res = reqwest::Client::builder()
+        .build()
+        .expect("client builder")
+        .get("https://google.com")
+        .send()
+        .await
+        .expect("request");
+
+    assert_eq!(res.status(), reqwest::StatusCode::OK);
+    assert_eq!(res.version(), reqwest::Version::HTTP_11);
+}
+
 #[cfg(feature = "__rustls")]
 #[tokio::test]
 #[ignore = "Needs TLS support in the test server"]


### PR DESCRIPTION
```
[dependencies.reqwest]
version = "0.13"
default-features = false
features = [
    "blocking",
    "native-tls",
]
```

```
16:19:09 [INFO] GET https://derpibooru.org/api/v1/json/search/images?key=&page=1&per_page=50&q=safe
16:19:09 [DEBUG] (2) reqwest::connect: starting new connection: https://derpibooru.org/

thread 'reqwest-internal-sync-runtime' (2185360) panicked at /home/fox/opt/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hyper-util-0.1.19/src/client/legacy/client.rs:564:33:
http2 feature is not enabled
```