### PR TITLE
[HTTP/3] Optimize IPv6 fallback and enforce HTTPS scheme #2911

### DIFF
--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -135,10 +135,11 @@ impl H3Connector {
         }
 
         if ipv6_addrs.is_empty() {
-            return Self::try_addresses_static(&self.endpoint,
+            return Self::try_addresses_static(
+                &self.endpoint,
                 &ipv4_addrs,
                 server_name,
-                &self.client_config
+                &self.client_config,
             )
             .await;
         }
@@ -147,7 +148,7 @@ impl H3Connector {
                 &self.endpoint,
                 &ipv6_addrs,
                 server_name,
-                &self.client_config
+                &self.client_config,
             )
             .await;
         }
@@ -155,12 +156,12 @@ impl H3Connector {
         let endpoint = self.endpoint.clone();
         let client_config = self.client_config.clone();
 
-        match Self::try_addresses_static(&endpoint, &ipv6_addrs, server_name, &client_config).await 
+        match Self::try_addresses_static(&endpoint, &ipv6_addrs, server_name, &client_config).await
         {
             Ok(conn) => Ok(conn),
             Err(_) => {
                 Self::try_addresses_static(&endpoint, &ipv4_addrs, server_name, &client_config)
-                .await
+                    .await
             }
         }
     }

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -59,6 +59,7 @@ pub(crate) struct H3Connector {
     resolver: DynResolver,
     endpoint: Endpoint,
     client_config: H3ClientConfig,
+    local_addr: Option<IpAddr>,
 }
 
 impl H3Connector {
@@ -86,6 +87,7 @@ impl H3Connector {
             resolver,
             endpoint,
             client_config,
+            local_addr,
         })
     }
 
