### PR TITLE
Make `rustls-platform-verifier` an optional feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+- **Breaking**: `rustls-platform-verifier` is now its own feature rather than
+  being pulled in unconditionally by `rustls`/`rustls-no-provider`. It is
+  still enabled by default (via `default-tls`), so callers using default
+  features are unaffected. Callers that set `default-features = false`
+  together with `features = ["rustls"]` (or `rustls-no-provider`) must now
+  either also enable `rustls-platform-verifier` to keep using OS trust, or
+  configure roots manually with `tls_certs_only()`.
+
 ## v0.13.2
 
 - Fix HTTP/2 and native-tls ALPN feature combinations.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,13 @@ features = [
 [features]
 default = ["default-tls", "charset", "http2", "system-proxy"]
 
-default-tls = ["rustls"]
+default-tls = ["rustls", "rustls-platform-verifier"]
 
 http2 = ["dep:h2", "hyper/http2", "hyper-util/http2", "hyper-rustls?/http2"]
 
-rustls = ["__rustls-aws-lc-rs", "dep:rustls-platform-verifier", "__rustls"]
-rustls-no-provider = ["dep:rustls-platform-verifier", "__rustls"]
+rustls = ["__rustls-aws-lc-rs", "__rustls"]
+rustls-no-provider = ["__rustls"]
+rustls-platform-verifier = ["dep:rustls-platform-verifier", "__rustls"]
 
 native-tls = ["__native-tls", "__native-tls-alpn"]
 native-tls-no-alpn = ["__native-tls"]

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -748,34 +748,44 @@ impl ClientBuilder {
                             ));
                         }
 
-                        let verifier = if config.root_certs.is_empty() {
-                            rustls_platform_verifier::Verifier::new(provider.clone())
-                                .map_err(crate::error::builder)?
-                        } else {
-                            #[cfg(any(
-                                all(unix, not(target_os = "android")),
-                                target_os = "windows"
-                            ))]
-                            {
-                                rustls_platform_verifier::Verifier::new_with_extra_roots(
-                                    crate::tls::rustls_der(config.root_certs)?,
-                                    provider.clone(),
-                                )
-                                .map_err(crate::error::builder)?
-                            }
+                        #[cfg(not(feature = "rustls-platform-verifier"))]
+                        return Err(crate::error::builder(
+                            "no TLS root certificates configured; \
+                             enable the `rustls-platform-verifier` feature \
+                             or call `tls_certs_only()`",
+                        ));
 
-                            #[cfg(not(any(
-                                all(unix, not(target_os = "android")),
-                                target_os = "windows"
-                            )))]
-                            return Err(crate::error::builder(
-                                "rustls-platform-verifier could not load extra certs",
-                            ));
-                        };
+                        #[cfg(feature = "rustls-platform-verifier")]
+                        {
+                            let verifier = if config.root_certs.is_empty() {
+                                rustls_platform_verifier::Verifier::new(provider.clone())
+                                    .map_err(crate::error::builder)?
+                            } else {
+                                #[cfg(any(
+                                    all(unix, not(target_os = "android")),
+                                    target_os = "windows"
+                                ))]
+                                {
+                                    rustls_platform_verifier::Verifier::new_with_extra_roots(
+                                        crate::tls::rustls_der(config.root_certs)?,
+                                        provider.clone(),
+                                    )
+                                    .map_err(crate::error::builder)?
+                                }
 
-                        config_builder
-                            .dangerous()
-                            .with_custom_certificate_verifier(Arc::new(verifier))
+                                #[cfg(not(any(
+                                    all(unix, not(target_os = "android")),
+                                    target_os = "windows"
+                                )))]
+                                return Err(crate::error::builder(
+                                    "rustls-platform-verifier could not load extra certs",
+                                ));
+                            };
+
+                            config_builder
+                                .dangerous()
+                                .with_custom_certificate_verifier(Arc::new(verifier))
+                        }
                     } else {
                         if config.crls.is_empty() {
                             config_builder.with_root_certificates(crate::tls::rustls_store(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,8 +192,14 @@
 //! - **http2** *(enabled by default)*: Enables HTTP/2 support.
 //! - **default-tls** *(enabled by default)*: Provides TLS support to connect
 //!   over HTTPS.
-//! - **rustls**: Enables TLS functionality provided by `rustls`.
-//! - **rustls-no-provider**: Enables TLS provided by `rustls` without specifying a crypto provider.
+//! - **rustls**: Enables TLS functionality provided by `rustls`, using
+//!   `aws-lc-rs` as the crypto provider.
+//! - **rustls-no-provider**: Enables TLS functionality provided by `rustls`
+//!   without specifying a crypto provider.
+//! - **rustls-platform-verifier**: Enables certificate verification against the
+//!   native OS trust store via `rustls-platform-verifier`. Required unless the
+//!   caller supplies trust roots via
+//!   [`ClientBuilder::tls_certs_only()`][crate::ClientBuilder::tls_certs_only].
 //! - **native-tls**: Enables TLS functionality provided by `native-tls`.
 //! - **native-tls-vendored**: Enables the `vendored` feature of `native-tls`.
 //! - **native-tls-no-alpn**: Enables `native-tls` without its `alpn` feature.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -622,7 +622,7 @@ pub(crate) fn rustls_store(certs: Vec<Certificate>) -> crate::Result<RootCertSto
     Ok(root_cert_store)
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(feature = "rustls-platform-verifier")]
 #[cfg(any(all(unix, not(target_os = "android")), target_os = "windows"))]
 pub(crate) fn rustls_der(
     certs: Vec<Certificate>,


### PR DESCRIPTION
Split `rustls-platform-verifier` out of the `rustls` and `rustls-no-provider` feature lists into its own `rustls-platform-verifier` feature. The default behaviour is preserved via `default-tls` pulling both `rustls` and `rustls-platform-verifier`.

This lets users that set `default-features = false` and select only `rustls` (or `rustls-no-provider`) drop `rustls-platform-verifier` and its transitive deps (`rustls-native-certs`, `openssl-probe` and other problematic stuff) from the build. Such callers must now either enable `rustls-platform-verifier` or, more likely what they want: supply trust roots with `tls_certs_only()`.

Breaking per Cargo semver rules because `dep:rustls-platform-verifier` is removed from existing feature lists.

This solves #2948.
This is an alternative implementation to #3008.

I personally do not really believe in the `no-X` style features. I think that's what caused the feature explosion we have seen here in the past. `rustls-no-x-no-y` scales badly. For the same reason, if reqwest is making a breaking release, I believe it would be possible to design this without `rustls-no-provider` also.