### PR TITLE
Expose the RFC 9266 tls-exporter channel binding via TlsInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Add `TlsInfo::tls_exporter()` exposing the RFC 9266 `tls-exporter` channel binding (rustls backend).
+- Add `TlsInfo::tls_exporter_channel_binding()` exposing the RFC 9266 `tls-exporter` channel binding (rustls backend, TLS 1.3).
 
 ## v0.13.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `TlsInfo::tls_exporter()` exposing the RFC 9266 `tls-exporter` channel binding (rustls backend).
+
 ## v0.13.4
 
 - Add `ClientBuilder::tls_sslkeylogfile(bool)` option to allow using the related environment variable.

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -959,6 +959,17 @@ trait TlsInfoFactory {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo>;
 }
 
+#[cfg(feature = "__rustls")]
+fn rustls_tls_exporter(conn: &tokio_rustls::rustls::ClientConnection) -> Option<Vec<u8>> {
+    use tokio_rustls::rustls::ProtocolVersion;
+    if conn.protocol_version() != Some(ProtocolVersion::TLSv1_3) {
+        return None;
+    }
+    conn.export_keying_material([0u8; 32], b"EXPORTER-Channel-Binding", None)
+        .ok()
+        .map(|buf| buf.to_vec())
+}
+
 #[cfg(feature = "__tls")]
 impl<T: TlsInfoFactory> TlsInfoFactory for TokioIo<T> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
@@ -984,7 +995,11 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
             .ok()
             .flatten()
             .and_then(|c| c.to_der().ok());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        // native-tls does not expose TLS keying material, so no channel binding.
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter: None,
+        })
     }
 }
 
@@ -1001,7 +1016,11 @@ impl TlsInfoFactory
             .ok()
             .flatten()
             .and_then(|c| c.to_der().ok());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        // native-tls does not expose TLS keying material, so no channel binding.
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter: None,
+        })
     }
 }
 
@@ -1018,13 +1037,16 @@ impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::TcpStrea
 #[cfg(feature = "__rustls")]
 impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::net::TcpStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
-        let peer_certificate = self
-            .get_ref()
-            .1
+        let conn = self.get_ref().1;
+        let peer_certificate = conn
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        let tls_exporter = rustls_tls_exporter(conn);
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter,
+        })
     }
 }
 
@@ -1035,13 +1057,16 @@ impl TlsInfoFactory
     >
 {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
-        let peer_certificate = self
-            .get_ref()
-            .1
+        let conn = self.get_ref().1;
+        let peer_certificate = conn
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        let tls_exporter = rustls_tls_exporter(conn);
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter,
+        })
     }
 }
 
@@ -1075,7 +1100,11 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
             .ok()
             .flatten()
             .and_then(|c| c.to_der().ok());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        // native-tls does not expose TLS keying material, so no channel binding.
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter: None,
+        })
     }
 }
 
@@ -1093,7 +1122,11 @@ impl TlsInfoFactory
             .ok()
             .flatten()
             .and_then(|c| c.to_der().ok());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        // native-tls does not expose TLS keying material, so no channel binding.
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter: None,
+        })
     }
 }
 
@@ -1112,13 +1145,16 @@ impl TlsInfoFactory for hyper_tls::MaybeHttpsStream<TokioIo<tokio::net::UnixStre
 #[cfg(unix)]
 impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::net::UnixStream>>> {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
-        let peer_certificate = self
-            .get_ref()
-            .1
+        let conn = self.get_ref().1;
+        let peer_certificate = conn
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        let tls_exporter = rustls_tls_exporter(conn);
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter,
+        })
     }
 }
 
@@ -1130,13 +1166,16 @@ impl TlsInfoFactory
     >
 {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
-        let peer_certificate = self
-            .get_ref()
-            .1
+        let conn = self.get_ref().1;
+        let peer_certificate = conn
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        let tls_exporter = rustls_tls_exporter(conn);
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter,
+        })
     }
 }
 
@@ -1175,7 +1214,11 @@ impl TlsInfoFactory
             .ok()
             .flatten()
             .and_then(|c| c.to_der().ok());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        // native-tls does not expose TLS keying material, so no channel binding.
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter: None,
+        })
     }
 }
 
@@ -1195,7 +1238,11 @@ impl TlsInfoFactory
             .ok()
             .flatten()
             .and_then(|c| c.to_der().ok());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        // native-tls does not expose TLS keying material, so no channel binding.
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter: None,
+        })
     }
 }
 
