### PR TITLE
client: add tls_server_name option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ rustls-pki-types = { version = "1.9.0", features = ["std"], optional = true }
 mime = { version = "0.3.16", optional = true }
 
 # native-tls
-hyper-tls = { version = "0.6", optional = true }
+hyper-tls = { version = "0.6", optional = true, git = "https://github.com/mcluseau/rs-hyper-tls" }
 native-tls-crate = { version = "0.2.10", optional = true, package = "native-tls" }
 tokio-native-tls = { version = "0.3.0", optional = true }
 

--- a/examples/tls-server-name.rs
+++ b/examples/tls-server-name.rs
@@ -1,0 +1,46 @@
+//! HTTPS GET client with custome TLS server name based on hyper-tls
+//!
+//! First parameter is the URL to GET.
+//! Second parameter is the TLS server name to negociate.
+#![deny(warnings)]
+
+// This is using the `tokio` runtime. You'll need the following dependency:
+//
+// `tokio = { version = "1", features = ["full"] }`
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() -> Result<(), reqwest::Error> {
+    let mut args = std::env::args().skip(1);
+
+    let (Some(url), Some(server_name)) = (args.next(), args.next()) else {
+        println!("Usage: client <url> <server_name>");
+        return Ok(());
+    };
+
+    eprintln!("Building client");
+
+    let client = reqwest::Client::builder()
+        .tls_server_name(Some(server_name.into()))
+        .build()
+        .expect("client should build");
+
+    eprintln!("Fetching {url:?}...");
+
+    let res = client.get(url).send().await?;
+
+    eprintln!("Response: {:?} {}", res.version(), res.status());
+    eprintln!("Headers: {:#?}\n", res.headers());
+
+    let body = res.text().await?;
+
+    println!("{body}");
+
+    Ok(())
+}
+
+// The [cfg(not(target_arch = "wasm32"))] above prevent building the tokio::main function
+// for wasm32 target, because tokio isn't compatible with wasm32.
+// If you aren't building for wasm32, you don't need that line.
+// The two lines below avoid the "'main' function not found" error when building for wasm32 target.
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -158,7 +158,7 @@ impl Service<hyper::Request<crate::async_impl::body::Body>> for HyperService {
 }
 
 struct Config {
-    // NOTE: When adding a new field, update `fmt::Debug for ClientBuilder`
+    // NOTE: When adding a new field, update `Config::fmt_fields`
     accepts: Accepts,
     headers: HeaderMap,
     #[cfg(feature = "__tls")]
@@ -197,6 +197,8 @@ struct Config {
     max_tls_version: Option<tls::Version>,
     #[cfg(feature = "__tls")]
     tls_info: bool,
+    #[cfg(feature = "__tls")]
+    tls_server_name: Option<String>,
     #[cfg(feature = "__tls")]
     tls: TlsBackend,
     connector_layers: Vec<BoxedConnectorLayer>,
@@ -322,6 +324,8 @@ impl ClientBuilder {
                 max_tls_version: None,
                 #[cfg(feature = "__tls")]
                 tls_info: false,
+                #[cfg(feature = "__tls")]
+                tls_server_name: None,
                 #[cfg(feature = "__tls")]
                 tls: TlsBackend::default(),
                 connector_layers: Vec::new(),
@@ -608,6 +612,7 @@ impl ClientBuilder {
                         config.interface.as_deref(),
                         config.nodelay,
                         config.tls_info,
+                        config.tls_server_name,
                     )?
                 }
                 #[cfg(feature = "__native-tls")]
@@ -632,6 +637,7 @@ impl ClientBuilder {
                     config.interface.as_deref(),
                     config.nodelay,
                     config.tls_info,
+                    config.tls_server_name,
                 ),
                 #[cfg(feature = "__rustls")]
                 TlsBackend::BuiltRustls(conn) => {
@@ -676,6 +682,7 @@ impl ClientBuilder {
                         config.interface.as_deref(),
                         config.nodelay,
                         config.tls_info,
+                        config.tls_server_name,
                     )
                 }
                 #[cfg(feature = "__rustls")]
@@ -876,6 +883,7 @@ impl ClientBuilder {
                         config.interface.as_deref(),
                         config.nodelay,
                         config.tls_info,
+                        config.tls_server_name,
                     )
                 }
                 #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
@@ -2216,6 +2224,22 @@ impl ClientBuilder {
         self
     }
 
+    /// If Some, value to use as TLS ServerName instead of URL's host.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls(-...)`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "default-tls", feature = "native-tls", feature = "rustls")))
+    )]
+    pub fn tls_server_name(mut self, tls_server_name: Option<String>) -> ClientBuilder {
+        self.config.tls_server_name = tls_server_name;
+        self
+    }
+
     /// Restrict the Client to be used with HTTPS only requests.
     ///
     /// Defaults to false.
