### PR TITLE
resolve: debug log to change only host

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -781,8 +781,7 @@ impl ConnectorService {
     }
 
     async fn connect_via_proxy(self, dst: Uri, proxy: Intercepted) -> Result<Conn, BoxError> {
-        let host = dst.host();
-        log::debug!("starting new connection '{host:?}'");
+        log::debug!("proxy({proxy:?}) intercepts '{:?}'", dst.host());
 
         #[cfg(feature = "socks")]
         match proxy.uri().scheme_str().ok_or("proxy scheme expected")? {
@@ -927,8 +926,7 @@ impl Service<Uri> for ConnectorService {
     }
 
     fn call(&mut self, dst: Uri) -> Self::Future {
-        let host = dst.host();
-        log::debug!("starting new connection '{host:?}'");
+        log::debug!("starting new connection '{:?}'", dst.host());
         let timeout = self.simple_timeout;
 
         // Local transports (UDS, Windows Named Pipes) skip proxies


### PR DESCRIPTION
change debug log

I changed it so that only the hostName is displayed, whereas previously the full URI was being displayed.

Clost #2971
 