### PR TITLE
feat(rustls): add rustls-webpki-roots feature for certificate verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ http2 = ["dep:h2", "hyper/http2", "hyper-util/http2", "hyper-rustls?/http2"]
 
 rustls = ["__rustls-aws-lc-rs", "dep:rustls-platform-verifier", "__rustls"]
 rustls-no-provider = ["dep:rustls-platform-verifier", "__rustls"]
+rustls-webpki-roots = ["__rustls-aws-lc-rs", "dep:webpki-roots", "__rustls"]
+rustls-webpki-roots-no-provider = ["dep:webpki-roots", "__rustls"]
 
 native-tls = ["__native-tls", "__native-tls-alpn"]
 native-tls-no-alpn = ["__native-tls"]
@@ -142,6 +144,7 @@ hyper-rustls = { version = "0.27.0", default-features = false, optional = true, 
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
 rustls-platform-verifier = { version = "0.6", optional = true }
+webpki-roots = { version = "0.26", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -748,34 +748,44 @@ impl ClientBuilder {
                             ));
                         }
 
-                        let verifier = if config.root_certs.is_empty() {
-                            rustls_platform_verifier::Verifier::new(provider.clone())
-                                .map_err(crate::error::builder)?
-                        } else {
-                            #[cfg(any(
-                                all(unix, not(target_os = "android")),
-                                target_os = "windows"
-                            ))]
-                            {
-                                rustls_platform_verifier::Verifier::new_with_extra_roots(
-                                    crate::tls::rustls_der(config.root_certs)?,
-                                    provider.clone(),
-                                )
-                                .map_err(crate::error::builder)?
-                            }
+                        #[cfg(feature = "rustls-webpki-roots-no-provider")]
+                        {
+                            let mut root_cert_store = crate::tls::rustls_store(config.root_certs)?;
+                            root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+                            config_builder.with_root_certificates(root_cert_store)
+                        }
 
-                            #[cfg(not(any(
-                                all(unix, not(target_os = "android")),
-                                target_os = "windows"
-                            )))]
-                            return Err(crate::error::builder(
-                                "rustls-platform-verifier could not load extra certs",
-                            ));
-                        };
+                        #[cfg(not(feature = "rustls-webpki-roots-no-provider"))]
+                        {
+                            let verifier = if config.root_certs.is_empty() {
+                                rustls_platform_verifier::Verifier::new(provider.clone())
+                                    .map_err(crate::error::builder)?
+                            } else {
+                                #[cfg(any(
+                                    all(unix, not(target_os = "android")),
+                                    target_os = "windows"
+                                ))]
+                                {
+                                    rustls_platform_verifier::Verifier::new_with_extra_roots(
+                                        crate::tls::rustls_der(config.root_certs)?,
+                                        provider.clone(),
+                                    )
+                                    .map_err(crate::error::builder)?
+                                }
 
-                        config_builder
-                            .dangerous()
-                            .with_custom_certificate_verifier(Arc::new(verifier))
+                                #[cfg(not(any(
+                                    all(unix, not(target_os = "android")),
+                                    target_os = "windows"
+                                )))]
+                                return Err(crate::error::builder(
+                                    "rustls-platform-verifier could not load extra certs",
+                                ));
+                            };
+
+                            config_builder
+                                .dangerous()
+                                .with_custom_certificate_verifier(Arc::new(verifier))
+                        }
                     } else {
                         if config.crls.is_empty() {
                             config_builder.with_root_certificates(crate::tls::rustls_store(


### PR DESCRIPTION
## Summary

Adds `rustls-webpki-roots` and `rustls-webpki-roots-no-provider` feature flags that use `webpki-roots` for TLS certificate verification instead of `rustls-platform-verifier`.

## Motivation

On Android, `rustls-platform-verifier` requires explicit JNI initialization via `rustls_platform_verifier::android::init_hosted()` before any network activity. This adds significant complexity for Android apps using Rust for networking.

In reqwest 0.12, the `rustls-tls-webpki-roots` feature provided a simple alternative that worked on Android without JNI initialization. This PR restores that capability for 0.13.

## Changes

- **Cargo.toml**: Added `rustls-webpki-roots` (with aws-lc-rs provider) and `rustls-webpki-roots-no-provider` features, plus `webpki-roots` v0.26 as an optional dependency
- **src/async_impl/client.rs**: When `rustls-webpki-roots-no-provider` is enabled, builds a `RootCertStore` from `webpki_roots::TLS_SERVER_ROOTS` (plus any user-provided certs) and uses rustls's standard `with_root_certificates()` instead of `rustls_platform_verifier`

## Usage

```toml
# With aws-lc-rs (default crypto provider)
reqwest = { version = "0.13", default-features = false, features = ["rustls-webpki-roots"] }

# With your own crypto provider
reqwest = { version = "0.13", default-features = false, features = ["rustls-webpki-roots-no-provider"] }
```

## Design

- Purely additive — no changes to existing behavior
- Mirrors the `rustls`/`rustls-no-provider` pattern for the new features
- When the feature is not enabled, the existing `rustls-platform-verifier` path is completely unchanged
- User-provided root certificates (via `add_root_certificate()`) are merged with the webpki roots

Closes #2968