### PR TITLE
Add cargo-fuzz target for OSS-Fuzz integration

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "reqwest-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+http = "1"
+bytes = "1"
+
+[[bin]]
+name = "fuzz_url"
+path = "fuzz_targets/fuzz_url.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_url.rs
+++ b/fuzz/fuzz_targets/fuzz_url.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use bytes::Bytes;
+use http::Uri;
+
+fuzz_target!(|data: &[u8]| {
+    // reqwest URL parsing — pre-auth for every HTTP request
+    let _ = Uri::from_maybe_shared(Bytes::copy_from_slice(data));
+});


### PR DESCRIPTION
Adds cargo-fuzz target covering URL/URI parsing — the pre-auth boundary for every HTTP request.