### PR TITLE
fix(blocking): preserve version and extensions in TryFrom<http::Request>

### DIFF
--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -665,11 +665,15 @@ where
             method,
             uri,
             headers,
+            version,
+            extensions,
             ..
         } = parts;
         let url = Url::parse(&uri.to_string()).map_err(crate::error::builder)?;
         let mut inner = async_impl::Request::new(method, url);
         crate::util::replace_headers(inner.headers_mut(), headers);
+        *inner.version_mut() = version;
+        *inner.extensions_mut() = extensions;
         Ok(Request {
             body: Some(body.into()),
             inner,


### PR DESCRIPTION
The blocking `Request::try_from(http::Request<_>)` implementation was destructuring only `method`, `uri`, and `headers` from `http::request::Parts`, discarding `version` and `extensions`.

This made it inconsistent with the async `reqwest::Request` conversion which properly preserves both fields.

This PR fixes the blocking implementation to match the async behavior.

Fixes #2989