### PR TITLE
chore(ci): add windows and linux arm64 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,13 @@ jobs:
       matrix:
         name:
           - linux / stable
+          - linux / stable-aarch64-gnu
           - linux / beta
           # - linux / nightly
           - macOS / stable
           - windows / stable-x86_64-msvc
           - windows / stable-i686-msvc
+          - windows / stable-aarch64-msvc
           - windows / stable-x86_64-gnu
           - windows / stable-i686-gnu
           - "feat.: default-tls disabled"
@@ -96,6 +98,9 @@ jobs:
 
         include:
           - name: linux / stable
+          - name: linux / stable-aarch64-gnu
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - name: linux / beta
             rust: beta
           # - name: linux / nightly
@@ -111,6 +116,11 @@ jobs:
           - name: windows / stable-i686-msvc
             os: windows-latest
             target: i686-pc-windows-msvc
+            features: "--features blocking,gzip,brotli,zstd,deflate,query,form,json,multipart,stream"
+            aws_lc_sys_prebuilt_nasm: 1
+          - name: windows / stable-aarch64-msvc
+            os: windows-11-arm
+            target: aarch64-pc-windows-msvc
             features: "--features blocking,gzip,brotli,zstd,deflate,query,form,json,multipart,stream"
             aws_lc_sys_prebuilt_nasm: 1
           - name: windows / stable-x86_64-gnu


### PR DESCRIPTION
GitHub already introduced `windows-11-arm` and `ubuntu-22.04-arm`/`ubuntu-24.04-arm` hosted runners last year. Their availability just got expanded to private repositories, which indicates that the platform has become stable. This PR adds both platforms to CI.