@@ -2848,6 +2872,8 @@ impl Config {
             f.field("tls_sni", &self.tls_sni);
 
             f.field("tls_info", &self.tls_info);
+
+            f.field("tls_server_name", &self.tls_server_name);
         }
 
         #[cfg(all(feature = "default-tls", feature = "__rustls"))]

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1062,6 +1062,22 @@ impl ClientBuilder {
         self.with_inner(|inner| inner.tls_info(tls_info))
     }
 
+    /// If Some, value to use as TLS ServerName instead of URL's host.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `default-tls`, `native-tls`, or `rustls(-...)`
+    /// feature to be enabled.
+    #[cfg(feature = "__tls")]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "default-tls", feature = "native-tls", feature = "rustls")))
+    )]
+    pub fn tls_server_name(mut self, tls_server_name: Option<String>) -> ClientBuilder {
+        self.config.tls_server_name = tls_server_name;
+        self
+    }
+
     /// Use a preconfigured TLS backend.
     ///
     /// If the passed `Any` argument is not a TLS backend that reqwest

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -78,6 +78,8 @@ pub(crate) struct ConnectorBuilder {
     tls_info: bool,
     #[cfg(feature = "__tls")]
     user_agent: Option<HeaderValue>,
+    #[cfg(feature = "__tls")]
+    tls_server_name: Option<String>,
     #[cfg(feature = "socks")]
     resolver: Option<DynResolver>,
     #[cfg(unix)]
@@ -98,6 +100,8 @@ where {
             nodelay: self.nodelay,
             #[cfg(feature = "__tls")]
             tls_info: self.tls_info,
+            #[cfg(feature = "__tls")]
+            tls_server_name: self.tls_server_name,
             #[cfg(feature = "__tls")]
             user_agent: self.user_agent,
             simple_timeout: None,
@@ -244,6 +248,7 @@ where {
         interface: Option<&str>,
         nodelay: bool,
         tls_info: bool,
+        tls_server_name: Option<String>,
     ) -> crate::Result<ConnectorBuilder>
     where
         T: Into<Option<IpAddr>>,
@@ -270,6 +275,7 @@ where {
             interface,
             nodelay,
             tls_info,
+            tls_server_name,
         ))
     }
 
@@ -295,6 +301,7 @@ where {
         interface: Option<&str>,
         nodelay: bool,
         tls_info: bool,
+        tls_server_name: Option<String>,
     ) -> ConnectorBuilder
     where
         T: Into<Option<IpAddr>>,