@@ -117,28 +119,74 @@ impl H3Connector {
         addrs: Vec<SocketAddr>,
         server_name: &str,
     ) -> Result<H3Connection, BoxError> {
-        let mut err = None;
-        for addr in addrs {
-            match self.endpoint.connect(addr, server_name)?.await {
-                Ok(new_conn) => {
-                    let quinn_conn = Connection::new(new_conn);
-                    let mut h3_client_builder = h3::client::builder();
-                    if let Some(max_field_section_size) = self.client_config.max_field_section_size
-                    {
-                        h3_client_builder.max_field_section_size(max_field_section_size);
-                    }
-                    if let Some(send_grease) = self.client_config.send_grease {
-                        h3_client_builder.send_grease(send_grease);
-                    }
-                    return Ok(h3_client_builder.build(quinn_conn).await?);
-                }
-                Err(e) => err = Some(e),
+        if addrs.is_empty() {
+            return Err("no addresses to connect to".into());
+        }
+
+        let (mut ipv6_addrs, mut ipv4_addrs): (Vec<SocketAddr>, Vec<SocketAddr>) =
+            addrs.into_iter().partition(|addr| addr.is_ipv6());
+
+        if let Some(local_ip) = self.local_addr {
+            if local_ip.is_ipv6() {
+                ipv4_addrs.clear();
+            } else {
+                ipv6_addrs.clear();
             }
         }
 
-        match err {
-            Some(e) => Err(Box::new(e) as BoxError),
-            None => Err("failed to establish connection for HTTP/3 request".into()),
+        if ipv6_addrs.is_empty() {
+            return Self::try_addresses_static(&self.endpoint, &ipv4_addrs, server_name, &self.client_config).await;
         }
+        if ipv4_addrs.is_empty() {
+            return Self::try_addresses_static(&self.endpoint, &ipv6_addrs, server_name, &self.client_config).await;
+        }
+
+        let endpoint = self.endpoint.clone();
+        let client_config = self.client_config.clone();
+
+        match Self::try_addresses_static(&endpoint, &ipv6_addrs, server_name, &client_config).await {
+            Ok(conn) => Ok(conn),
+            Err(_) => {
+                Self::try_addresses_static(&endpoint, &ipv4_addrs, server_name, &client_config).await
+            }
+        }
+    }
+
+    async fn try_addresses_static(
+        endpoint: &Endpoint,
+        addrs: &[SocketAddr],
+        server_name: &str,
+        client_config: &H3ClientConfig,
+    ) -> Result<H3Connection, BoxError> {
+        let mut last_err: Option<BoxError> = None;
+
+        for addr in addrs {
+            match endpoint.connect(*addr, server_name) {
+                Ok(connecting) => {
+                    match connecting.await {
+                        Ok(new_conn) => {
+                            let quinn_conn = Connection::new(new_conn);
+                            let mut h3_client_builder = h3::client::builder();
+                            if let Some(max_field_section_size) = client_config.max_field_section_size
+                            {
+                                h3_client_builder.max_field_section_size(max_field_section_size);
+                            }
+                            if let Some(send_grease) = client_config.send_grease {
+                                h3_client_builder.send_grease(send_grease);
+                            }
+                            return Ok(h3_client_builder.build(quinn_conn).await?);
+                        }
+                        Err(e) => {
+                            last_err = Some(Box::new(e) as BoxError);
+                        }
+                    }
+                }
+                Err(e) => {
+                    last_err = Some(Box::new(e) as BoxError);
+                }
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| "no addresses available".into()))
     }
 }

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -59,7 +59,7 @@ pub(crate) struct H3Connector {
     resolver: DynResolver,
     endpoint: Endpoint,
     client_config: H3ClientConfig,
-    local_addr: Option<IpAddr>,
+    bound_addr: IpAddr,
 }
 
 impl H3Connector {
@@ -75,19 +75,23 @@ impl H3Connector {
         // FIXME: Replace this when there is a setter.
         config.transport_config(Arc::new(transport_config));
 
+        // Pipe the local address through to the endpoint creation
         let socket_addr = match local_addr {
             Some(ip) => SocketAddr::new(ip, 0),
-            None => "[::]:0".parse::<SocketAddr>().unwrap(),
+            None => "0.0.0.0:0".parse::<SocketAddr>().unwrap(),
         };
 
         let mut endpoint = Endpoint::client(socket_addr)?;
         endpoint.set_default_client_config(config);
 
+        // Get the actual bound address from the endpoint
+        let bound_addr = endpoint.local_addr()?.ip();
+
         Ok(Self {
             resolver,
             endpoint,
             client_config,
-            local_addr,
+            bound_addr,
         })
     }
 
@@ -126,12 +130,10 @@ impl H3Connector {
         let (mut ipv6_addrs, mut ipv4_addrs): (Vec<SocketAddr>, Vec<SocketAddr>) =
             addrs.into_iter().partition(|addr| addr.is_ipv6());
 
-        if let Some(local_ip) = self.local_addr {
-            if local_ip.is_ipv6() {
-                ipv4_addrs.clear();
-            } else {
-                ipv6_addrs.clear();
-            }
+        if self.bound_addr.is_ipv6() {
+            ipv4_addrs.clear();
+        } else {
+            ipv6_addrs.clear();
         }
 
         if ipv6_addrs.is_empty() {

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -78,7 +78,7 @@ impl H3Connector {
         // Pipe the local address through to the endpoint creation
         let socket_addr = match local_addr {
             Some(ip) => SocketAddr::new(ip, 0),
-            None => "0.0.0.0:0".parse::<SocketAddr>().unwrap(),
+            None => "[::]:0".parse::<SocketAddr>().unwrap(),
         };
 
         let mut endpoint = Endpoint::client(socket_addr)?;

--- a/src/async_impl/h3_client/connect.rs
+++ b/src/async_impl/h3_client/connect.rs
@@ -135,19 +135,32 @@ impl H3Connector {
         }
 
         if ipv6_addrs.is_empty() {
-            return Self::try_addresses_static(&self.endpoint, &ipv4_addrs, server_name, &self.client_config).await;
+            return Self::try_addresses_static(&self.endpoint,
+                &ipv4_addrs,
+                server_name,
+                &self.client_config
+            )
+            .await;
         }
         if ipv4_addrs.is_empty() {
-            return Self::try_addresses_static(&self.endpoint, &ipv6_addrs, server_name, &self.client_config).await;
+            return Self::try_addresses_static(
+                &self.endpoint,
+                &ipv6_addrs,
+                server_name,
+                &self.client_config
+            )
+            .await;
         }
 
         let endpoint = self.endpoint.clone();
         let client_config = self.client_config.clone();
 
-        match Self::try_addresses_static(&endpoint, &ipv6_addrs, server_name, &client_config).await {
+        match Self::try_addresses_static(&endpoint, &ipv6_addrs, server_name, &client_config).await 
+        {
             Ok(conn) => Ok(conn),
             Err(_) => {
-                Self::try_addresses_static(&endpoint, &ipv4_addrs, server_name, &client_config).await
+                Self::try_addresses_static(&endpoint, &ipv4_addrs, server_name, &client_config)
+                .await
             }
         }
     }
@@ -162,25 +175,22 @@ impl H3Connector {
 
         for addr in addrs {
             match endpoint.connect(*addr, server_name) {
-                Ok(connecting) => {
-                    match connecting.await {
-                        Ok(new_conn) => {
-                            let quinn_conn = Connection::new(new_conn);
-                            let mut h3_client_builder = h3::client::builder();
-                            if let Some(max_field_section_size) = client_config.max_field_section_size
-                            {
-                                h3_client_builder.max_field_section_size(max_field_section_size);
-                            }
-                            if let Some(send_grease) = client_config.send_grease {
-                                h3_client_builder.send_grease(send_grease);
-                            }
-                            return Ok(h3_client_builder.build(quinn_conn).await?);
+                Ok(connecting) => match connecting.await {
+                    Ok(new_conn) => {
+                        let quinn_conn = Connection::new(new_conn);
+                        let mut h3_client_builder = h3::client::builder();
+                        if let Some(max_field_section_size) = client_config.max_field_section_size {
+                            h3_client_builder.max_field_section_size(max_field_section_size);
                         }
-                        Err(e) => {
-                            last_err = Some(Box::new(e) as BoxError);
+                        if let Some(send_grease) = client_config.send_grease {
+                            h3_client_builder.send_grease(send_grease);
                         }
+                        return Ok(h3_client_builder.build(quinn_conn).await?);
                     }
-                }
+                    Err(e) => {
+                        last_err = Some(Box::new(e) as BoxError);
+                    }
+                },
                 Err(e) => {
                     last_err = Some(Box::new(e) as BoxError);
                 }

--- a/src/async_impl/h3_client/pool.rs
+++ b/src/async_impl/h3_client/pool.rs
@@ -364,7 +364,22 @@ where
 pub(crate) fn extract_domain(uri: &mut Uri) -> Result<Key, Error> {
     let uri_clone = uri.clone();
     match (uri_clone.scheme(), uri_clone.authority()) {
-        (Some(scheme), Some(auth)) => Ok((scheme.clone(), auth.clone())),
+        (Some(scheme), Some(auth)) => {
+            let scheme_str = scheme.as_str();
+            if scheme_str != "https" && scheme_str != "h3" {
+                return Err(Error::new(
+                    Kind::Request,
+                    Some(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "HTTP/3 only supports 'https' or 'h3' schemes, got: {}",
+                            scheme_str
+                        ),
+                    ))),
+                ));
+            }
+            Ok((scheme.clone(), auth.clone()))
+        }
         _ => Err(Error::new(Kind::Request, None::<Error>)),
     }
 }


### PR DESCRIPTION
  This PR aims to improve the reliability of HTTP/3 connection establishment, specifically addressing the long timeouts often encountered in dual-stack environments like macOS.
  I noticed that when connecting to localhost, the client would frequently hang for 30 seconds if the IPv6 route was unreachable, as it waited for a full QUIC handshake timeout before attempting the IPv4 address. I've refactored the connection logic to handle IPv6 and IPv4 address families separately, allowing for an immediate fallback to IPv4 if the preferred IPv6 connection fails, which significantly improves responsiveness.
  While working on this, I found that the local_address configured in the client builder was being ignored during the H3 handshake. I've updated H3Connector to store this configuration and use it to filter resolved DNS entries, ensuring the client strictly respects the user's preferred address family.
  Lastly, to prevent silent timeouts when a user incorrectly provides an http scheme for a QUIC connection, I've added a validation check in extract_domain to enforce https or h3 as required by RFC 9114. This provides immediate feedback for invalid schemes instead of letting the request trigger a long, opaque timeout. I've also included unit tests to verify the new address filtering and fallback behavior.

fixed #2911 