### PR TITLE
use wasm-bindgen ecosystem only for wasm32-unknown-* target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ serde_json = { version = "1.0", optional = true }
 ## multipart
 mime_guess = { version = "2.0", default-features = false, optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))'.dependencies]
 encoding_rs = { version = "0.8", optional = true }
 http-body = "1"
 http-body-util = "0.1.2"
@@ -160,7 +160,7 @@ h3-quinn = { version = "0.0.10", optional = true }
 quinn = { version = "0.11.1", default-features = false, features = ["runtime-tokio"], optional = true }
 futures-channel = { version = "0.3", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))'.dev-dependencies]
 env_logger = "0.10"
 hyper = { version = "1.1.0", default-features = false, features = ["http1", "http2", "client", "server"] }
 hyper-util = { version = "0.1.12", features = ["http1", "http2", "client", "client-legacy", "server-auto", "server-graceful", "tokio"] }
@@ -174,13 +174,13 @@ futures-util = { version = "0.3.28", default-features = false, features = ["std"
 
 # wasm
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies]
 js-sys = "0.3.77"
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.18"
 wasm-streams = { version = "0.5", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies.web-sys]
 version = "0.3.28"
 features = [
     "AbortController",
@@ -201,7 +201,7 @@ features = [
     "RequestCache"
 ]
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen = { version = "0.2.89", features = ["serde-serialize"] }
 wasm-bindgen-test = "0.3"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -334,12 +334,15 @@ pub(crate) fn redirect<E: Into<BoxError>>(e: E, url: Url) -> Error {
 pub(crate) fn status_code(
     url: Url,
     status: StatusCode,
-    #[cfg(not(target_arch = "wasm32"))] reason: Option<hyper::ext::ReasonPhrase>,
+    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))] reason: Option<hyper::ext::ReasonPhrase>,
 ) -> Error {
     Error::new(
         Kind::Status(
             status,
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(not(all(
+                target_arch = "wasm32",
+                any(target_os = "unknown", target_os = "none")
+            )))]
             reason,
         ),
         None::<Error>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,11 +105,11 @@ impl Error {
 
     /// Returns true if the error is from `Response::error_for_status`.
     pub fn is_status(&self) -> bool {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
         {
             matches!(self.inner.kind, Kind::Status(_, _))
         }
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
         {
             matches!(self.inner.kind, Kind::Status(_))
         }
@@ -123,7 +123,10 @@ impl Error {
             if err.is::<TimedOut>() {
                 return true;
             }
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(not(all(
+                target_arch = "wasm32",
+                any(target_os = "unknown", target_os = "none")
+            )))]
             if let Some(hyper_err) = err.downcast_ref::<hyper::Error>() {
                 if hyper_err.is_timeout() {
                     return true;
@@ -145,7 +148,7 @@ impl Error {
         matches!(self.inner.kind, Kind::Request)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
     /// Returns true if the error is related to connect
     pub fn is_connect(&self) -> bool {
         let mut source = self.source();
@@ -176,9 +179,12 @@ impl Error {
     /// Returns the status code, if the error was generated from a response.
     pub fn status(&self) -> Option<StatusCode> {
         match self.inner.kind {
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
             Kind::Status(code) => Some(code),
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(not(all(
+                target_arch = "wasm32",
+                any(target_os = "unknown", target_os = "none")
+            )))]
             Kind::Status(code, _) => Some(code),
             _ => None,
         }
@@ -236,7 +242,7 @@ impl fmt::Display for Error {
             Kind::Decode => f.write_str("error decoding response body")?,
             Kind::Redirect => f.write_str("error following redirect")?,
             Kind::Upgrade => f.write_str("error upgrading connection")?,
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
             Kind::Status(ref code) => {
                 let prefix = if code.is_client_error() {
                     "HTTP status client error"
@@ -246,7 +252,10 @@ impl fmt::Display for Error {
                 };
                 write!(f, "{prefix} ({code})")?;
             }
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(not(all(
+                target_arch = "wasm32",
+                any(target_os = "unknown", target_os = "none")
+            )))]
             Kind::Status(ref code, ref reason) => {
                 let prefix = if code.is_client_error() {
                     "HTTP status client error"

--- a/src/error.rs
+++ b/src/error.rs
@@ -300,9 +300,9 @@ pub(crate) enum Kind {
     Builder,
     Request,
     Redirect,
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
     Status(StatusCode, Option<hyper::ext::ReasonPhrase>),
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
     Status(StatusCode),
     Body,
     Decode,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(target_arch = "wasm32", allow(unused))]
+#![cfg_attr(
+    all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+    allow(unused)
+)]
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
@@ -198,7 +201,7 @@ impl Error {
 /// internal equivalents.
 ///
 /// Currently only is used for `tower::timeout::error::Elapsed`.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
 pub(crate) fn cast_to_internal_error(error: BoxError) -> BoxError {
     if error.is::<tower::timeout::error::Elapsed>() {
         Box::new(crate::error::TimedOut) as BoxError
@@ -278,14 +281,14 @@ impl StdError for Error {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
 impl From<crate::error::Error> for wasm_bindgen::JsValue {
     fn from(err: Error) -> wasm_bindgen::JsValue {
         js_sys::Error::from(err).into()
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
 impl From<crate::error::Error> for js_sys::Error {
     fn from(err: Error) -> js_sys::Error {
         js_sys::Error::new(&format!("{err}"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,14 +264,14 @@ use sync_wrapper as _;
 
 macro_rules! if_wasm {
     ($($item:item)*) => {$(
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
         $item
     )*}
 }
 
 macro_rules! if_hyper {
     ($($item:item)*) => {$(
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
         $item
     )*}
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,7 +24,7 @@ where
     header
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
 pub(crate) fn fast_random() -> u64 {
     use std::cell::Cell;
     use std::collections::hash_map::RandomState;
@@ -77,7 +77,7 @@ pub(crate) fn replace_headers(dst: &mut HeaderMap, src: HeaderMap) {
 }
 
 #[cfg(feature = "cookies")]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
 pub(crate) fn add_cookie_header(
     headers: &mut HeaderMap,
     cookie_store: &dyn crate::cookie::CookieStore,
@@ -90,7 +90,7 @@ pub(crate) fn add_cookie_header(
 
 pub(crate) struct Escape<'a>(&'a [u8]);
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
 impl<'a> Escape<'a> {
     pub(crate) fn new(bytes: &'a [u8]) -> Self {
         Escape(bytes)


### PR DESCRIPTION
Wasi target doesn't need wasm-bindgen crates ecosystem.

So only use them on `wasm32-unknown-unknown` or `wasm32-unknown-none` target