### PR TITLE
chore: upgrade wasm-streams to v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ futures-util = { version = "0.3.28", default-features = false, features = ["std"
 js-sys = "0.3.77"
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.18"
-wasm-streams = { version = "0.4", optional = true }
+wasm-streams = { version = "0.5", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.28"


### PR DESCRIPTION
Fixes https://github.com/seanmonstar/reqwest/issues/2957

No breaking changes at all that seem to impact `reqwest`, see: https://github.com/MattiasBuelens/wasm-streams/compare/3bb7b55817393a2cf973f526414d7356e2ec5567...c512e77c4d7211f153913d1bdcf14903a9a15024

A simple bump from v0.4 -> v0.5.