### PR TITLE
Implement IntoUrl for &Url

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -3110,7 +3110,7 @@ mod tests {
     async fn execute_request_rejects_invalid_urls() {
         let url_str = "hxxps://www.rust-lang.org/";
         let url = url::Url::parse(url_str).unwrap();
-        let result = crate::get(url.clone()).await;
+        let result = crate::get(&url).await;
 
         assert!(result.is_err());
         let err = result.err().unwrap();
@@ -3123,7 +3123,7 @@ mod tests {
     async fn execute_request_rejects_invalid_hostname() {
         let url_str = "https://{{hostname}}/";
         let url = url::Url::parse(url_str).unwrap();
-        let result = crate::get(url.clone()).await;
+        let result = crate::get(&url).await;
 
         assert!(result.is_err());
         let err = result.err().unwrap();

--- a/src/into_url.rs
+++ b/src/into_url.rs
@@ -7,6 +7,7 @@ use url::Url;
 pub trait IntoUrl: IntoUrlSealed {}
 
 impl IntoUrl for Url {}
+impl<'a> IntoUrl for &'a Url {}
 impl IntoUrl for String {}
 impl<'a> IntoUrl for &'a str {}
 impl<'a> IntoUrl for &'a String {}
@@ -36,6 +37,16 @@ impl IntoUrlSealed for Url {
         } else {
             Err(crate::error::url_bad_scheme(self))
         }
+    }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+impl<'a> IntoUrlSealed for &'a Url {
+    fn into_url(self) -> crate::Result<Url> {
+        self.clone().into_url()
     }
 
     fn as_str(&self) -> &str {


### PR DESCRIPTION
This was previously discussed in #412. Feel free to just close this, and accept my apology for wasting your time in that case. I just think maybe the reasoning there should be reconsidered.

In the general case, I agree: functions that need e.g. an owned `String` should just take a `String` argument. What makes this case special is that there's already a tacit admission that convenience matters here, i.e. `IntoUrl` existing and already accepting multiple types that require copying strings and parsing.

It's true that supporting `&Url` makes it possible for user code to do an extraneous clone unwittingly, but that's common in Rust. On the other hand, rejecting `&Url` makes it less convenient to use the more appropriate type, encouraging `format!` and `String`s instead. On the whole I imagine this makes the world's code a little worse? Who can say.

On the third hand, we are most likely about to do a network request. Presumably that swamps the overhead of copying a single string. Maybe it's best to optimize for convenience here. Thanks for hearing me out and thanks for reqwest.