@@ -324,6 +331,7 @@ where {
             verbose: verbose::OFF,
             nodelay,
             tls_info,
+            tls_server_name,
             user_agent,
             timeout: None,
             #[cfg(feature = "socks")]
@@ -357,6 +365,7 @@ where {
         interface: Option<&str>,
         nodelay: bool,
         tls_info: bool,
+        tls_server_name: Option<String>,
     ) -> ConnectorBuilder
     where
         T: Into<Option<IpAddr>>,
@@ -399,6 +408,7 @@ where {
             verbose: verbose::OFF,
             nodelay,
             tls_info,
+            tls_server_name,
             user_agent,
             timeout: None,
             #[cfg(feature = "socks")]
@@ -495,6 +505,8 @@ pub(crate) struct ConnectorService {
     #[cfg(feature = "__tls")]
     tls_info: bool,
     #[cfg(feature = "__tls")]
+    tls_server_name: Option<String>,
+    #[cfg(feature = "__tls")]
     user_agent: Option<HeaderValue>,
     #[cfg(feature = "socks")]
     resolver: DynResolver,
@@ -544,16 +556,18 @@ impl ConnectorService {
             }
         };
 
+        #[cfg(feature = "__tls")]
+        let server_name = self.tls_server_name(&dst)?;
+
         match &mut self.inner {
             #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, tls) => {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
-                    let host = dst.host().ok_or("no host in url")?.to_string();
                     let conn = socks::connect(proxy, dst, dns, &self.resolver, http).await?;
                     let conn = TokioIo::new(conn);
                     let conn = TokioIo::new(conn);
                     let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
-                    let io = tls_connector.connect(&host, conn).await?;
+                    let io = tls_connector.connect(&server_name, conn).await?;
                     let io = TokioIo::new(io);
                     return Ok(Conn {
                         inner: self.verbose.wrap(NativeTlsConn { inner: io }),
@@ -569,13 +583,11 @@ impl ConnectorService {
                     use tokio_rustls::TlsConnector as RustlsConnector;
 
                     let tls = tls.clone();
-                    let host = dst.host().ok_or("no host in url")?.to_string();
                     let conn = socks::connect(proxy, dst, dns, &self.resolver, http).await?;
                     let conn = TokioIo::new(conn);
                     let conn = TokioIo::new(conn);
-                    let server_name =
-                        rustls_pki_types::ServerName::try_from(host.as_str().to_owned())
-                            .map_err(|_| "Invalid Server Name")?;
+                    let server_name = rustls_pki_types::ServerName::try_from(server_name)
+                        .map_err(|_| "Invalid Server Name")?;
                     let io = RustlsConnector::from(tls)
                         .connect(server_name, conn)
                         .await?;
@@ -610,6 +622,17 @@ impl ConnectorService {
             .map_err(Into::into)
     }
 
+    #[cfg(any(feature = "__native-tls", feature = "__rustls"))]
+    fn tls_server_name(&self, dst: &Uri) -> Result<String, BoxError> {
+        eprintln!("TLS SERVER NAME: {:?}", self.tls_server_name);
+        Ok(self
+            .tls_server_name
+            .as_deref()
+            .or_else(|| dst.host())
+            .ok_or("no host in url")?
+            .to_string())
+    }
+
     async fn connect_with_maybe_proxy(self, dst: Uri, is_proxy: bool) -> Result<Conn, BoxError> {
         match self.inner {
             #[cfg(not(feature = "__tls"))]
@@ -622,7 +645,7 @@ impl ConnectorService {
                 })
             }
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(http, tls) => {
+            Inner::NativeTls(ref http, ref tls) => {
                 let mut http = http.clone();
 
                 // Disable Nagle's algorithm for TLS handshake
@@ -632,8 +655,7 @@ impl ConnectorService {
                     http.set_nodelay(true);
                 }
 
-                let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
-                let mut http = hyper_tls::HttpsConnector::from((http, tls_connector));
+                let mut http = self.native_tls_connector(http, tls);
                 let io = http.call(dst).await?;
 
                 if let hyper_tls::MaybeHttpsStream::Https(stream) = io {
@@ -661,7 +683,9 @@ impl ConnectorService {
                 }
             }
             #[cfg(feature = "__rustls")]
-            Inner::RustlsTls { http, tls, .. } => {
+            Inner::RustlsTls {
+                ref http, ref tls, ..
+            } => {
                 let mut http = http.clone();
 
                 // Disable Nagle's algorithm for TLS handshake
@@ -671,7 +695,7 @@ impl ConnectorService {
                     http.set_nodelay(true);
                 }
 
-                let mut http = hyper_rustls::HttpsConnector::from((http, tls.clone()));
+                let mut http = self.rustls_connector(http, tls.clone())?;
                 let io = http.call(dst).await?;
 
                 if let hyper_rustls::MaybeHttpsStream::Https(stream) = io {
@@ -739,9 +763,8 @@ impl ConnectorService {
                 })
             }
             #[cfg(feature = "__native-tls")]
-            Inner::NativeTls(_, tls) => {
-                let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
-                let mut http = hyper_tls::HttpsConnector::from((svc, tls_connector));
+            Inner::NativeTls(_, ref tls) => {
+                let mut http = self.native_tls_connector(svc, tls);
                 let io = http.call(dst).await?;
 
                 if let hyper_tls::MaybeHttpsStream::Https(stream) = io {
@@ -759,8 +782,8 @@ impl ConnectorService {
                 }
             }
             #[cfg(feature = "__rustls")]
-            Inner::RustlsTls { tls, .. } => {
-                let mut http = hyper_rustls::HttpsConnector::from((svc, tls.clone()));
+            Inner::RustlsTls { ref tls, .. } => {
+                let mut http = self.rustls_connector(svc, tls.clone())?;
                 let io = http.call(dst).await?;
 
                 if let hyper_rustls::MaybeHttpsStream::Https(stream) = io {
@@ -798,6 +821,9 @@ impl ConnectorService {
         #[cfg(feature = "__tls")]
         let misc = proxy.custom_headers().clone();
 
+        #[cfg(feature = "__tls")]
+        let server_name = &self.tls_server_name(&dst)?;
+
         match &self.inner {
             #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, tls) => {
@@ -826,7 +852,7 @@ impl ConnectorService {
                     let tunneled = tunnel.call(dst.clone()).await?;
                     let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
                     let io = tls_connector
-                        .connect(dst.host().ok_or("no host in url")?, TokioIo::new(tunneled))
+                        .connect(&server_name, TokioIo::new(tunneled))
                         .await?;
                     return Ok(Conn {
                         inner: self.verbose.wrap(NativeTlsConn {
@@ -851,6 +877,7 @@ impl ConnectorService {
                     log::trace!("tunneling HTTPS over proxy");
                     let http = http.clone();
                     let inner = hyper_rustls::HttpsConnector::from((http, tls_proxy.clone()));
+                    let server_name = self.tls_server_name(&dst)?;
                     // TODO: we could cache constructing this
                     let mut tunnel =
                         hyper_util::client::legacy::connect::proxy::Tunnel::new(proxy_dst, inner);
@@ -868,9 +895,8 @@ impl ConnectorService {
                     // We don't wrap this again in an HttpsConnector since that uses Maybe,
                     // and we know this is definitely HTTPS.
                     let tunneled = tunnel.call(dst.clone()).await?;
-                    let host = dst.host().ok_or("no host in url")?.to_string();
-                    let server_name = ServerName::try_from(host.as_str().to_owned())
-                        .map_err(|_| "Invalid Server Name")?;
+                    let server_name =
+                        ServerName::try_from(server_name).map_err(|_| "Invalid Server Name")?;
                     let io = RustlsConnector::from(tls.clone())
                         .connect(server_name, TokioIo::new(tunneled))
                         .await?;
@@ -898,6 +924,32 @@ impl ConnectorService {
 
         #[cfg(target_os = "windows")]
         return self.windows_named_pipe.is_some();
+    }
+
+    #[cfg(feature = "__native-tls")]
+    fn native_tls_connector<H>(&self, http: H, tls: &TlsConnector) -> hyper_tls::HttpsConnector<H> {
+        let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
+        let mut http = hyper_tls::HttpsConnector::from((http, tls_connector));
+        if let Some(server_name) = self.tls_server_name.clone() {
+            http = http.with_tls_server_name(server_name);
+        }
+        http
+    }
+
+    #[cfg(feature = "__rustls")]
+    fn rustls_connector<H>(
+        &self,
+        http: H,
+        cfg: impl Into<Arc<rustls::ClientConfig>>,
+    ) -> Result<hyper_rustls::HttpsConnector<H>, BoxError> {
+        let cfg = cfg.into();
+        Ok(if let Some(server_name) = self.tls_server_name.clone() {
+            let server_name = rustls::pki_types::ServerName::try_from(server_name)?;
+            let resolver = hyper_rustls::FixedServerNameResolver::new(server_name);
+            hyper_rustls::HttpsConnector::new(http, cfg, false, Arc::new(resolver))
+        } else {
+            hyper_rustls::HttpsConnector::from((http, cfg))
+        })
     }
 }
 


### PR DESCRIPTION
Hi,

it seems using a custom TLS ServerName is supported by both `rustls` and `native-tls`.

This is my attempt to provide an option to set it at the client's level. I didn't see any TLS-specific options in `Request`, it may be better there instead. I'll just let you tell me :)