### PR TITLE
fix: upgrade quinn and fix RUSTSEC-2026-0037 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ once_cell = { version = "1.18", optional = true }
 # HTTP/3 experimental support
 h3 = { version = "0.0.8", optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
-quinn = { version = "0.11.1", default-features = false, features = [
+quinn = { version = "0.11.4", default-features = false, features = [
     "runtime-tokio",
 ], optional = true }
 futures-channel = { version = "0.3", optional = true }


### PR DESCRIPTION
This PR should address [RUSTSEC-2026-0037](https://rustsec.org/advisories/RUSTSEC-2026-0037) (fixed with https://github.com/quinn-rs/quinn/pull/2559).