### PR TITLE
fix: update hickory-resolver to 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ cookie_store = { version = "0.22.0", optional = true }
 tokio-util = { version = "0.7.9", default-features = false, features = ["io"], optional = true }
 
 ## hickory-dns
-hickory-resolver = { version = "0.25", optional = true, features = ["tokio"] }
+hickory-resolver = { version = "0.26", optional = true, features = ["tokio"] }
 once_cell = { version = "1.18", optional = true }
 
 # HTTP/3 experimental support

--- a/src/dns/hickory.rs
+++ b/src/dns/hickory.rs
@@ -2,8 +2,7 @@
 
 use hickory_resolver::{
     config::{LookupIpStrategy, ResolverConfig},
-    lookup_ip::LookupIpIntoIter,
-    name_server::TokioConnectionProvider,
+    net::{runtime::TokioRuntimeProvider, NetError},
     TokioResolver,
 };
 use once_cell::sync::OnceCell;
@@ -23,18 +22,22 @@ pub(crate) struct HickoryDnsResolver {
 }
 
 struct SocketAddrs {
-    iter: LookupIpIntoIter,
+    iter: std::vec::IntoIter<SocketAddr>,
 }
 
 impl Resolve for HickoryDnsResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let resolver = self.clone();
         Box::pin(async move {
-            let resolver = resolver.state.get_or_init(new_resolver);
+            let resolver = resolver.state.get_or_try_init(new_resolver)?;
 
             let lookup = resolver.lookup_ip(name.as_str()).await?;
+            let addrs = lookup
+                .iter()
+                .map(|ip| SocketAddr::new(ip, 0))
+                .collect::<Vec<_>>();
             let addrs: Addrs = Box::new(SocketAddrs {
-                iter: lookup.into_iter(),
+                iter: addrs.into_iter(),
             });
             Ok(addrs)
         })
@@ -45,7 +48,7 @@ impl Iterator for SocketAddrs {
     type Item = SocketAddr;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|ip_addr| SocketAddr::new(ip_addr, 0))
+        self.iter.next()
     }
 }
 
@@ -54,7 +57,7 @@ impl Iterator for SocketAddrs {
 /// it fallbacks to hickory_resolver's default config.
 /// The options are overridden to look up for both IPv4 and IPv6 addresses
 /// to work with "happy eyeballs" algorithm.
-fn new_resolver() -> TokioResolver {
+fn new_resolver() -> Result<TokioResolver, NetError> {
     let mut builder = TokioResolver::builder_tokio().unwrap_or_else(|err| {
         log::debug!(
             "hickory-dns: failed to load system DNS configuration; falling back to hickory_resolver defaults: {:?}",
@@ -62,7 +65,7 @@ fn new_resolver() -> TokioResolver {
         );
         TokioResolver::builder_with_config(
             ResolverConfig::default(),
-            TokioConnectionProvider::default(),
+            TokioRuntimeProvider::default(),
         )
     });
     builder.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;


### PR DESCRIPTION
The only main difference is that the resolver creation can fail is when using hickory-dns with some TLS implementation plus the tls platform verifier, and its initialization fails. This only happens in some rare edge cases, and the error will bubble up.