### PR TITLE
fix(tls): map TLS 1.3 to native_tls::Protocol::Tlsv13

### DIFF
--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -572,9 +572,6 @@ impl ClientBuilder {
 
                     if let Some(min_tls_version) = config.min_tls_version {
                         let protocol = min_tls_version.to_native_tls().ok_or_else(|| {
-                            // TLS v1.3. This would be entirely reasonable,
-                            // native-tls just doesn't support it.
-                            // https://github.com/sfackler/rust-native-tls/issues/140
                             crate::error::builder("invalid minimum TLS version for backend")
                         })?;
                         tls.min_protocol_version(Some(protocol));
@@ -582,10 +579,6 @@ impl ClientBuilder {
 
                     if let Some(max_tls_version) = config.max_tls_version {
                         let protocol = max_tls_version.to_native_tls().ok_or_else(|| {
-                            // TLS v1.3.
-                            // We could arguably do max_protocol_version(None), given
-                            // that 1.4 does not exist yet, but that'd get messy in the
-                            // future.
                             crate::error::builder("invalid maximum TLS version for backend")
                         })?;
                         tls.max_protocol_version(Some(protocol));

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -567,7 +567,7 @@ impl Version {
             InnerVersion::Tls1_0 => Some(native_tls_crate::Protocol::Tlsv10),
             InnerVersion::Tls1_1 => Some(native_tls_crate::Protocol::Tlsv11),
             InnerVersion::Tls1_2 => Some(native_tls_crate::Protocol::Tlsv12),
-            InnerVersion::Tls1_3 => None,
+            InnerVersion::Tls1_3 => Some(native_tls_crate::Protocol::Tlsv13),
         }
     }
 


### PR DESCRIPTION
`rust-native-tls` has supported TLS 1.3 since the resolution of [rust-native-tls/rust-native-tls#140](https://github.com/rust-native-tls/rust-native-tls/issues/140), but `Version::to_native_tls` still mapped `Tls1_3` to `None`. As a result, `ClientBuilder::min_tls_version(Version::TLS_1_3)` / `max_tls_version(Version::TLS_1_3)` rejected TLS 1.3 at build time with `"invalid minimum/maximum TLS version for backend"` whenever the native-tls backend was selected.

This change:
- Maps `InnerVersion::Tls1_3` to `native_tls_crate::Protocol::Tlsv13` in `Version::to_native_tls`.
- Drops the now-stale comments in `src/async_impl/client.rs` that explained why TLS 1.3 was unsupported.