### PR TITLE
Removal of unnecessary prefixes and improvement of impl order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ mime = { version = "0.3.16", optional = true }
 
 # native-tls
 hyper-tls = { version = "0.6", optional = true }
-native-tls-crate = { version = "0.2.10", optional = true, package = "native-tls" }
+native-tls-crate = { version = "0.2.16", optional = true, package = "native-tls" }
 tokio-native-tls = { version = "0.3.0", optional = true }
 
 # default rustls

--- a/src/async_impl/body.rs
+++ b/src/async_impl/body.rs
@@ -260,17 +260,17 @@ impl HttpBody for Body {
         }
     }
 
-    fn size_hint(&self) -> http_body::SizeHint {
-        match self.inner {
-            Inner::Reusable(ref bytes) => http_body::SizeHint::with_exact(bytes.len() as u64),
-            Inner::Streaming(ref body) => body.size_hint(),
-        }
-    }
-
     fn is_end_stream(&self) -> bool {
         match self.inner {
             Inner::Reusable(ref bytes) => bytes.is_empty(),
             Inner::Streaming(ref body) => body.is_end_stream(),
+        }
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        match self.inner {
+            Inner::Reusable(ref bytes) => http_body::SizeHint::with_exact(bytes.len() as u64),
+            Inner::Streaming(ref body) => body.size_hint(),
         }
     }
 }
@@ -315,13 +315,13 @@ where
     }
 
     #[inline]
-    fn size_hint(&self) -> http_body::SizeHint {
-        self.inner.size_hint()
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
     }
 
     #[inline]
-    fn is_end_stream(&self) -> bool {
-        self.inner.is_end_stream()
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
     }
 }
 
@@ -360,18 +360,17 @@ where
     }
 
     #[inline]
-    fn size_hint(&self) -> http_body::SizeHint {
-        self.inner.size_hint()
-    }
-
-    #[inline]
     fn is_end_stream(&self) -> bool {
         self.inner.is_end_stream()
     }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
 }
 
-pub(crate) type ResponseBody =
-    http_body_util::combinators::BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
+pub(crate) type ResponseBody = BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
 
 pub(crate) fn boxed<B>(body: B) -> ResponseBody
 where
@@ -443,13 +442,13 @@ where
     }
 
     #[inline]
-    fn size_hint(&self) -> http_body::SizeHint {
-        self.inner.size_hint()
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
     }
 
     #[inline]
-    fn is_end_stream(&self) -> bool {
-        self.inner.is_end_stream()
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
     }
 }
 

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -141,19 +141,19 @@ struct HyperService {
     hyper: HyperClient,
 }
 