@@ -1220,13 +1267,16 @@ impl TlsInfoFactory
     >
 {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
-        let peer_certificate = self
-            .get_ref()
-            .1
+        let conn = self.get_ref().1;
+        let peer_certificate = conn
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        let tls_exporter = rustls_tls_exporter(conn);
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter,
+        })
     }
 }
 
@@ -1242,13 +1292,16 @@ impl TlsInfoFactory
     >
 {
     fn tls_info(&self) -> Option<crate::tls::TlsInfo> {
-        let peer_certificate = self
-            .get_ref()
-            .1
+        let conn = self.get_ref().1;
+        let peer_certificate = conn
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        Some(crate::tls::TlsInfo { peer_certificate })
+        let tls_exporter = rustls_tls_exporter(conn);
+        Some(crate::tls::TlsInfo {
+            peer_certificate,
+            tls_exporter,
+        })
     }
 }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -960,7 +960,9 @@ trait TlsInfoFactory {
 }
 
 #[cfg(feature = "__rustls")]
-fn rustls_tls_exporter(conn: &tokio_rustls::rustls::ClientConnection) -> Option<Vec<u8>> {
+fn rustls_tls_exporter_channel_binding(
+    conn: &tokio_rustls::rustls::ClientConnection,
+) -> Option<Vec<u8>> {
     use tokio_rustls::rustls::ProtocolVersion;
     if conn.protocol_version() != Some(ProtocolVersion::TLSv1_3) {
         return None;
@@ -998,7 +1000,7 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
         // native-tls does not expose TLS keying material, so no channel binding.
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter: None,
+            tls_exporter_channel_binding: None,
         })
     }
 }
@@ -1019,7 +1021,7 @@ impl TlsInfoFactory
         // native-tls does not expose TLS keying material, so no channel binding.
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter: None,
+            tls_exporter_channel_binding: None,
         })
     }
 }
@@ -1042,10 +1044,10 @@ impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::n
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        let tls_exporter = rustls_tls_exporter(conn);
+        let tls_exporter_channel_binding = rustls_tls_exporter_channel_binding(conn);
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter,
+            tls_exporter_channel_binding,
         })
     }
 }
@@ -1062,10 +1064,10 @@ impl TlsInfoFactory
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        let tls_exporter = rustls_tls_exporter(conn);
+        let tls_exporter_channel_binding = rustls_tls_exporter_channel_binding(conn);
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter,
+            tls_exporter_channel_binding,
         })
     }
 }
@@ -1103,7 +1105,7 @@ impl TlsInfoFactory for tokio_native_tls::TlsStream<TokioIo<TokioIo<tokio::net::
         // native-tls does not expose TLS keying material, so no channel binding.
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter: None,
+            tls_exporter_channel_binding: None,
         })
     }
 }
@@ -1125,7 +1127,7 @@ impl TlsInfoFactory
         // native-tls does not expose TLS keying material, so no channel binding.
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter: None,
+            tls_exporter_channel_binding: None,
         })
     }
 }
@@ -1150,10 +1152,10 @@ impl TlsInfoFactory for tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::n
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        let tls_exporter = rustls_tls_exporter(conn);
+        let tls_exporter_channel_binding = rustls_tls_exporter_channel_binding(conn);
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter,
+            tls_exporter_channel_binding,
         })
     }
 }
@@ -1171,10 +1173,10 @@ impl TlsInfoFactory
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        let tls_exporter = rustls_tls_exporter(conn);
+        let tls_exporter_channel_binding = rustls_tls_exporter_channel_binding(conn);
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter,
+            tls_exporter_channel_binding,
         })
     }
 }
@@ -1217,7 +1219,7 @@ impl TlsInfoFactory
         // native-tls does not expose TLS keying material, so no channel binding.
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter: None,
+            tls_exporter_channel_binding: None,
         })
     }
 }
@@ -1241,7 +1243,7 @@ impl TlsInfoFactory
         // native-tls does not expose TLS keying material, so no channel binding.
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter: None,
+            tls_exporter_channel_binding: None,
         })
     }
 }
@@ -1272,10 +1274,10 @@ impl TlsInfoFactory
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        let tls_exporter = rustls_tls_exporter(conn);
+        let tls_exporter_channel_binding = rustls_tls_exporter_channel_binding(conn);
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter,
+            tls_exporter_channel_binding,
         })
     }
 }
@@ -1297,10 +1299,10 @@ impl TlsInfoFactory
             .peer_certificates()
             .and_then(|certs| certs.first())
             .map(|c| c.to_vec());
