### PR TITLE
Add `Referrer` and `Referrer Policy` methods to WASM Request API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ features = [
     "RequestCredentials",
     "File",
     "ReadableStream",
+    "ReferrerPolicy",
     "RequestCache"
 ]
 

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -198,6 +198,14 @@ async fn fetch(req: Request) -> crate::Result<Response> {
     let mut init = web_sys::RequestInit::new();
     init.method(req.method().as_str());
 
+    if let Some(referrer) = &req.referrer {
+        init.set_referrer(referrer);
+    }
+
+    if let Some(policy) = req.referrer_policy {
+        init.set_referrer_policy(policy);
+    }
+
     // convert HeaderMap to Headers
     let js_headers = web_sys::Headers::new()
         .map_err(crate::error::wasm)

--- a/src/wasm/client.rs
+++ b/src/wasm/client.rs
@@ -202,7 +202,20 @@ async fn fetch(req: Request) -> crate::Result<Response> {
         init.set_referrer(referrer);
     }
 
-    if let Some(policy) = req.referrer_policy {
+    if let Some(policy) = &req.referrer_policy {
+        let policy = match policy.as_str() {
+            "no-referrer" => web_sys::ReferrerPolicy::NoReferrer,
+            "no-referrer-when-downgrade" => web_sys::ReferrerPolicy::NoReferrerWhenDowngrade,
+            "origin" => web_sys::ReferrerPolicy::Origin,
+            "origin-when-cross-origin" => web_sys::ReferrerPolicy::OriginWhenCrossOrigin,
+            "same-origin" => web_sys::ReferrerPolicy::SameOrigin,
+            "strict-origin" => web_sys::ReferrerPolicy::StrictOrigin,
+            "strict-origin-when-cross-origin" => {
+                web_sys::ReferrerPolicy::StrictOriginWhenCrossOrigin
+            }
+            "unsafe-url" => web_sys::ReferrerPolicy::UnsafeUrl,
+            _ => web_sys::ReferrerPolicy::None,
+        };
         init.set_referrer_policy(policy);
     }
 

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 #[cfg(feature = "json")]
 use serde_json;
 use url::Url;
-use web_sys::{RequestCache, RequestCredentials, ReferrerPolicy};
+use web_sys::{RequestCache, RequestCredentials};
 
 use super::{Body, Client, Response};
 #[cfg(any(feature = "form", feature = "json"))]
@@ -27,7 +27,7 @@ pub struct Request {
     pub(super) credentials: Option<RequestCredentials>,
     pub(super) cache: Option<RequestCache>,
     pub(super) referrer: Option<String>,
-    pub(super) referrer_policy: Option<ReferrerPolicy>,
+    pub(super) referrer_policy: Option<String>,
 }
 
 /// A builder to construct the properties of a `Request`.
@@ -513,13 +513,13 @@ impl RequestBuilder {
     /// # WASM
     ///
     /// This maps to the browser `RequestInit.referrerPolicy` field.
-    pub fn fetch_referrer_policy(mut self, policy: web_sys::ReferrerPolicy) -> RequestBuilder {
+    pub fn fetch_referrer_policy(mut self, policy: &str) -> RequestBuilder {
         if let Ok(ref mut req) = self.request {
-            req.referrer_policy = Some(policy);
+            req.referrer_policy = Some(policy.to_string());
         }
         self
     }
-    
+
     /// Build a `Request`, which can be inspected, modified and executed with
     /// `Client::execute()`.
     pub fn build(self) -> crate::Result<Request> {

--- a/src/wasm/request.rs
+++ b/src/wasm/request.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 #[cfg(feature = "json")]
 use serde_json;
 use url::Url;
-use web_sys::{RequestCache, RequestCredentials};
+use web_sys::{RequestCache, RequestCredentials, ReferrerPolicy};
 
 use super::{Body, Client, Response};
 #[cfg(any(feature = "form", feature = "json"))]
@@ -26,6 +26,8 @@ pub struct Request {
     pub(super) cors: bool,
     pub(super) credentials: Option<RequestCredentials>,
     pub(super) cache: Option<RequestCache>,
+    pub(super) referrer: Option<String>,
+    pub(super) referrer_policy: Option<ReferrerPolicy>,
 }
 
 /// A builder to construct the properties of a `Request`.
@@ -47,6 +49,8 @@ impl Request {
             cors: true,
             credentials: None,
             cache: None,
+            referrer: None,
+            referrer_policy: None,
         }
     }
 
@@ -128,6 +132,8 @@ impl Request {
             cors: self.cors,
             credentials: self.credentials,
             cache: self.cache,
+            referrer: self.referrer.clone(),
+            referrer_policy: self.referrer_policy.clone(),
         })
     }
 }
@@ -490,6 +496,30 @@ impl RequestBuilder {
         self
     }
 
+    /// Set fetch referrer
+    ///
+    /// # WASM
+    ///
+    /// This maps to the browser `RequestInit.referrer` field.
+    pub fn fetch_referrer(mut self, referrer: &str) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            req.referrer = Some(referrer.to_string());
+        }
+        self
+    }
+
+    /// Set fetch referrer policy
+    ///
+    /// # WASM
+    ///
+    /// This maps to the browser `RequestInit.referrerPolicy` field.
+    pub fn fetch_referrer_policy(mut self, policy: web_sys::ReferrerPolicy) -> RequestBuilder {
+        if let Ok(ref mut req) = self.request {
+            req.referrer_policy = Some(policy);
+        }
+        self
+    }
+    
     /// Build a `Request`, which can be inspected, modified and executed with
     /// `Client::execute()`.
     pub fn build(self) -> crate::Result<Request> {
@@ -609,6 +639,8 @@ where
             cors: true,
             credentials: None,
             cache: None,
+            referrer: None,
+            referrer_policy: None,
         })
     }
 }


### PR DESCRIPTION
Allows for setting of the referrer and referrer policy headers.

Turns out its extremely useful to have access to set these for fetch requests if sending them from a browser web worker.