### PR TITLE
Validate PEM format in Certificate::from_pem for rustls

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -167,6 +167,17 @@ impl Certificate {
     /// # }
     /// ```
     pub fn from_pem(pem: &[u8]) -> crate::Result<Certificate> {
+        #[cfg(feature = "__rustls")]
+        {
+            // Validate that the input is actually PEM-encoded before storing it.
+            // Without this check, DER-encoded bytes would be silently accepted
+            // but fail later when the certificate is used.
+            let mut reader = std::io::BufReader::new(pem);
+            let certs = Self::read_pem_certs(&mut reader)?;
+            if certs.is_empty() {
+                return Err(crate::error::builder("no PEM certificate found in input"));
+            }
+        }
         Ok(Certificate {
             #[cfg(feature = "__native-tls")]
             native: native_tls_crate::Certificate::from_pem(pem).map_err(crate::error::builder)?,
@@ -795,6 +806,20 @@ mod tests {
     #[test]
     fn certificate_from_pem_invalid() {
         Certificate::from_pem(b"not pem").unwrap_err();
+    }
+
+    #[cfg(feature = "__rustls")]
+    #[test]
+    fn certificate_from_pem_invalid_rustls() {
+        Certificate::from_pem(b"not pem").unwrap_err();
+    }
+
+    #[cfg(feature = "__rustls")]
+    #[test]
+    fn certificate_from_pem_rejects_der() {
+        // DER-encoded bytes should not be accepted by from_pem
+        let der = b"\x30\x82\x01\x22"; // minimal DER prefix
+        Certificate::from_pem(der).unwrap_err();
     }
 
     #[cfg(feature = "__native-tls")]


### PR DESCRIPTION
Fixes #1858

`Certificate::from_pem` with the rustls backend was silently accepting DER-encoded input, only failing later during the TLS handshake with a confusing error. This happened because the rustls path just stored the raw bytes without any validation.

Now it eagerly parses the PEM data upfront using `rustls_pemfile::certs` and returns a clear error if no valid PEM certificates are found. The native-tls backend already validated eagerly, so this brings rustls in line.

Added two tests to verify the behavior:
- `certificate_from_pem_invalid_rustls` - rejects garbage input
- `certificate_from_pem_rejects_der` - rejects DER-encoded bytes

```
running 7 tests
test tls::tests::certificate_from_pem ... ok
test tls::tests::certificate_from_pem_invalid_rustls ... ok
test tls::tests::certificate_from_pem_rejects_der ... ok
test tls::tests::certificate_from_der ... ok
test tls::tests::identity_from_pkcs12_der ... ok
test tls::tests::identity_from_pkcs8_pem ... ok
test tls::tests::identity_from_pem ... ok
```