-impl Service<hyper::Request<crate::async_impl::body::Body>> for HyperService {
-    type Error = crate::Error;
+impl Service<hyper::Request<Body>> for HyperService {
     type Response = http::Response<hyper::body::Incoming>;
+    type Error = crate::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + Sync>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.hyper.poll_ready(cx).map_err(crate::error::request)
+        self.hyper.poll_ready(cx).map_err(error::request)
     }
 
-    fn call(&mut self, req: hyper::Request<crate::async_impl::body::Body>) -> Self::Future {
+    fn call(&mut self, req: hyper::Request<Body>) -> Self::Future {
         let clone = self.hyper.clone();
         let mut inner = std::mem::replace(&mut self.hyper, clone);
-        Box::pin(async move { inner.call(req).await.map_err(crate::error::request) })
+        Box::pin(async move { inner.call(req).await.map_err(error::request) })
     }
 }
 
@@ -572,9 +572,11 @@ impl ClientBuilder {
 
                     if let Some(min_tls_version) = config.min_tls_version {
                         let protocol = min_tls_version.to_native_tls().ok_or_else(|| {
-                            // TLS v1.3. This would be entirely reasonable,
-                            // native-tls just doesn't support it.
-                            // https://github.com/sfackler/rust-native-tls/issues/140
+                            // native-tls added support for TLS v1.3 in 0.2.16 🎉
+                            // `to_native_tls` could arguably return the value directly
+                            // instead of making us check for an impossible None here,
+                            // but given that 1.4 does not exist yet, that might get
+                            // messy in the future.
                             crate::error::builder("invalid minimum TLS version for backend")
                         })?;
                         tls.min_protocol_version(Some(protocol));
@@ -582,7 +584,6 @@ impl ClientBuilder {
 
                     if let Some(max_tls_version) = config.max_tls_version {
                         let protocol = max_tls_version.to_native_tls().ok_or_else(|| {
-                            // TLS v1.3.
                             // We could arguably do max_protocol_version(None), given
                             // that 1.4 does not exist yet, but that'd get messy in the
                             // future.
@@ -710,7 +711,7 @@ impl ClientBuilder {
                     }
 
                     if versions.is_empty() {
-                        return Err(crate::error::builder("empty supported tls versions"));
+                        return Err(error::builder("empty supported tls versions"));
                     }
 
                     // Allow user to have installed a runtime default.
@@ -724,7 +725,7 @@ impl ClientBuilder {
                     let config_builder =
                         rustls::ClientConfig::builder_with_provider(provider.clone())
                             .with_protocol_versions(&versions)
-                            .map_err(|_| crate::error::builder("invalid TLS versions"))?;
+                            .map_err(|_| error::builder("invalid TLS versions"))?;
 
                     let config_builder = if !config.certs_verification {
                         config_builder
@@ -733,7 +734,7 @@ impl ClientBuilder {
                     } else if !config.hostname_verification {
                         if !config.tls_certs_only {
                             // Should this just warn? Error for now...
-                            return Err(crate::error::builder(
+                            return Err(error::builder(
                                     "disabling rustls hostname verification only allowed with tls_certs_only()"
                             ));
                         }
@@ -741,20 +742,18 @@ impl ClientBuilder {
                         config_builder
                             .dangerous()
                             .with_custom_certificate_verifier(Arc::new(IgnoreHostname::new(
-                                crate::tls::rustls_store(config.root_certs)?,
+                                tls::rustls_store(config.root_certs)?,
                                 signature_algorithms,
                             )))
                     } else if !config.tls_certs_only {
                         // Check for some misconfigurations and report them.
                         if !config.crls.is_empty() {
-                            return Err(crate::error::builder(
-                                "CRLs only allowed with tls_certs_only()",
-                            ));
+                            return Err(error::builder("CRLs only allowed with tls_certs_only()"));
                         }
 
                         let verifier = if config.root_certs.is_empty() {
                             rustls_platform_verifier::Verifier::new(provider.clone())
-                                .map_err(crate::error::builder)?
+                                .map_err(error::builder)?
                         } else {
                             #[cfg(any(
                                 all(unix, not(target_os = "android")),
@@ -762,10 +761,10 @@ impl ClientBuilder {
                             ))]
                             {
                                 rustls_platform_verifier::Verifier::new_with_extra_roots(
-                                    crate::tls::rustls_der(config.root_certs)?,
+                                    tls::rustls_der(config.root_certs)?,
                                     provider.clone(),
                                 )
-                                .map_err(crate::error::builder)?
+                                .map_err(error::builder)?
                             }
 
                             #[cfg(not(any(
@@ -782,9 +781,8 @@ impl ClientBuilder {
                             .with_custom_certificate_verifier(Arc::new(verifier))
                     } else {
                         if config.crls.is_empty() {
-                            config_builder.with_root_certificates(crate::tls::rustls_store(
-                                config.root_certs,
-                            )?)
+                            config_builder
+                                .with_root_certificates(tls::rustls_store(config.root_certs)?)
                         } else {
                             let crls = config
                                 .crls
@@ -793,14 +791,12 @@ impl ClientBuilder {
                                 .collect::<Vec<_>>();
                             let verifier =
                                 rustls::client::WebPkiServerVerifier::builder_with_provider(
-                                    Arc::new(crate::tls::rustls_store(config.root_certs)?),
+                                    Arc::new(tls::rustls_store(config.root_certs)?),
                                     provider,
                                 )
                                 .with_crls(crls)
                                 .build()
-                                .map_err(|_| {
-                                    crate::error::builder("invalid TLS verification settings")
-                                })?;
+                                .map_err(|_| error::builder("invalid TLS verification settings"))?;
                             config_builder.with_webpki_verifier(verifier)
                         }
                     };
@@ -888,7 +884,7 @@ impl ClientBuilder {
                 }
                 #[cfg(any(feature = "__native-tls", feature = "__rustls",))]
                 TlsBackend::UnknownPreconfigured => {
-                    return Err(crate::error::builder(
+                    return Err(error::builder(
                         "Unknown TLS backend passed to `use_preconfigured_tls`",
                     ));
                 }
@@ -1134,7 +1130,7 @@ impl ClientBuilder {
                 self.config.headers.insert(USER_AGENT, value);
             }
             Err(e) => {
-                self.config.error = Some(crate::error::builder(e.into()));
+                self.config.error = Some(error::builder(e.into()));
             }
         };
         self
@@ -2061,12 +2057,9 @@ impl ClientBuilder {
     ///
     /// By default, the TLS backend's own default is used.
     ///
-    /// # Errors
-    ///
-    /// A value of `tls::Version::TLS_1_3` will cause an error with the
-    /// `native-tls` backend. This does not mean the version
-    /// isn't supported, just that it can't be set as a minimum due to
-    /// technical limitations.
+    /// On Apple platforms, a value of `tls::Version::TLS_1_3` may cause requests
+    /// to fail (with error -9830) with the `native-tls` backend due to lack of
+    /// TLS 1.3 support.
     ///
     /// # Optional
     ///
@@ -2092,12 +2085,11 @@ impl ClientBuilder {
     ///
     /// By default, there's no maximum.
     ///
-    /// # Errors
+    /// On Apple platforms, a value of `tls::Version::TLS_1_3` may cause requests
+    /// to fall back to TLS 1.2 if allowed by `tls_version_min`, or fail (with error
+    /// -9830) with the `native-tls` backend due to lack of TLS 1.3 support.
     ///
-    /// A value of `tls::Version::TLS_1_3` will cause an error with the
-    /// `native-tls` backend. This does not mean the version
-    /// isn't supported, just that it can't be set as a maximum due to
-    /// technical limitations.
+    /// # Errors
     ///
     /// Cannot set a maximum outside the protocol versions supported by
     /// `rustls` with the `rustls` backend.
@@ -2209,14 +2201,14 @@ impl ClientBuilder {
                 (&mut tls as &mut dyn Any).downcast_mut::<Option<rustls::ClientConfig>>()
             {
                 let tls = conn.take().expect("is definitely Some");
-                let tls = crate::tls::TlsBackend::BuiltRustls(tls);
+                let tls = TlsBackend::BuiltRustls(tls);
                 self.config.tls = tls;
                 return self;
             }
         }
 
         // Otherwise, we don't recognize the TLS backend!
-        self.config.tls = crate::tls::TlsBackend::UnknownPreconfigured;
+        self.config.tls = TlsBackend::UnknownPreconfigured;
         self
     }
 
@@ -2473,7 +2465,7 @@ impl ClientBuilder {
     }
 }
 
-type HyperClient = hyper_util::client::legacy::Client<Connector, super::Body>;
+type HyperClient = hyper_util::client::legacy::Client<Connector, Body>;
 
 impl Default for Client {
     fn default() -> Self {
@@ -2735,7 +2727,7 @@ impl fmt::Debug for Client {
     }
 }
 
-impl tower_service::Service<Request> for Client {
+impl Service<Request> for Client {
     type Response = Response;
     type Error = crate::Error;
     type Future = Pending;
@@ -2749,7 +2741,7 @@ impl tower_service::Service<Request> for Client {
     }
 }
 
-impl tower_service::Service<Request> for &'_ Client {
+impl Service<Request> for &'_ Client {
     type Response = Response;
     type Error = crate::Error;
     type Future = Pending;
@@ -3077,7 +3069,7 @@ impl Future for PendingRequest {
         if let Some(delay) = self.as_mut().total_timeout().as_mut().as_pin_mut() {
             if let Poll::Ready(()) = delay.poll(cx) {
                 return Poll::Ready(Err(
-                    crate::error::request(crate::error::TimedOut).with_url(self.url.clone())
+                    error::request(error::TimedOut).with_url(self.url.clone())
                 ));
             }
         }
@@ -3085,7 +3077,7 @@ impl Future for PendingRequest {
         if let Some(delay) = self.as_mut().read_timeout().as_mut().as_pin_mut() {
             if let Poll::Ready(()) = delay.poll(cx) {
                 return Poll::Ready(Err(
-                    crate::error::request(crate::error::TimedOut).with_url(self.url.clone())
+                    error::request(error::TimedOut).with_url(self.url.clone())
                 ));
             }
         }
@@ -3112,7 +3104,7 @@ impl Future for PendingRequest {
         {
             self.url = match Url::parse(&url.0.to_string()) {
                 Ok(url) => url,
-                Err(e) => return Poll::Ready(Err(crate::error::decode(e))),
+                Err(e) => return Poll::Ready(Err(error::decode(e))),
             }
         };
 
@@ -3170,7 +3162,7 @@ mod tests {
 
     #[test]
     fn test_future_size() {
-        let s = std::mem::size_of::<super::Pending>();
+        let s = size_of::<super::Pending>();
         assert!(s < 128, "size_of::<Pending>() == {s}, too big");
     }
 }

--- a/src/async_impl/h3_client/mod.rs
+++ b/src/async_impl/h3_client/mod.rs
@@ -46,10 +46,10 @@ impl H3Client {
             pool::Connecting::InProgress(waiter) => {
                 trace!("connecting to {key:?} is already in progress, subscribing...");
 
-                match waiter.receive().await {
-                    Some(client) => return Ok(client),
-                    None => return Err("failed to establish connection for HTTP/3 request".into()),
-                }
+                return match waiter.receive().await {
+                    Some(client) => Ok(client),
+                    None => Err("failed to establish connection for HTTP/3 request".into()),
+                };
             }
             pool::Connecting::Acquired(lock) => lock,
         };

--- a/src/async_impl/multipart.rs
+++ b/src/async_impl/multipart.rs
@@ -604,7 +604,9 @@ mod tests {
     use super::*;
     use futures_util::stream;
     use futures_util::TryStreamExt;
+    use mime_guess::mime;
     use std::future;
+    use std::io;
     use tokio::{self, runtime};
 
     #[test]
@@ -634,10 +636,7 @@ mod tests {
                 ))))),
             )
             .part("key1", Part::text("value1"))
-            .part(
-                "key2",
-                Part::text("value2").mime(mime_guess::mime::IMAGE_BMP),
-            )
+            .part("key2", Part::text("value2").mime(mime::IMAGE_BMP))
             .part(
                 "reader2",
                 Part::stream(Body::stream(stream::once(future::ready::<
@@ -683,7 +682,7 @@ mod tests {
 
     #[test]
     fn stream_to_end_with_header() {
-        let mut part = Part::text("value2").mime(mime_guess::mime::IMAGE_BMP);
+        let mut part = Part::text("value2").mime(mime::IMAGE_BMP);
         let mut headers = HeaderMap::new();
         headers.insert("Hdr3", "/a/b/c".parse().unwrap());
         part = part.headers(headers);
@@ -720,7 +719,7 @@ mod tests {
         let stream_len = stream_data.len();
         let stream_data = stream_data
             .chunks(3)
-            .map(|c| Ok::<_, std::io::Error>(Bytes::from(c)));
+            .map(|c| Ok::<_, io::Error>(Bytes::from(c)));
         let the_stream = futures_util::stream::iter(stream_data);
 
         let bytes_data = b"some bytes data".to_vec();

--- a/src/async_impl/request.rs
+++ b/src/async_impl/request.rs
@@ -189,7 +189,7 @@ impl RequestBuilder {
     pub fn from_parts(client: Client, request: Request) -> RequestBuilder {
         RequestBuilder {
             client,
-            request: crate::Result::Ok(request),
+            request: Ok(request),
         }
     }
 
@@ -239,7 +239,7 @@ impl RequestBuilder {
     /// Add a set of Headers to the existing ones on this Request.
     ///
     /// The headers will be merged in to any already set.
-    pub fn headers(mut self, headers: crate::header::HeaderMap) -> RequestBuilder {
+    pub fn headers(mut self, headers: HeaderMap) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             crate::util::replace_headers(req.headers_mut(), headers);
         }
@@ -812,12 +812,12 @@ mod tests {
     #[test]
     #[cfg(feature = "stream")]
     fn try_clone_stream() {
-        let chunks: Vec<Result<_, ::std::io::Error>> = vec![Ok("hello"), Ok(" "), Ok("world")];
+        let chunks: Vec<Result<_, std::io::Error>> = vec![Ok("hello"), Ok(" "), Ok("world")];
         let stream = futures_util::stream::iter(chunks);
         let client = Client::new();
         let builder = client
             .get("http://httpbin.org/get")
-            .body(super::Body::wrap_stream(stream));
+            .body(Body::wrap_stream(stream));
         let clone = builder.try_clone();
         assert!(clone.is_none());
     }
@@ -876,7 +876,7 @@ mod tests {
         let client = Client::new();
         let some_url = "https://localhost/";
 
-        let mut header = http::HeaderValue::from_static("in plain sight");
+        let mut header = HeaderValue::from_static("in plain sight");
         header.set_sensitive(true);
 
         let req = client

--- a/src/async_impl/response.rs
+++ b/src/async_impl/response.rs
@@ -461,7 +461,7 @@ impl<T: Into<Body>> From<http::Response<T>> for Response {
         use crate::response::ResponseUrl;
 
         let (mut parts, body) = r.into_parts();
-        let body: crate::async_impl::body::Body = body.into();
+        let body: Body = body.into();
         let url = parts
             .extensions
             .remove::<ResponseUrl>()

--- a/src/async_impl/upgrade.rs
+++ b/src/async_impl/upgrade.rs
@@ -29,20 +29,20 @@ impl AsyncWrite for Upgraded {
         Pin::new(&mut self.inner).poll_write(cx, buf)
     }
 
-    fn poll_write_vectored(
-        mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-        bufs: &[io::IoSlice<'_>],
-    ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
-    }
-
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_flush(cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
     }
 
     fn is_write_vectored(&self) -> bool {

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -381,6 +381,7 @@ impl Read for Reader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mime_guess::mime;
 
     #[test]
     fn form_empty() {
@@ -396,13 +397,10 @@ mod tests {
     fn read_to_end() {
         let mut output = Vec::new();
         let mut form = Form::new()
-            .part("reader1", Part::reader(std::io::empty()))
+            .part("reader1", Part::reader(io::empty()))
             .part("key1", Part::text("value1"))
-            .part(
-                "key2",
-                Part::text("value2").mime(mime_guess::mime::IMAGE_BMP),
-            )
-            .part("reader2", Part::reader(std::io::empty()))
+            .part("key2", Part::text("value2").mime(mime::IMAGE_BMP))
+            .part("reader2", Part::reader(io::empty()))
             .part("key3", Part::text("value3").file_name("filename"));
         form.inner.boundary = "boundary".to_string();
         let length = form.compute_length();
@@ -438,10 +436,7 @@ mod tests {
         let mut output = Vec::new();
         let mut form = Form::new()
             .text("key1", "value1")
-            .part(
-                "key2",
-                Part::text("value2").mime(mime_guess::mime::IMAGE_BMP),
-            )
+            .part("key2", Part::text("value2").mime(mime::IMAGE_BMP))
             .part("key3", Part::text("value3").file_name("filename"));
         form.inner.boundary = "boundary".to_string();
         let length = form.compute_length();
@@ -469,7 +464,7 @@ mod tests {
     #[test]
     fn read_to_end_with_header() {
         let mut output = Vec::new();
-        let mut part = Part::text("value2").mime(mime_guess::mime::IMAGE_BMP);
+        let mut part = Part::text("value2").mime(mime::IMAGE_BMP);
         let mut headers = HeaderMap::new();
         headers.insert("Hdr3", "/a/b/c".parse().unwrap());
         part = part.headers(headers);

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -174,7 +174,7 @@ impl RequestBuilder {
     pub fn from_parts(client: Client, request: Request) -> RequestBuilder {
         RequestBuilder {
             client,
-            request: crate::Result::Ok(request),
+            request: Ok(request),
         }
     }
 
@@ -258,7 +258,7 @@ impl RequestBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn headers(mut self, headers: crate::header::HeaderMap) -> RequestBuilder {
+    pub fn headers(mut self, headers: HeaderMap) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
             crate::util::replace_headers(req.headers_mut(), headers);
         }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1343,19 +1343,6 @@ pub(crate) mod sealed {
             Write::poll_write(this.inner, cx, buf)
         }
 
-        fn poll_write_vectored(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            bufs: &[IoSlice<'_>],
-        ) -> Poll<Result<usize, io::Error>> {
-            let this = self.project();
-            Write::poll_write_vectored(this.inner, cx, bufs)
-        }
-
-        fn is_write_vectored(&self) -> bool {
-            self.inner.is_write_vectored()
-        }
-
         fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
             let this = self.project();
             Write::poll_flush(this.inner, cx)
@@ -1364,6 +1351,19 @@ pub(crate) mod sealed {
         fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
             let this = self.project();
             Write::poll_shutdown(this.inner, cx)
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            self.inner.is_write_vectored()
+        }
+
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<Result<usize, io::Error>> {
+            let this = self.project();
+            Write::poll_write_vectored(this.inner, cx, bufs)
         }
     }
 }
@@ -1771,7 +1771,7 @@ mod rustls_tls_conn {
             self: Pin<&mut Self>,
             cx: &mut Context,
             buf: ReadBufCursor<'_>,
-        ) -> Poll<tokio::io::Result<()>> {
+        ) -> Poll<io::Result<()>> {
             let this = self.project();
             Read::poll_read(this.inner, cx, buf)
         }
@@ -1782,9 +1782,23 @@ mod rustls_tls_conn {
             self: Pin<&mut Self>,
             cx: &mut Context,
             buf: &[u8],
-        ) -> Poll<Result<usize, tokio::io::Error>> {
+        ) -> Poll<Result<usize, io::Error>> {
             let this = self.project();
             Write::poll_write(this.inner, cx, buf)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
+            let this = self.project();
+            Write::poll_flush(this.inner, cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
+            let this = self.project();
+            Write::poll_shutdown(this.inner, cx)
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            self.inner.is_write_vectored()
         }
 
         fn poll_write_vectored(
@@ -1794,26 +1808,6 @@ mod rustls_tls_conn {
         ) -> Poll<Result<usize, io::Error>> {
             let this = self.project();
             Write::poll_write_vectored(this.inner, cx, bufs)
-        }
-
-        fn is_write_vectored(&self) -> bool {
-            self.inner.is_write_vectored()
-        }
-
-        fn poll_flush(
-            self: Pin<&mut Self>,
-            cx: &mut Context,
-        ) -> Poll<Result<(), tokio::io::Error>> {
-            let this = self.project();
-            Write::poll_flush(this.inner, cx)
-        }
-
-        fn poll_shutdown(
-            self: Pin<&mut Self>,
-            cx: &mut Context,
-        ) -> Poll<Result<(), tokio::io::Error>> {
-            let this = self.project();
-            Write::poll_shutdown(this.inner, cx)
         }
     }
     impl<T> TlsInfoFactory for RustlsTlsConn<T>
@@ -1986,7 +1980,7 @@ mod verbose {
             mut self: Pin<&mut Self>,
             cx: &mut Context,
             mut buf: ReadBufCursor<'_>,
-        ) -> Poll<std::io::Result<()>> {
+        ) -> Poll<io::Result<()>> {
             // TODO: This _does_ forget the `init` len, so it could result in
             // re-initializing twice. Needs upstream support, perhaps.
             // SAFETY: Passing to a ReadBuf will never de-initialize any bytes.
@@ -2013,7 +2007,7 @@ mod verbose {
             mut self: Pin<&mut Self>,
             cx: &mut Context,
             buf: &[u8],
-        ) -> Poll<Result<usize, std::io::Error>> {
+        ) -> Poll<Result<usize, io::Error>> {
             match Pin::new(&mut self.inner).poll_write(cx, buf) {
                 Poll::Ready(Ok(n)) => {
                     log::trace!("{:08x} write: {:?}", self.id, Escape::new(&buf[..n]));
@@ -2022,6 +2016,21 @@ mod verbose {
                 Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
                 Poll::Pending => Poll::Pending,
             }
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
+            Pin::new(&mut self.inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context,
+        ) -> Poll<Result<(), io::Error>> {
+            Pin::new(&mut self.inner).poll_shutdown(cx)
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            self.inner.is_write_vectored()
         }
 
         fn poll_write_vectored(
@@ -2041,24 +2050,6 @@ mod verbose {
                 Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
                 Poll::Pending => Poll::Pending,
             }
-        }
-
-        fn is_write_vectored(&self) -> bool {
-            self.inner.is_write_vectored()
-        }
-
-        fn poll_flush(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context,
-        ) -> Poll<Result<(), std::io::Error>> {
-            Pin::new(&mut self.inner).poll_flush(cx)
-        }
-
-        fn poll_shutdown(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context,
-        ) -> Poll<Result<(), std::io::Error>> {
-            Pin::new(&mut self.inner).poll_shutdown(cx)
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -210,7 +210,7 @@ impl Error {
 #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
 pub(crate) fn cast_to_internal_error(error: BoxError) -> BoxError {
     if error.is::<tower::timeout::error::Elapsed>() {
-        Box::new(crate::error::TimedOut) as BoxError
+        Box::new(TimedOut) as BoxError
     } else {
         error
     }
@@ -427,7 +427,7 @@ mod tests {
         let root = Error::new(Kind::Request, None::<Error>);
         assert!(root.source().is_none());
 
-        let link = super::body(root);
+        let link = body(root);
         assert!(link.source().is_some());
         assert_send::<Error>();
         assert_sync::<Error>();
@@ -441,11 +441,11 @@ mod tests {
 
     #[test]
     fn roundtrip_io_error() {
-        let orig = super::request("orig");
+        let orig = request("orig");
         // Convert reqwest::Error into an io::Error...
         let io = orig.into_io();
         // Convert that io::Error back into a reqwest::Error...
-        let err = super::decode_io(io);
+        let err = decode_io(io);
         // It should have pulled out the original, not nested it...
         match err.inner.kind {
             Kind::Request => (),
@@ -456,7 +456,7 @@ mod tests {
     #[test]
     fn from_unknown_io_error() {
         let orig = io::Error::new(io::ErrorKind::Other, "orly");
-        let err = super::decode_io(orig);
+        let err = decode_io(orig);
         match err.inner.kind {
             Kind::Decode => (),
             _ => panic!("{err:?}"),
@@ -465,13 +465,13 @@ mod tests {
 
     #[test]
     fn is_timeout() {
-        let err = super::request(super::TimedOut);
+        let err = request(TimedOut);
         assert!(err.is_timeout());
 
         // todo: test `hyper::Error::is_timeout` when we can easily construct one
 
         let io = io::Error::from(io::ErrorKind::TimedOut);
-        let nested = super::request(io);
+        let nested = request(io);
         assert!(nested.is_timeout());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@ pub use self::response::ResponseBuilderExt;
 /// - supplied `Url` cannot be parsed
 /// - there was an error while sending request
 /// - redirect limit was exhausted
-pub async fn get<T: IntoUrl>(url: T) -> crate::Result<Response> {
+pub async fn get<T: IntoUrl>(url: T) -> Result<Response> {
     Client::builder().build()?.get(url).send().await
 }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -587,7 +587,7 @@ impl fmt::Debug for Matcher {
 }
 
 impl Intercepted {
-    pub(crate) fn uri(&self) -> &http::Uri {
+    pub(crate) fn uri(&self) -> &Uri {
         self.inner.uri()
     }
 
@@ -776,7 +776,7 @@ struct Custom {
 }
 
 impl Custom {
-    fn call(&self, uri: &http::Uri) -> Option<matcher::Intercept> {
+    fn call(&self, uri: &Uri) -> Option<matcher::Intercept> {
         let url = format!(
             "{}://{}{}{}",
             uri.scheme()?,
@@ -814,7 +814,7 @@ pub(crate) fn encode_basic_auth(username: &str, password: &str) -> HeaderValue {
 mod tests {
     use super::*;
 
-    fn url(s: &str) -> http::Uri {
+    fn url(s: &str) -> Uri {
         s.parse().unwrap()
     }
 
@@ -890,7 +890,7 @@ mod tests {
         let target = "http://example.domain/";
         let p = Proxy::all(target)
             .unwrap()
-            .custom_http_auth(http::HeaderValue::from_static("testme"))
+            .custom_http_auth(HeaderValue::from_static("testme"))
             .into_matcher();
 
         let got = p.intercept(&url("http://anywhere.local")).unwrap();
@@ -902,7 +902,7 @@ mod tests {
     fn test_custom_with_custom_auth_header() {
         let target = "http://example.domain/";
         let p = Proxy::custom(move |_| target.parse::<Url>().ok())
-            .custom_http_auth(http::HeaderValue::from_static("testme"))
+            .custom_http_auth(HeaderValue::from_static("testme"))
             .into_matcher();
 
         let got = p.intercept(&url("http://anywhere.local")).unwrap();

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -41,6 +41,7 @@ use std::time::Duration;
 
 use tower::retry::budget::{Budget as _, TpsBudget as Budget};
 
+use crate::retry::classify::ReqRep;
 #[cfg(docsrs)]
 pub use classify::ReqRep;
 
@@ -181,7 +182,7 @@ impl Builder {
     /// ```
     pub fn classify_fn<F>(self, func: F) -> Self
     where
-        F: Fn(classify::ReqRep<'_>) -> classify::Action + Send + Sync + 'static,
+        F: Fn(ReqRep<'_>) -> classify::Action + Send + Sync + 'static,
     {
         self.classify(classify::ClassifyFn(func))
     }
@@ -342,7 +343,7 @@ mod scope {
         F: Fn(&super::Req) -> bool + Send + Sync + 'static,
     {
         fn applies_to(&self, req: &super::Req) -> bool {
-            (self.0)(req)
+            self.0(req)
         }
     }
 
@@ -392,7 +393,7 @@ mod classify {
         F: Fn(ReqRep<'_>) -> Action + Send + Sync + 'static,
     {
         fn classify(&self, req_rep: ReqRep<'_>) -> Action {
-            (self.0)(req_rep)
+            self.0(req_rep)
         }
     }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -236,10 +236,7 @@ impl Certificate {
     }
 
     #[cfg(feature = "__rustls")]
-    pub(crate) fn add_to_rustls(
-        self,
-        root_cert_store: &mut rustls::RootCertStore,
-    ) -> crate::Result<()> {
+    pub(crate) fn add_to_rustls(self, root_cert_store: &mut RootCertStore) -> crate::Result<()> {
         use std::io::Cursor;
 
         match self.original {
@@ -376,7 +373,7 @@ impl Identity {
 
         let (key, certs) = {
             let mut pem = Cursor::new(buf);
-            let mut sk = Vec::<rustls_pki_types::PrivateKeyDer>::new();
+            let mut sk = Vec::<PrivateKeyDer>::new();
             let mut certs = Vec::<rustls_pki_types::CertificateDer>::new();
 
             while let Some((kind, data)) =
@@ -567,7 +564,7 @@ impl Version {
             InnerVersion::Tls1_0 => Some(native_tls_crate::Protocol::Tlsv10),
             InnerVersion::Tls1_1 => Some(native_tls_crate::Protocol::Tlsv11),
             InnerVersion::Tls1_2 => Some(native_tls_crate::Protocol::Tlsv12),
-            InnerVersion::Tls1_3 => None,
+            InnerVersion::Tls1_3 => Some(native_tls_crate::Protocol::Tlsv13),
         }
     }
 
@@ -637,7 +634,7 @@ impl Default for TlsBackend {
 
 #[cfg(feature = "__rustls")]
 pub(crate) fn rustls_store(certs: Vec<Certificate>) -> crate::Result<RootCertStore> {
-    let mut root_cert_store = rustls::RootCertStore::empty();
+    let mut root_cert_store = RootCertStore::empty();
     for cert in certs {
         cert.add_to_rustls(&mut root_cert_store)?;
     }
@@ -799,7 +796,7 @@ impl TlsInfo {
 }
 
 impl std::fmt::Debug for TlsInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("TlsInfo").finish()
     }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -47,7 +47,7 @@ async fn auto_headers() {
     });
 
     let url = format!("http://{}/1", server.addr());
-    let res = reqwest::Client::builder()
+    let res = Client::builder()
         .no_proxy()
         .build()
         .unwrap()
@@ -73,7 +73,7 @@ async fn donot_set_content_length_0_if_have_no_body() {
     });
 
     let url = format!("http://{}/content-length", server.addr());
-    let res = reqwest::Client::builder()
+    let res = Client::builder()
         .no_proxy()
         .build()
         .expect("client builder")
@@ -93,7 +93,7 @@ async fn user_agent() {
     });
 
     let url = format!("http://{}/ua", server.addr());
-    let res = reqwest::Client::builder()
+    let res = Client::builder()
         .user_agent("reqwest-test-agent")
         .build()
         .expect("client builder")
@@ -217,7 +217,7 @@ async fn overridden_dns_resolution_with_gai() {
         "http://{overridden_domain}:{}/domain_override",
         server.addr().port()
     );
-    let client = reqwest::Client::builder()
+    let client = Client::builder()
         .no_proxy()
         .resolve(overridden_domain, server.addr())
         .build()
@@ -242,7 +242,7 @@ async fn overridden_dns_resolution_with_gai_multiple() {
     );
     // the server runs on IPv4 localhost, so provide both IPv4 and IPv6 and let the happy eyeballs
     // algorithm decide which address to use.
-    let client = reqwest::Client::builder()
+    let client = Client::builder()
         .no_proxy()
         .resolve_to_addrs(
             overridden_domain,
@@ -330,7 +330,7 @@ async fn overridden_dns_resolution_with_hickory_dns_multiple() {
 fn use_preconfigured_tls_with_bogus_backend() {
     struct DefinitelyNotTls;
 
-    reqwest::Client::builder()
+    Client::builder()
         .use_preconfigured_tls(DefinitelyNotTls)
         .build()
         .expect_err("definitely is not TLS");
@@ -365,7 +365,7 @@ fn use_preconfigured_rustls_default() {
     .with_root_certificates(root_cert_store)
     .with_no_client_auth();
 
-    reqwest::Client::builder()
+    Client::builder()
         .use_preconfigured_tls(tls)
         .build()
         .expect("preconfigured rustls tls");
@@ -393,7 +393,7 @@ async fn http2_upgrade() {
     let server = server::http(move |_| async move { http::Response::default() });
 
     let url = format!("https://localhost:{}", server.addr().port());
-    let res = reqwest::Client::builder()
+    let res = Client::builder()
         .tls_danger_accept_invalid_certs(true)
         .tls_backend_rustls()
         .build()
@@ -411,7 +411,7 @@ async fn http2_upgrade() {
 #[cfg_attr(feature = "http3", ignore = "enabling http3 seems to break this, why?")]
 #[tokio::test]
 async fn test_allowed_methods() {
-    let resp = reqwest::Client::builder()
+    let resp = Client::builder()
         .https_only(true)
         .build()
         .expect("client builder")
@@ -421,7 +421,7 @@ async fn test_allowed_methods() {
 
     assert!(resp.is_ok());
 
-    let resp = reqwest::Client::builder()
+    let resp = Client::builder()
         .https_only(true)
         .build()
         .expect("client builder")
@@ -465,7 +465,7 @@ fn update_json_content_type_if_set_manually() {
 #[cfg(all(feature = "__tls", not(feature = "rustls-no-provider")))]
 #[tokio::test]
 async fn test_tls_info() {
-    let resp = reqwest::Client::builder()
+    let resp = Client::builder()
         .tls_info(true)
         .build()
         .expect("client builder")
@@ -481,7 +481,7 @@ async fn test_tls_info() {
     let der = peer_certificate.unwrap();
     assert_eq!(der[0], 0x30); // ASN.1 SEQUENCE
 
-    let resp = reqwest::Client::builder()
+    let resp = Client::builder()
         .build()
         .expect("client builder")
         .get("https://google.com")
@@ -496,7 +496,7 @@ async fn test_tls_info() {
 async fn close_connection_after_idle_timeout() {
     let mut server = server::http(move |_| async move { http::Response::default() });
 
-    let client = reqwest::Client::builder()
+    let client = Client::builder()
         .pool_idle_timeout(std::time::Duration::from_secs(1))
         .build()
         .unwrap();

--- a/tests/support/delay_layer.rs
+++ b/tests/support/delay_layer.rs
@@ -59,10 +59,7 @@ where
 
     type Future = ResponseFuture<S::Future>;
 
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match self.inner.poll_ready(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(r) => Poll::Ready(r.map_err(Into::into)),

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -46,7 +46,7 @@ impl Drop for Server {
             let _ = tx.send(());
         }
 
-        if !::std::thread::panicking() {
+        if !thread::panicking() {
             self.panic_rx
                 .recv_timeout(Duration::from_secs(3))
                 .expect("test server should not panic");
@@ -83,7 +83,7 @@ where
             .build()
             .expect("new rt");
         let listener = rt.block_on(async move {
-            tokio::net::TcpListener::bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            tokio::net::TcpListener::bind(&net::SocketAddr::from(([127, 0, 0, 1], 0)))
                 .await
                 .unwrap()
         });
@@ -364,7 +364,7 @@ where
             .build()
             .expect("new rt");
         let listener = rt.block_on(async move {
-            tokio::net::TcpListener::bind(&std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            tokio::net::TcpListener::bind(&net::SocketAddr::from(([127, 0, 0, 1], 0)))
                 .await
                 .unwrap()
         });
@@ -428,7 +428,7 @@ where
 
 async fn low_level_read_http_request(
     client_socket: &mut TcpStream,
-) -> core::result::Result<Vec<u8>, std::io::Error> {
+) -> Result<Vec<u8>, std::io::Error> {
     let mut buf = Vec::new();
 
     // Read until the delimiter "\r\n\r\n" is found


### PR DESCRIPTION
Unnecessary prefixes were removed from the entire code.

The impl structure was standardized.

No code logic was modified or added separately.

It was verified that the tests passed successfully locally using cargo test --all.