### PR TITLE
Add per-request connect timeout

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -16,7 +16,7 @@ use super::Body;
 use crate::async_impl::h3_client::connect::{H3ClientConfig, H3Connector};
 #[cfg(feature = "http3")]
 use crate::async_impl::h3_client::H3Client;
-use crate::config::{RequestConfig, TotalTimeout};
+use crate::config::{ConnectTimeout, RequestConfig, TotalTimeout};
 #[cfg(unix)]
 use crate::connect::uds::UnixSocketProvider;
 #[cfg(target_os = "windows")]
@@ -443,9 +443,7 @@ impl ClientBuilder {
                 headers.get(USER_AGENT).cloned()
             }
 
-            let mut http = HttpConnector::new_with_resolver(resolver.clone());
-            http.set_connect_timeout(config.connect_timeout);
-
+            let http = HttpConnector::new_with_resolver(resolver.clone());
             #[cfg(all(feature = "http3", feature = "__rustls"))]
             let build_h3_connector =
                 |resolver,
@@ -1084,6 +1082,7 @@ impl ClientBuilder {
                 referer: config.referer,
                 read_timeout: config.read_timeout,
                 total_timeout: RequestConfig::new(config.timeout),
+                connect_timeout: RequestConfig::new(config.connect_timeout),
                 hyper,
                 proxies,
                 proxies_maybe_http_auth,
@@ -2611,21 +2610,29 @@ impl Client {
             .uri(uri)
             .version(version);
 
-        let in_flight = match version {
-            #[cfg(feature = "http3")]
-            http::Version::HTTP_3 if self.inner.h3_client.is_some() => {
-                let mut req = builder.body(body).expect("valid request parts");
-                *req.headers_mut() = headers.clone();
-                let mut h3 = self.inner.h3_client.as_ref().unwrap().clone();
-                ResponseFuture::H3(h3.call(req))
+        let connect_timeout = self
+            .inner
+            .connect_timeout
+            .fetch(&extensions)
+            .copied();
+
+        let in_flight = crate::connect::with_request_connect_timeout(connect_timeout, || {
+            match version {
+                #[cfg(feature = "http3")]
+                http::Version::HTTP_3 if self.inner.h3_client.is_some() => {
+                    let mut req = builder.body(body).expect("valid request parts");
+                    *req.headers_mut() = headers.clone();
+                    let mut h3 = self.inner.h3_client.as_ref().unwrap().clone();
+                    ResponseFuture::H3(h3.call(req))
+                }
+                _ => {
+                    let mut req = builder.body(body).expect("valid request parts");
+                    *req.headers_mut() = headers.clone();
+                    let mut hyper = self.inner.hyper.clone();
+                    ResponseFuture::Default(hyper.call(req))
+                }
             }
-            _ => {
-                let mut req = builder.body(body).expect("valid request parts");
-                *req.headers_mut() = headers.clone();
-                let mut hyper = self.inner.hyper.clone();
-                ResponseFuture::Default(hyper.call(req))
-            }
-        };
+        });
 
         let total_timeout = self
             .inner
@@ -2650,6 +2657,7 @@ impl Client {
                 client: self.inner.clone(),
 
                 in_flight,
+                connect_timeout,
                 total_timeout,
                 read_timeout_fut,
                 read_timeout: self.inner.read_timeout,
@@ -2919,6 +2927,7 @@ struct ClientRef {
     h3_client: Option<LayeredService<H3Client>>,
     referer: bool,
     total_timeout: RequestConfig<TotalTimeout>,
+    connect_timeout: RequestConfig<ConnectTimeout>,
     read_timeout: Option<Duration>,
     proxies: Arc<Vec<ProxyMatcher>>,
     proxies_maybe_http_auth: bool,
@@ -2956,6 +2965,7 @@ impl ClientRef {
         f.field("default_headers", &self.headers);
 
         self.total_timeout.fmt_as_field(f);
+        self.connect_timeout.fmt_as_field(f);
 
         if let Some(ref d) = self.read_timeout {
             f.field("read_timeout", d);
@@ -2985,6 +2995,7 @@ pin_project! {
 
         #[pin]
         in_flight: ResponseFuture,
+        connect_timeout: Option<Duration>,
         #[pin]
         total_timeout: Option<Pin<Box<Sleep>>>,
         #[pin]
@@ -3059,15 +3070,24 @@ impl Future for PendingRequest {
             }
         }
 
+        let connect_timeout = self.connect_timeout;
         let res = match self.as_mut().in_flight().get_mut() {
-            ResponseFuture::Default(r) => match ready!(Pin::new(r).poll(cx)) {
+            ResponseFuture::Default(r) => match ready!(
+                crate::connect::with_request_connect_timeout(connect_timeout, || {
+                    Pin::new(r).poll(cx)
+                })
+            ) {
                 Err(e) => {
                     return Poll::Ready(Err(e.if_no_url(|| self.url.clone())));
                 }
                 Ok(res) => res.map(super::body::boxed),
             },
             #[cfg(feature = "http3")]
-            ResponseFuture::H3(r) => match ready!(Pin::new(r).poll(cx)) {
+            ResponseFuture::H3(r) => match ready!(
+                crate::connect::with_request_connect_timeout(connect_timeout, || {
+                    Pin::new(r).poll(cx)
+                })
+            ) {
                 Err(e) => {
                     return Poll::Ready(Err(crate::error::request(e).with_url(self.url.clone())));
                 }

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -13,7 +13,7 @@ use super::client::{Client, Pending};
 #[cfg(feature = "multipart")]
 use super::multipart;
 use super::response::Response;
-use crate::config::{RequestConfig, TotalTimeout};
+use crate::config::{ConnectTimeout, RequestConfig, TotalTimeout};
 #[cfg(feature = "multipart")]
 use crate::header::CONTENT_LENGTH;
 #[cfg(any(feature = "multipart", feature = "form", feature = "json"))]
@@ -127,6 +127,18 @@ impl Request {
         RequestConfig::<TotalTimeout>::get_mut(&mut self.extensions)
     }
 
+    /// Get the connect timeout.
+    #[inline]
+    pub fn connect_timeout(&self) -> Option<&Duration> {
+        RequestConfig::<ConnectTimeout>::get(&self.extensions)
+    }
+
+    /// Get a mutable reference to the connect timeout.
+    #[inline]
+    pub fn connect_timeout_mut(&mut self) -> &mut Option<Duration> {
+        RequestConfig::<ConnectTimeout>::get_mut(&mut self.extensions)
+    }
+
     /// Get the http version.
     #[inline]
     pub fn version(&self) -> Version {
@@ -149,6 +161,7 @@ impl Request {
         };
         let mut req = Request::new(self.method().clone(), self.url().clone());
         *req.timeout_mut() = self.timeout().copied();
+        *req.connect_timeout_mut() = self.connect_timeout().copied();
         *req.headers_mut() = self.headers().clone();
         *req.version_mut() = self.version();
         *req.extensions_mut() = self.extensions().clone();
@@ -294,6 +307,22 @@ impl RequestBuilder {
     pub fn timeout(mut self, timeout: Duration) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             *req.timeout_mut() = Some(timeout);
+        }
+        self
+    }
+
+    /// Set a timeout for only the connect phase of this request.
+    ///
+    /// This affects only this request and overrides the timeout configured
+    /// using `ClientBuilder::connect_timeout()`.
+    ///
+    /// # Note
+    ///
+    /// This **requires** the future be executed in a tokio runtime with
+    /// a tokio timer enabled.
+    pub fn connect_timeout(mut self, timeout: Duration) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            *req.connect_timeout_mut() = Some(timeout);
         }
         self
     }

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -115,6 +115,18 @@ impl Request {
         self.inner.timeout_mut()
     }
 
+    /// Get the connect timeout.
+    #[inline]
+    pub fn connect_timeout(&self) -> Option<&Duration> {
+        self.inner.connect_timeout()
+    }
+
+    /// Get a mutable reference to the connect timeout.
+    #[inline]
+    pub fn connect_timeout_mut(&mut self) -> &mut Option<Duration> {
+        self.inner.connect_timeout_mut()
+    }
+
     /// Attempts to clone the `Request`.
     ///
     /// None is returned if a body is which can not be cloned. This can be because the body is a
@@ -131,6 +143,7 @@ impl Request {
         };
         let mut req = Request::new(self.method().clone(), self.url().clone());
         *req.timeout_mut() = self.timeout().copied();
+        *req.connect_timeout_mut() = self.connect_timeout().copied();
         *req.headers_mut() = self.headers().clone();
         *req.version_mut() = self.version().clone();
         req.body = body;
@@ -362,6 +375,17 @@ impl RequestBuilder {
     pub fn timeout(mut self, timeout: Duration) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             *req.timeout_mut() = Some(timeout);
+        }
+        self
+    }
+
+    /// Set a timeout for only the connect phase of this request.
+    ///
+    /// This affects only this request and overrides the timeout configured
+    /// using `ClientBuilder::connect_timeout()`.
+    pub fn connect_timeout(mut self, timeout: Duration) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            *req.connect_timeout_mut() = Some(timeout);
         }
         self
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,3 +108,10 @@ pub(crate) struct TotalTimeout;
 impl RequestConfigValue for TotalTimeout {
     type Value = Duration;
 }
+
+#[derive(Clone, Copy)]
+pub(crate) struct ConnectTimeout;
+
+impl RequestConfigValue for ConnectTimeout {
+    type Value = Duration;
+}

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -11,9 +11,10 @@ use hyper_util::rt::TokioIo;
 use native_tls_crate::{TlsConnector, TlsConnectorBuilder};
 use pin_project_lite::pin_project;
 use tower::util::{BoxCloneSyncServiceLayer, MapRequestLayer};
-use tower::{timeout::TimeoutLayer, util::BoxCloneSyncService, ServiceBuilder};
+use tower::{util::BoxCloneSyncService, ServiceBuilder};
 use tower_service::Service;
 
+use std::cell::Cell;
 use std::future::Future;
 use std::io::{self, IoSlice};
 use std::net::IpAddr;
@@ -33,13 +34,41 @@ use sealed::{Conn, Unnameable};
 
 pub(crate) type HttpConnector = hyper_util::client::legacy::connect::HttpConnector<DynResolver>;
 
+thread_local! {
+    static REQUEST_CONNECT_TIMEOUT: Cell<Option<Duration>> = Cell::new(None);
+}
+
+struct ResetConnectTimeout(Option<Duration>);
+
+impl Drop for ResetConnectTimeout {
+    fn drop(&mut self) {
+        REQUEST_CONNECT_TIMEOUT.with(|timeout| timeout.set(self.0));
+    }
+}
+
+pub(crate) fn with_request_connect_timeout<T>(
+    timeout: Option<Duration>,
+    f: impl FnOnce() -> T,
+) -> T {
+    let previous = REQUEST_CONNECT_TIMEOUT.with(|cell| {
+        let previous = cell.get();
+        cell.set(timeout);
+        previous
+    });
+    let _reset = ResetConnectTimeout(previous);
+    f()
+}
+
+fn connect_timeout(default: Option<Duration>) -> Option<Duration> {
+    REQUEST_CONNECT_TIMEOUT.with(|timeout| timeout.get().or(default))
+}
+
 #[derive(Clone)]
 pub(crate) enum Connector {
     // base service, with or without an embedded timeout
     Simple(ConnectorService),
-    // at least one custom layer along with maybe an outer timeout layer
-    // from `builder.connect_timeout()`
-    WithLayers(BoxCloneSyncService<Unnameable, Conn, BoxError>),
+    // at least one custom layer, with a default connect timeout.
+    WithLayers(BoxCloneSyncService<Unnameable, Conn, BoxError>, Option<Duration>),
 }
 
 impl Service<Uri> for Connector {
@@ -50,14 +79,17 @@ impl Service<Uri> for Connector {
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match self {
             Connector::Simple(service) => service.poll_ready(cx),
-            Connector::WithLayers(service) => service.poll_ready(cx),
+            Connector::WithLayers(service, _) => service.poll_ready(cx),
         }
     }
 
     fn call(&mut self, dst: Uri) -> Self::Future {
         match self {
             Connector::Simple(service) => service.call(dst),
-            Connector::WithLayers(service) => service.call(Unnameable(dst)),
+            Connector::WithLayers(service, default_timeout) => {
+                let timeout = connect_timeout(*default_timeout);
+                Box::pin(with_timeout(service.call(Unnameable(dst)), timeout))
+            }
         }
     }
 }
@@ -138,33 +170,14 @@ where {
             service = ServiceBuilder::new().layer(layer).service(service);
         }
 
-        // now we handle the concrete stuff - any `connect_timeout`,
-        // plus a final map_err layer we can use to cast default tower layer
-        // errors to internal errors
-        match self.timeout {
-            Some(timeout) => {
-                let service = ServiceBuilder::new()
-                    .layer(TimeoutLayer::new(timeout))
-                    .service(service);
-                let service = ServiceBuilder::new()
-                    .map_err(|error: BoxError| cast_to_internal_error(error))
-                    .service(service);
-                let service = BoxCloneSyncService::new(service);
-
-                Connector::WithLayers(service)
-            }
-            None => {
-                // no timeout, but still map err
-                // no named timeout layer but we still map errors since
-                // we might have user-provided timeout layer
-                let service = ServiceBuilder::new().service(service);
-                let service = ServiceBuilder::new()
-                    .map_err(|error: BoxError| cast_to_internal_error(error))
-                    .service(service);
-                let service = BoxCloneSyncService::new(service);
-                Connector::WithLayers(service)
-            }
-        }
+        // Map errors so user-provided timeout layers are still reported as
+        // reqwest timeouts. The request/client connect timeout is applied by
+        // `Connector::call`, where a request-scoped override is available.
+        let service = ServiceBuilder::new()
+            .map_err(|error: BoxError| cast_to_internal_error(error))
+            .service(service);
+        let service = BoxCloneSyncService::new(service);
+        Connector::WithLayers(service, self.timeout)
     }
 
     #[cfg(not(feature = "__tls"))]
@@ -535,7 +548,12 @@ impl Inner {
 
 impl ConnectorService {
     #[cfg(feature = "socks")]
-    async fn connect_socks(mut self, dst: Uri, proxy: Intercepted) -> Result<Conn, BoxError> {
+    async fn connect_socks(
+        mut self,
+        dst: Uri,
+        proxy: Intercepted,
+        connect_timeout: Option<Duration>,
+    ) -> Result<Conn, BoxError> {
         let dns = match proxy.uri().scheme_str() {
             Some("socks4") | Some("socks5") => socks::DnsResolve::Local,
             Some("socks4a") | Some("socks5h") => socks::DnsResolve::Proxy,
@@ -547,6 +565,7 @@ impl ConnectorService {
         match &mut self.inner {
             #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, tls) => {
+                http.set_connect_timeout(connect_timeout);
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     let host = dst.host().ok_or("no host in url")?.to_string();
                     let conn = socks::connect(proxy, dst, dns, &self.resolver, http).await?;
@@ -564,6 +583,7 @@ impl ConnectorService {
             }
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, tls, .. } => {
+                http.set_connect_timeout(connect_timeout);
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     use std::convert::TryFrom;
                     use tokio_rustls::TlsConnector as RustlsConnector;
@@ -589,6 +609,7 @@ impl ConnectorService {
             }
             #[cfg(not(feature = "__tls"))]
             Inner::Http(http) => {
+                http.set_connect_timeout(connect_timeout);
                 let conn = socks::connect(proxy, dst, dns, &self.resolver, http).await?;
                 return Ok(Conn {
                     inner: self.verbose.wrap(TokioIo::new(conn)),
@@ -600,6 +621,7 @@ impl ConnectorService {
 
         let resolver = &self.resolver;
         let http = self.inner.get_http_connector();
+        http.set_connect_timeout(connect_timeout);
         socks::connect(proxy, dst, dns, resolver, http)
             .await
             .map(|tcp| Conn {
@@ -610,10 +632,16 @@ impl ConnectorService {
             .map_err(Into::into)
     }
 
-    async fn connect_with_maybe_proxy(self, dst: Uri, is_proxy: bool) -> Result<Conn, BoxError> {
+    async fn connect_with_maybe_proxy(
+        self,
+        dst: Uri,
+        is_proxy: bool,
+        connect_timeout: Option<Duration>,
+    ) -> Result<Conn, BoxError> {
         match self.inner {
             #[cfg(not(feature = "__tls"))]
             Inner::Http(mut http) => {
+                http.set_connect_timeout(connect_timeout);
                 let io = http.call(dst).await?;
                 Ok(Conn {
                     inner: self.verbose.wrap(io),
@@ -624,6 +652,7 @@ impl ConnectorService {
             #[cfg(feature = "__native-tls")]
             Inner::NativeTls(http, tls) => {
                 let mut http = http.clone();
+                http.set_connect_timeout(connect_timeout);
 
                 // Disable Nagle's algorithm for TLS handshake
                 //
@@ -663,6 +692,7 @@ impl ConnectorService {
             #[cfg(feature = "__rustls")]
             Inner::RustlsTls { http, tls, .. } => {
                 let mut http = http.clone();
+                http.set_connect_timeout(connect_timeout);
 
                 // Disable Nagle's algorithm for TLS handshake
                 //
@@ -780,13 +810,18 @@ impl ConnectorService {
         }
     }
 
-    async fn connect_via_proxy(self, dst: Uri, proxy: Intercepted) -> Result<Conn, BoxError> {
+    async fn connect_via_proxy(
+        self,
+        dst: Uri,
+        proxy: Intercepted,
+        connect_timeout: Option<Duration>,
+    ) -> Result<Conn, BoxError> {
         log::debug!("proxy({proxy:?}) intercepts '{:?}'", dst.host());
 
         #[cfg(feature = "socks")]
         match proxy.uri().scheme_str().ok_or("proxy scheme expected")? {
             "socks4" | "socks4a" | "socks5" | "socks5h" => {
-                return self.connect_socks(dst, proxy).await
+                return self.connect_socks(dst, proxy, connect_timeout).await
             }
             _ => (),
         }
@@ -804,8 +839,9 @@ impl ConnectorService {
                 if dst.scheme() == Some(&Scheme::HTTPS) {
                     log::trace!("tunneling HTTPS over proxy");
                     let tls_connector = tokio_native_tls::TlsConnector::from(tls.clone());
-                    let inner =
-                        hyper_tls::HttpsConnector::from((http.clone(), tls_connector.clone()));
+                    let mut http = http.clone();
+                    http.set_connect_timeout(connect_timeout);
+                    let inner = hyper_tls::HttpsConnector::from((http, tls_connector.clone()));
                     // TODO: we could cache constructing this
                     let mut tunnel =
                         hyper_util::client::legacy::connect::proxy::Tunnel::new(proxy_dst, inner);
@@ -849,7 +885,8 @@ impl ConnectorService {
                     use tokio_rustls::TlsConnector as RustlsConnector;
 
                     log::trace!("tunneling HTTPS over proxy");
-                    let http = http.clone();
+                    let mut http = http.clone();
+                    http.set_connect_timeout(connect_timeout);
                     let inner = hyper_rustls::HttpsConnector::from((http, tls_proxy.clone()));
                     // TODO: we could cache constructing this
                     let mut tunnel =
@@ -888,7 +925,8 @@ impl ConnectorService {
             Inner::Http(_) => (),
         }
 
-        self.connect_with_maybe_proxy(proxy_dst, true).await
+        self.connect_with_maybe_proxy(proxy_dst, true, connect_timeout)
+            .await
     }
 
     #[cfg(any(unix, target_os = "windows"))]
@@ -927,7 +965,7 @@ impl Service<Uri> for ConnectorService {
 
     fn call(&mut self, dst: Uri) -> Self::Future {
         log::debug!("starting new connection '{:?}'", dst.host());
-        let timeout = self.simple_timeout;
+        let timeout = connect_timeout(self.simple_timeout);
 
         // Local transports (UDS, Windows Named Pipes) skip proxies
         #[cfg(any(unix, target_os = "windows"))]
@@ -941,14 +979,14 @@ impl Service<Uri> for ConnectorService {
         for prox in self.proxies.iter() {
             if let Some(intercepted) = prox.intercept(&dst) {
                 return Box::pin(with_timeout(
-                    self.clone().connect_via_proxy(dst, intercepted),
+                    self.clone().connect_via_proxy(dst, intercepted, timeout),
                     timeout,
                 ));
             }
         }
 
         Box::pin(with_timeout(
-            self.clone().connect_with_maybe_proxy(dst, false),
+            self.clone().connect_with_maybe_proxy(dst, false, timeout),
             timeout,
         ))
     }

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 #![cfg(not(feature = "rustls-no-provider"))]
 mod support;
-use support::server;
+use support::{delay_layer::DelayLayer, server};
 
 use std::time::Duration;
 
@@ -86,6 +86,49 @@ async fn connect_timeout() {
     let err = res.unwrap_err();
 
     assert!(err.is_connect() && err.is_timeout());
+}
+
+#[tokio::test]
+async fn request_connect_timeout() {
+    let _ = env_logger::try_init();
+
+    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+
+    let url = "http://192.0.2.1:81/slow";
+
+    let res = client
+        .get(url)
+        .connect_timeout(Duration::from_millis(100))
+        .timeout(Duration::from_millis(1000))
+        .send()
+        .await;
+
+    let err = res.unwrap_err();
+
+    assert!(err.is_connect() && err.is_timeout());
+}
+
+#[tokio::test]
+async fn request_connect_timeout_overrides_client_connect_timeout() {
+    let _ = env_logger::try_init();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+    let url = format!("http://{}/", server.addr());
+
+    let client = reqwest::Client::builder()
+        .connector_layer(DelayLayer::new(Duration::from_millis(200)))
+        .connect_timeout(Duration::from_millis(50))
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    let res = client
+        .get(url)
+        .connect_timeout(Duration::from_millis(500))
+        .send()
+        .await;
+
+    assert!(res.is_ok());
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -350,6 +393,28 @@ fn connect_timeout_blocking_request() {
     let url = "http://192.0.2.1:81/slow";
 
     let err = client.get(url).send().unwrap_err();
+
+    assert!(err.is_timeout());
+}
+
+#[cfg(feature = "blocking")]
+#[test]
+fn request_connect_timeout_blocking_request() {
+    let _ = env_logger::try_init();
+
+    let client = reqwest::blocking::Client::builder()
+        .no_proxy()
+        .build()
+        .unwrap();
+
+    // never returns
+    let url = "http://192.0.2.1:81/slow";
+
+    let err = client
+        .get(url)
+        .connect_timeout(Duration::from_millis(100))
+        .send()
+        .unwrap_err();
 
     assert!(err.is_timeout());
 }


### PR DESCRIPTION
### What

Adds `RequestBuilder::connect_timeout(Duration)` for async and blocking clients.

### Why

`RequestBuilder::timeout()` can override the client-level total timeout, but `connect_timeout()` was only available on `ClientBuilder`. This adds per-request connect timeout support and lets request-level values override the client default.

### Tests

- `cargo test --test timeouts request_connect_timeout -- --nocapture`
- `cargo test --test timeouts connect_timeout -- --nocapture`
- `cargo test --test connector_layers -- --nocapture`
- `cargo check --no-default-features --tests`
- `cargo test --test timeouts request_connect_timeout_blocking_request --features blocking -- --nocapture`
