### PR TITLE
Expose url::ParseError, so the documentation for Url struct links to correct enum page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,7 @@ macro_rules! if_hyper {
 pub use http::header;
 pub use http::Method;
 pub use http::{StatusCode, Version};
+pub use url::ParseError; // For correct docs of reexported Url struct
 pub use url::Url;
 
 // universal mods


### PR DESCRIPTION
Problem: the current docs for Url struct, for example 
https://docs.rs/reqwest/latest/reqwest/struct.Url.html#method.parse
link ParseError in the method Errors section. However, there is no ParseError enum, so the link is broken: https://docs.rs/reqwest/latest/reqwest/enum.ParseError.html

By reexporting also the ParseError enum, the link will become valid.