-        let tls_exporter = rustls_tls_exporter(conn);
+        let tls_exporter_channel_binding = rustls_tls_exporter_channel_binding(conn);
         Some(crate::tls::TlsInfo {
             peer_certificate,
-            tls_exporter,
+            tls_exporter_channel_binding,
         })
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -789,7 +789,7 @@ impl ServerCertVerifier for IgnoreHostname {
 #[derive(Clone)]
 pub struct TlsInfo {
     pub(crate) peer_certificate: Option<Vec<u8>>,
-    pub(crate) tls_exporter: Option<Vec<u8>>,
+    pub(crate) tls_exporter_channel_binding: Option<Vec<u8>>,
 }
 
 impl TlsInfo {
@@ -799,8 +799,8 @@ impl TlsInfo {
     }
 
     /// Get the [RFC 9266] `tls-exporter` channel binding for this connection.
-    pub fn tls_exporter(&self) -> Option<&[u8]> {
-        self.tls_exporter.as_ref().map(|v| &v[..])
+    pub fn tls_exporter_channel_binding(&self) -> Option<&[u8]> {
+        self.tls_exporter_channel_binding.as_ref().map(|v| &v[..])
     }
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -789,12 +789,18 @@ impl ServerCertVerifier for IgnoreHostname {
 #[derive(Clone)]
 pub struct TlsInfo {
     pub(crate) peer_certificate: Option<Vec<u8>>,
+    pub(crate) tls_exporter: Option<Vec<u8>>,
 }
 
 impl TlsInfo {
     /// Get the DER encoded leaf certificate of the peer.
     pub fn peer_certificate(&self) -> Option<&[u8]> {
         self.peer_certificate.as_ref().map(|der| &der[..])
+    }
+
+    /// Get the [RFC 9266] `tls-exporter` channel binding for this connection.
+    pub fn tls_exporter(&self) -> Option<&[u8]> {
+        self.tls_exporter.as_ref().map(|v| &v[..])
     }
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -492,6 +492,30 @@ async fn test_tls_info() {
     assert!(tls_info.is_none());
 }
 
+#[cfg(feature = "__rustls")]
+#[tokio::test]
+async fn test_tls_info_exporter() {
+    let resp = reqwest::Client::builder()
+        .tls_info(true)
+        .build()
+        .expect("client builder")
+        .get("https://google.com")
+        .send()
+        .await
+        .expect("response");
+    let tls_info = resp
+        .extensions()
+        .get::<reqwest::tls::TlsInfo>()
+        .expect("tls info");
+    // The rustls backend exposes the RFC 9266 tls-exporter channel binding.
+    let exporter = tls_info.tls_exporter();
+    assert!(
+        exporter.is_some(),
+        "rustls should expose the tls-exporter channel binding"
+    );
+    assert_eq!(exporter.unwrap().len(), 32);
+}
+
 #[tokio::test]
 async fn close_connection_after_idle_timeout() {
     let mut server = server::http(move |_| async move { http::Response::default() });

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -492,11 +492,14 @@ async fn test_tls_info() {
     assert!(tls_info.is_none());
 }
 
-#[cfg(feature = "__rustls")]
+#[cfg(all(feature = "__rustls", not(feature = "rustls-no-provider")))]
 #[tokio::test]
 async fn test_tls_info_exporter() {
     let resp = reqwest::Client::builder()
         .tls_info(true)
+        // Pin rustls: the channel binding is rustls-only, and native-tls would
+        // otherwise take over as the active backend when both are enabled.
+        .tls_backend_rustls()
         .build()
         .expect("client builder")
         .get("https://google.com")
@@ -508,7 +511,7 @@ async fn test_tls_info_exporter() {
         .get::<reqwest::tls::TlsInfo>()
         .expect("tls info");
     // The rustls backend exposes the RFC 9266 tls-exporter channel binding.
-    let exporter = tls_info.tls_exporter();
+    let exporter = tls_info.tls_exporter_channel_binding();
     assert!(
         exporter.is_some(),
         "rustls should expose the tls-exporter channel binding"


### PR DESCRIPTION
Adds `TlsInfo::tls_exporter_channel_binding()`, returning the RFC 9266 tls-exporter channel binding for a connection (the TLS exporter with label EXPORTER-Channel-Binding, empty context, 32 bytes).

The channel binding lets applications cryptographically tie higher-layer authentication to the underlying TLS session to detect a man-in-the-middle that terminates and re-originates TLS, etc. This change simply exposes the value that `rustls` already computes.

A few caveats:

- Populated for the rustls backend; `None` for native-tls (no keying-material export is exposed).
- Gated to TLS 1.3. The exporter is only sound for channel binding on TLS 1.3 or TLS 1.2 with Extended Master Secret (RFC 7627), and the state of EMS cannot be known here. This returns `None` on anything below 1.3 rather than risk handing back a potentially unsound `Some(_)`.