### PR TITLE
Edit reference link 

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -3,8 +3,8 @@ use std::fmt;
 
 pub fn basic_auth<U, P>(username: U, password: Option<P>) -> HeaderValue
 where
-    U: std::fmt::Display,
-    P: std::fmt::Display,
+    U: fmt::Display,
+    P: fmt::Display,
 {
     use base64::prelude::BASE64_STANDARD;
     use base64::write::EncoderWriter;


### PR DESCRIPTION
Upon checking, I confirmed that the links are working correctly, with the exception of the comment regarding rust-lang.

It appears that the link for rust-lang was changed when the reference page was separated.

closed #2995 