### PR TITLE
feat: add rustls-no-provider-no-roots feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,9 @@ default-tls = ["rustls"]
 
 http2 = ["dep:h2", "hyper/http2", "hyper-util/http2", "hyper-rustls?/http2"]
 
-rustls = ["__rustls-aws-lc-rs", "dep:rustls-platform-verifier", "__rustls"]
-rustls-no-provider = ["dep:rustls-platform-verifier", "__rustls"]
+rustls = ["__rustls-aws-lc-rs", "__rustls-platform-verifier", "__rustls"]
+rustls-no-provider = ["__rustls-platform-verifier", "__rustls"]
+rustls-no-provider-no-roots = ["__rustls"]
 
 native-tls = ["__native-tls", "__native-tls-alpn"]
 native-tls-no-alpn = ["__native-tls"]
@@ -89,6 +90,7 @@ __tls = ["dep:rustls-pki-types", "tokio/io-util"]
 # Enables common rustls code.
 __rustls = ["dep:hyper-rustls", "dep:tokio-rustls", "dep:rustls", "__tls"]
 __rustls-aws-lc-rs = ["hyper-rustls?/aws-lc-rs", "tokio-rustls?/aws-lc-rs", "rustls?/aws-lc-rs", "quinn?/rustls-aws-lc-rs"]
+__rustls-platform-verifier = ["dep:rustls-platform-verifier"]
 
 # Enables common native-tls code.
 __native-tls = ["dep:hyper-tls", "dep:native-tls-crate", "__tls", "dep:tokio-native-tls"]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -748,6 +748,8 @@ impl ClientBuilder {
                             ));
                         }
 
+                        #[cfg(feature = "__rustls-platform-verifier")]
+                        {
                         let verifier = if config.root_certs.is_empty() {
                             rustls_platform_verifier::Verifier::new(provider.clone())
                                 .map_err(crate::error::builder)?
@@ -776,6 +778,12 @@ impl ClientBuilder {
                         config_builder
                             .dangerous()
                             .with_custom_certificate_verifier(Arc::new(verifier))
+                        }
+
+                        #[cfg(not(feature = "__rustls-platform-verifier"))]
+                        return Err(crate::error::builder(
+                            "no TLS root certificates configured, use tls_certs_only()",
+                        ));
                     } else {
                         if config.crls.is_empty() {
                             config_builder.with_root_certificates(crate::tls::rustls_store(
@@ -3104,7 +3112,7 @@ impl fmt::Debug for Pending {
 
 #[cfg(test)]
 mod tests {
-    #![cfg(not(feature = "rustls-no-provider"))]
+    #![cfg(not(any(feature = "rustls-no-provider", feature = "rustls-no-provider-no-roots")))]
 
     #[tokio::test]
     async fn execute_request_rejects_invalid_urls() {

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -662,7 +662,7 @@ impl TryFrom<Request> for HttpRequest<Body> {
 
 #[cfg(test)]
 mod tests {
-    #![cfg(not(feature = "rustls-no-provider"))]
+    #![cfg(not(any(feature = "rustls-no-provider", feature = "rustls-no-provider-no-roots")))]
 
     use super::*;
     #[cfg(feature = "query")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,11 @@
 //! - **default-tls** *(enabled by default)*: Provides TLS support to connect
 //!   over HTTPS.
 //! - **rustls**: Enables TLS functionality provided by `rustls`.
+//!   Uses `rustls-platform-verifier` for certificate verification by default.
 //! - **rustls-no-provider**: Enables TLS provided by `rustls` without specifying a crypto provider.
+//! - **rustls-no-provider-no-roots**: Enables TLS provided by `rustls` without a crypto provider
+//!   or `rustls-platform-verifier`. You must provide both a crypto provider and call
+//!   `tls_certs_only()` to provide certificates.
 //! - **native-tls**: Enables TLS functionality provided by `native-tls`.
 //! - **native-tls-vendored**: Enables the `vendored` feature of `native-tls`.
 //! - **native-tls-no-alpn**: Enables `native-tls` without its `alpn` feature.

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 
 #[cfg(all(feature = "__tls"))]
 #[tokio::test]

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 mod support;
 use support::server;
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -462,7 +462,13 @@ fn update_json_content_type_if_set_manually() {
     assert_eq!("application/json", req.headers().get(CONTENT_TYPE).unwrap());
 }
 
-#[cfg(all(feature = "__tls", not(feature = "rustls-no-provider")))]
+#[cfg(all(
+    feature = "__tls",
+    not(any(
+        feature = "rustls-no-provider",
+        feature = "rustls-no-provider-no-roots"
+    ))
+))]
 #[tokio::test]
 async fn test_tls_info() {
     let resp = reqwest::Client::builder()

--- a/tests/connector_layers.rs
+++ b/tests/connector_layers.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 mod support;
 
 use std::time::Duration;

--- a/tests/not_tcp.rs
+++ b/tests/not_tcp.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 #![cfg(unix)]
 
 mod support;

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 mod support;
 use support::server;
 

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 mod support;
 use http_body_util::BodyExt;
 use reqwest::Body;

--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 mod support;
 use support::server;
 

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 mod support;
 use support::server;
 

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -1,5 +1,8 @@
 #![cfg(not(target_arch = "wasm32"))]
-#![cfg(not(feature = "rustls-no-provider"))]
+#![cfg(not(any(
+    feature = "rustls-no-provider",
+    feature = "rustls-no-provider-no-roots"
+)))]
 mod support;
 use support::server;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};


### PR DESCRIPTION
Implemented suggestion mentioned here: https://github.com/seanmonstar/reqwest/issues/2968#issuecomment-3917451353

---

Add a feature flag to use rustls without a crypto provider and without rustls-platform-verifier, for users who provide their own crypto provider and certificates via `tls_certs_only()`.

This avoids pulling in platform-native dependencies that are problematic for cross-compilation and environments like Android where JNI initialization is required.

Closes #2948
Closes #2968