### PR TITLE
feat: as_bytes function

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -33,7 +33,6 @@ use crate::cookie::service::CookieService;
 use crate::dns::hickory::HickoryDnsResolver;
 use crate::dns::{gai::GaiResolver, DnsResolverWithOverrides, DynResolver, Resolve};
 use crate::error::{self, BoxError};
-use crate::into_url::try_uri;
 use crate::proxy::Matcher as ProxyMatcher;
 use crate::redirect::{self, TowerRedirectPolicy};
 #[cfg(feature = "__rustls")]
@@ -1449,6 +1448,7 @@ impl ClientBuilder {
         self
     }
 
+
     /// Set a timeout for only the connect phase of a `Client`.
     ///
     /// Default is `None`.
@@ -2571,6 +2571,109 @@ impl Client {
         self.execute_request(request)
     }
 
+    /// Prepare a request by merging headers and converting URL to URI.
+    ///
+    /// This is shared logic between `execute_request` and `request_bytes`.
+    /// It merges default headers from the client, converts the URL to a URI,
+    /// and merges proxy authentication and custom headers.
+    fn prepare_request_headers(
+        &self,
+        url: &Url,
+        headers: &mut HeaderMap,
+    ) -> crate::Result<Uri> {
+        // Merge default headers (same logic as execute_request)
+        for (key, value) in &self.inner.headers {
+            if let Entry::Vacant(entry) = headers.entry(key) {
+                entry.insert(value.clone());
+            }
+        }
+
+        let uri = match crate::into_url::try_uri(url) {
+            Ok(uri) => uri,
+            Err(_) => return Err(crate::error::url_invalid_uri(url.clone())),
+        };
+
+        // Merge proxy headers (same logic as execute_request)
+        self.proxy_auth(&uri, headers);
+        self.proxy_custom_headers(&uri, headers);
+
+        Ok(uri)
+    }
+
+    /// Get the raw HTTP request bytes that would be sent for a request.
+    ///
+    /// This serializes the request (including all merged headers from the client)
+    /// to HTTP/1.1 wire format bytes, exactly as they would be sent over the wire.
+    ///
+    /// Returns `None` if the body is a stream (non-reusable body).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # async fn example() -> Result<(), reqwest::Error> {
+    /// let client = reqwest::Client::new();
+    /// let request = client.post("https://httpbin.org/post")
+    ///     .json(&serde_json::json!({"key": "value"}))
+    ///     .build()?;
+    ///
+    /// if let Some(bytes) = client.request_bytes(&request)? {
+    ///     // Write to file, log, or do whatever you want
+    ///     std::fs::write("request.log", bytes)?;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn request_bytes(&self, req: &Request) -> crate::Result<Option<Vec<u8>>> {
+        // Clone the request (returns None if body is a stream, which we handle)
+        let mut req = match req.try_clone() {
+            Some(req) => req,
+            None => return Ok(None), // Streaming body
+        };
+
+        let url = req.url().clone();
+        let uri = self.prepare_request_headers(&url, req.headers_mut())?;
+
+        // Get body bytes if available
+        let body_bytes: &[u8] = match req.body() {
+            Some(body) => match body.as_bytes() {
+                Some(bytes) => bytes,
+                None => return Ok(None), // Shouldn't happen since try_clone succeeded
+            },
+            None => &[],
+        };
+
+        // Serialize the request to HTTP/1.1 wire format bytes
+        // This ensures we capture exactly what gets sent over the wire
+        let mut bytes = Vec::new();
+
+        // Write request line: METHOD /path?query HTTP/1.1\r\n
+        let path_and_query = uri
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("/");
+        bytes.extend_from_slice(format!("{} {} {:?}\r\n", req.method(), path_and_query, req.version()).as_bytes());
+
+        // Write headers - use the same iteration order as hyper would
+        for (name, value) in req.headers() {
+            // Write header name
+            bytes.extend_from_slice(name.as_str().as_bytes());
+            bytes.extend_from_slice(b": ");
+            
+            // Write header value - handle non-UTF-8 values the same way hyper does
+            // Hyper writes header values as bytes, so we do the same
+            bytes.extend_from_slice(value.as_bytes());
+            bytes.extend_from_slice(b"\r\n");
+        }
+
+        // Write empty line separating headers from body
+        bytes.extend_from_slice(b"\r\n");
+
+        // Write body
+        bytes.extend_from_slice(body_bytes);
+
+        Ok(Some(bytes))
+    }
+
     pub(super) fn execute_request(&self, req: Request) -> Pending {
         let (method, url, mut headers, body, version, extensions) = req.pieces();
         if url.scheme() != "http" && url.scheme() != "https" {
@@ -2582,42 +2685,31 @@ impl Client {
             return Pending::new_err(error::url_bad_scheme(url));
         }
 
-        // insert default headers in the request headers
-        // without overwriting already appended headers.
-        for (key, value) in &self.inner.headers {
-            if let Entry::Vacant(entry) = headers.entry(key) {
-                entry.insert(value.clone());
-            }
-        }
-
-        let uri = match try_uri(&url) {
+        let uri = match self.prepare_request_headers(&url, &mut headers) {
             Ok(uri) => uri,
-            _ => return Pending::new_err(error::url_invalid_uri(url)),
+            Err(e) => return Pending::new_err(e),
         };
 
         let body = body.unwrap_or_else(Body::empty);
 
-        self.proxy_auth(&uri, &mut headers);
-        self.proxy_custom_headers(&uri, &mut headers);
-
+        // Build the actual request with the body for sending
+        // This is the same request object that hyper will serialize
         let builder = hyper::Request::builder()
             .method(method.clone())
             .uri(uri)
             .version(version);
+        let mut hyper_req = builder.body(body).expect("valid request parts");
+        *hyper_req.headers_mut() = headers.clone();
 
         let in_flight = match version {
             #[cfg(feature = "http3")]
             http::Version::HTTP_3 if self.inner.h3_client.is_some() => {
-                let mut req = builder.body(body).expect("valid request parts");
-                *req.headers_mut() = headers.clone();
                 let mut h3 = self.inner.h3_client.as_ref().unwrap().clone();
-                ResponseFuture::H3(h3.call(req))
+                ResponseFuture::H3(h3.call(hyper_req))
             }
             _ => {
-                let mut req = builder.body(body).expect("valid request parts");
-                *req.headers_mut() = headers.clone();
                 let mut hyper = self.inner.hyper.clone();
-                ResponseFuture::Default(hyper.call(req))
+                ResponseFuture::Default(hyper.call(hyper_req))
             }
         };
 

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -298,6 +298,48 @@ impl RequestBuilder {
         self
     }
 
+    /// Get the raw HTTP request bytes that would be sent for this request.
+    ///
+    /// This serializes the request (including all merged headers from the client)
+    /// to HTTP/1.1 wire format bytes, exactly as they would be sent over the wire.
+    ///
+    /// Returns `None` if:
+    /// - The request is in an error state
+    /// - The body is a stream (non-reusable body)
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # async fn example() -> Result<(), reqwest::Error> {
+    /// let client = reqwest::Client::new();
+    /// let builder = client.post("https://httpbin.org/post")
+    ///     .json(&serde_json::json!({"key": "value"}));
+    ///
+    /// if let Some(bytes) = builder.as_bytes()? {
+    ///     // Write to file, log, or do whatever you want
+    ///     std::fs::write("request.log", bytes)?;
+    /// }
+    ///
+    /// let response = builder.send().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn as_bytes(&self) -> crate::Result<Option<Vec<u8>>> {
+        // Get a reference to the request to check for errors
+        let req = match &self.request {
+            Ok(req) => req,
+            Err(e) => {
+                // Convert the error to an owned error by creating a new one
+                // We can't clone Error, so we extract the error kind
+                return Err(crate::error::builder(format!("{}", e)));
+            }
+        };
+
+        // Delegate to the client's request_bytes method which handles
+        // all the header merging logic
+        self.client.request_bytes(req)
+    }
+
     /// Sends a multipart/form-data body.
     ///
     /// ```

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -547,3 +547,156 @@ async fn error_has_url() {
     let err = reqwest::get(u).await.unwrap_err();
     assert_eq!(err.url().map(AsRef::as_ref), Some(u), "{err:?}");
 }
+
+#[test]
+fn request_builder_as_bytes() {
+    let client = Client::new();
+    let builder = client
+        .post("https://httpbin.org/post")
+        .header("X-Custom-Header", "test-value")
+        .body("test body");
+
+    let bytes = builder.as_bytes().unwrap();
+    assert!(bytes.is_some());
+    let bytes = bytes.unwrap();
+
+    // Verify it's valid HTTP/1.1 wire format
+    let request_str = String::from_utf8_lossy(&bytes);
+    assert!(request_str.starts_with("POST /post HTTP/1.1\r\n"));
+    assert!(request_str.contains("X-Custom-Header: test-value\r\n"));
+    assert!(request_str.contains("\r\n\r\ntest body"));
+}
+
+#[test]
+fn request_builder_as_bytes_with_json() {
+    #[cfg(feature = "json")]
+    {
+        let client = Client::new();
+        let builder = client
+            .post("https://httpbin.org/post")
+            .json(&serde_json::json!({"key": "value"}));
+
+        let bytes = builder.as_bytes().unwrap();
+        assert!(bytes.is_some());
+        let bytes = bytes.unwrap();
+
+        let request_str = String::from_utf8_lossy(&bytes);
+        assert!(request_str.starts_with("POST /post HTTP/1.1\r\n"));
+        assert!(request_str.contains("Content-Type: application/json\r\n"));
+        assert!(request_str.contains(r#"{"key":"value"}"#));
+    }
+}
+
+#[test]
+fn request_builder_as_bytes_streaming_body() {
+    #[cfg(feature = "stream")]
+    {
+        use reqwest::Body;
+
+        let client = Client::new();
+        let stream = futures_util::stream::iter(vec![
+            Ok::<_, std::convert::Infallible>("hello"),
+            Ok::<_, std::convert::Infallible>(" "),
+            Ok::<_, std::convert::Infallible>("world"),
+        ]);
+        let builder = client
+            .post("https://httpbin.org/post")
+            .body(Body::wrap_stream(stream));
+
+        // Streaming bodies should return None
+        let bytes = builder.as_bytes().unwrap();
+        assert!(bytes.is_none());
+    }
+}
+
+#[test]
+fn client_request_bytes() {
+    let client = Client::new();
+    let request = client
+        .post("https://httpbin.org/post")
+        .header("X-Custom-Header", "test-value")
+        .body("test body")
+        .build()
+        .unwrap();
+
+    let bytes = client.request_bytes(&request).unwrap();
+    assert!(bytes.is_some());
+    let bytes = bytes.unwrap();
+
+    // Verify it's valid HTTP/1.1 wire format
+    let request_str = String::from_utf8_lossy(&bytes);
+    assert!(request_str.starts_with("POST /post HTTP/1.1\r\n"));
+    assert!(request_str.contains("X-Custom-Header: test-value\r\n"));
+    assert!(request_str.contains("\r\n\r\ntest body"));
+}
+
+#[test]
+fn client_request_bytes_with_default_headers() {
+    let client = Client::builder()
+        .user_agent("test-agent/1.0")
+        .build()
+        .unwrap();
+
+    let request = client.get("https://httpbin.org/get").build().unwrap();
+
+    let bytes = client.request_bytes(&request).unwrap();
+    assert!(bytes.is_some());
+    let bytes = bytes.unwrap();
+
+    let request_str = String::from_utf8_lossy(&bytes);
+    // Should include the default user-agent header
+    assert!(request_str.contains("User-Agent: test-agent/1.0\r\n"));
+    // Should include the default accept header
+    assert!(request_str.contains("Accept: */*\r\n"));
+}
+
+#[test]
+fn client_request_bytes_streaming_body() {
+    #[cfg(feature = "stream")]
+    {
+        use reqwest::Body;
+
+        let client = Client::new();
+        let stream = futures_util::stream::iter(vec![
+            Ok::<_, std::convert::Infallible>("hello"),
+            Ok::<_, std::convert::Infallible>(" "),
+            Ok::<_, std::convert::Infallible>("world"),
+        ]);
+        let request = client
+            .post("https://httpbin.org/post")
+            .body(Body::wrap_stream(stream))
+            .build()
+            .unwrap();
+
+        // Streaming bodies should return None
+        let bytes = client.request_bytes(&request).unwrap();
+        assert!(bytes.is_none());
+    }
+}
+
+#[test]
+fn request_bytes_format() {
+    let client = Client::new();
+    let request = client
+        .post("https://example.com/path?query=value")
+        .header("Content-Type", "application/json")
+        .body(r#"{"test": "data"}"#)
+        .build()
+        .unwrap();
+
+    let bytes = client.request_bytes(&request).unwrap().unwrap();
+    let request_str = String::from_utf8_lossy(&bytes);
+
+    // Verify request line format
+    assert!(request_str.starts_with("POST /path?query=value HTTP/1.1\r\n"));
+
+    // Verify headers are present
+    assert!(request_str.contains("Content-Type: application/json\r\n"));
+
+    // Verify header/body separator
+    let parts: Vec<&str> = request_str.split("\r\n\r\n").collect();
+    assert_eq!(parts.len(), 2);
+
+    // Verify body
+    assert_eq!(parts[1], r#"{"test": "data"}"#);
+}


### PR DESCRIPTION
Adds the ability to get the bytes that would be sent by the request.  This is useful for introspection and debugging - e.g. #2883 

I'm not wedded to this implementation, but a concrete proposal seemed a good way to get the conversation started @seanmonstar 