### PR TITLE
Upgrade rustls-platform-verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Downgrade rustls-platform-verifier
+        run: cargo update -p rustls-platform-verifier --precise 0.6.2
+
       - name: Check
         run: cargo check
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ tokio-native-tls = { version = "0.3.0", optional = true }
 hyper-rustls = { version = "0.27.0", default-features = false, optional = true, features = ["http1", "tls12"] }
 rustls = { version = "0.23.4", optional = true, default-features = false, features = ["std", "tls12"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["tls12"] }
-rustls-platform-verifier = { version = "0.6", optional = true }
+rustls-platform-verifier = { version = ">=0.6.0, <0.8.0", optional = true }
 
 ## cookies
 cookie_crate = { version = "0.18.0", package = "cookie", optional = true }


### PR DESCRIPTION
New release is out that gets rid of a bunch of outdated transitive dependencies.