### PR TITLE
Specify h3 alpn for http3 connector

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -633,9 +633,12 @@ impl ClientBuilder {
                 TlsBackend::BuiltRustls(conn) => {
                     #[cfg(feature = "http3")]
                     {
+                        let mut h3_tls = conn.clone();
+                        h3_tls.alpn_protocols = vec!["h3".into()];
+
                         h3_connector = build_h3_connector(
                             resolver.clone(),
-                            conn.clone(),
+                            h3_tls,
                             config.quic_max_idle_timeout,
                             config.quic_stream_receive_window,
                             config.quic_receive_window,
@@ -814,7 +817,7 @@ impl ClientBuilder {
                         }
                         #[cfg(feature = "http3")]
                         HttpVersionPref::Http3 => {
-                            tls.alpn_protocols = vec!["h3".into()];
+                            // h3 ALPN is not valid over TCP
                         }
                         HttpVersionPref::All => {
                             tls.alpn_protocols = vec![
@@ -827,11 +830,15 @@ impl ClientBuilder {
 
                     #[cfg(feature = "http3")]
                     {
-                        tls.enable_early_data = config.tls_enable_early_data;
+                        let mut h3_tls = tls.clone();
+                        h3_tls.enable_early_data = config.tls_enable_early_data;
+
+                        // h3 ALPN is required over QUIC for HTTP/3
+                        h3_tls.alpn_protocols = vec!["h3".into()];
 
                         h3_connector = build_h3_connector(
                             resolver.clone(),
-                            tls.clone(),
+                            h3_tls,
                             config.quic_max_idle_timeout,
                             config.quic_stream_receive_window,
                             config.quic_receive_window,


### PR DESCRIPTION
I've been trying to get HTTP/3 working, and observed the following behaviour (with v0.13.1):

- AWS CloudFront server
    - client defaults
        - no request version specified
            - Works, uses HTTP/2
        - request.version = HTTP_2
            - Works, uses HTTP/2
        - request.version = HTTP_3
            - ERROR: `ConnectionClosed(ConnectionClose { error_code: Code::crypto(28) })`
    - client with http3_prior_knowledge
        - no request version specified
            - Works, uses HTTP/1.1
        - request.version = HTTP_2
            - ERROR: `hyper_util::client::legacy::Error(UserUnsupportedVersion)`
        - request.version = HTTP_3
            - Works, uses HTTP/3
- Google (`https://google.com/`)
    - defaults
        - no request version specified
            - Works, uses HTTP/2
        - request.version = HTTP_2
            - Works, uses HTTP/2
        - request.version = HTTP_3
            - ERROR: `handshake failure routines:OPENSSL_internal:NO_APPLICATION_PROTOCOL`
    - http3_prior_knowledge
        - no request version specified
            - ERROR: `hyper_util::client::legacy::Error(Connect, Custom { AlertReceived(NoApplicationProtocol) })`
        - request.version = HTTP_2
            - ERROR: `hyper_util::client::legacy::Error(UserUnsupportedVersion)`
        - request.version = HTTP_3
            - Works, uses HTTP/3

That is, it seems impossible to connect with HTTP/3 if `http3_prior_knowledge()` isn't specified, and at the same time, if it _is_ specified, then HTTP/1 and /2 cannot be used (that makes sense) unless the server is a bit lax and does HTTP/1.1 when it can't negotiate an ALPN (AWS CloudFront, but not Google).

Digging into the code, this seems to be because:

1. the `h3` ALPN is only sent if `http3_prior_knowledge()` is specified,
2. if `http3_prior_knowledge()` is specified and `request.version` isn't explicitly HTTP_3, then the request gets made with the hyper client, and with a rustls configured to send only the `h3` ALPN.

That makes it impossible to configure a client for _both_ HTTP/3 and others at the same time.

This PR:

- _overrides_ the ALPN set to just `[h3]` when creating the h3_connector from builder
- _removes_ the `h3` ALPN from being added to the TCP/hyper client when looking at http version prefs
 
This then leaves the ALPN set empty for the hyper client when using `http3_prior_knowledge()` — I'm not sure whether that's correct. Also maybe having http3_prior_knowledge should force or default `version = HTTP_3` for requests executed on that client? That was discussed [here](https://github.com/seanmonstar/reqwest/issues/2808#issuecomment-3228387693), I can make that change as a follow-up if you want.

In any case, with this change, the behaviour is:

- AWS CloudFront server
    - client defaults
        - no request version specified
            - Works, uses HTTP/2
        - request.version = HTTP_2
            - Works, uses HTTP/2
        - request.version = HTTP_3
            - Works, uses HTTP/3
    - client with http3_prior_knowledge
        - no request version specified
            - Works, uses HTTP/1.1
        - request.version = HTTP_2
            - ERROR: `hyper_util::client::legacy::Error(UserUnsupportedVersion)`
        - request.version = HTTP_3
            - Works, uses HTTP/3
- Google (`https://google.com/`)
    - defaults
        - no request version specified
            - Works, uses HTTP/2
        - request.version = HTTP_2
            - Works, uses HTTP/2
        - request.version = HTTP_3
            - Works, uses HTTP/3
    - http3_prior_knowledge
        - no request version specified
            - Works, uses HTTP/1.1
        - request.version = HTTP_2
            - ERROR: `hyper_util::client::legacy::Error(UserUnsupportedVersion)`
        - request.version = HTTP_3
            - Works, uses HTTP/3