### PR TITLE
feat: add `Error::is_dns()` to identify DNS resolution failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `Error::is_dns()` to identify errors caused by DNS resolution failures.
+
 ## v0.13.4
 
 - Add `ClientBuilder::tls_sslkeylogfile(bool)` option to allow using the related environment variable.

--- a/src/dns/resolve.rs
+++ b/src/dns/resolve.rs
@@ -97,7 +97,11 @@ impl DynResolver {
 
         let explicit_port = target.port().is_some();
 
-        let addrs = self.resolver.resolve(host.parse()?).await?;
+        let addrs = self
+            .resolver
+            .resolve(host.parse()?)
+            .await
+            .map_err(crate::error::dns)?;
 
         Ok(addrs.map(move |mut addr| {
             if explicit_port || addr.port() == 0 {
@@ -118,7 +122,9 @@ impl Service<HyperName> for DynResolver {
     }
 
     fn call(&mut self, name: HyperName) -> Self::Future {
-        self.resolver.resolve(Name(name))
+        let resolving = self.resolver.resolve(Name(name));
+        // Tag resolution failures so `Error::is_dns` can recognize them once
+        Box::pin(async move { resolving.await.map_err(crate::error::dns) })
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -512,6 +512,7 @@ mod tests {
         assert!(nested.is_timeout());
     }
 
+    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
     #[test]
     fn is_dns() {
         let err = super::request(DnsError { inner: "".into() });

--- a/src/error.rs
+++ b/src/error.rs
@@ -442,7 +442,7 @@ pub(crate) struct DnsError {
 
 impl fmt::Display for DnsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, f)
+        f.write_str("error resolving DNS")
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -166,6 +166,22 @@ impl Error {
         false
     }
 
+    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+    /// Returns true if the error is related to DNS resolution.
+    pub fn is_dns(&self) -> bool {
+        let mut source = self.source();
+
+        while let Some(err) = source {
+            if err.is::<DnsError>() {
+                return true;
+            }
+
+            source = err.source();
+        }
+
+        false
+    }
+
     /// Returns true if the error is related to the request or response body
     pub fn is_body(&self) -> bool {
         matches!(self.inner.kind, Kind::Body)
@@ -336,6 +352,10 @@ pub(crate) fn request<E: Into<BoxError>>(e: E) -> Error {
     Error::new(Kind::Request, Some(e))
 }
 
+pub(crate) fn dns<E: Into<BoxError>>(e: E) -> BoxError {
+    Box::new(DnsError { inner: e.into() })
+}
+
 pub(crate) fn redirect<E: Into<BoxError>>(e: E, url: Url) -> Error {
     Error::new(Kind::Redirect, Some(e)).with_url(url)
 }
@@ -415,6 +435,23 @@ impl fmt::Display for BadScheme {
 
 impl StdError for BadScheme {}
 
+#[derive(Debug)]
+pub(crate) struct DnsError {
+    pub(crate) inner: BoxError,
+}
+
+impl fmt::Display for DnsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl StdError for DnsError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&*self.inner as _)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -473,5 +510,11 @@ mod tests {
         let io = io::Error::from(io::ErrorKind::TimedOut);
         let nested = super::request(io);
         assert!(nested.is_timeout());
+    }
+
+    #[test]
+    fn is_dns() {
+        let err = super::request(DnsError { inner: "".into() });
+        assert!(err.is_dns());
     }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -207,6 +207,35 @@ async fn body_pipe_response() {
     assert_eq!(res2.status(), reqwest::StatusCode::OK);
 }
 
+struct FailingResolver;
+
+impl reqwest::dns::Resolve for FailingResolver {
+    fn resolve(&self, _name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        Box::pin(async { Err("simulated resolver failure".into()) })
+    }
+}
+
+#[tokio::test]
+async fn dns_resolution_failure_is_dns_error() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .dns_resolver(std::sync::Arc::new(FailingResolver))
+        .build()
+        .expect("client builder");
+
+    let err = client
+        .get("http://does.not.resolve.invalid/")
+        .send()
+        .await
+        .expect_err("request should fail during resolution");
+
+    assert!(err.is_dns(), "expected a DNS error, got: {err:?}");
+    // DNS errors are a refinement of connect errors.
+    assert!(err.is_connect(), "expected is_connect() to also be true");
+}
+
 #[tokio::test]
 async fn overridden_dns_resolution_with_gai() {
     let _ = env_logger::builder().is_test(true).try_init();


### PR DESCRIPTION
Adds `Error::is_dns()`, so you can tell a DNS resolution failure apart
from other connection errors. 
Closes #1501.

The resolver error gets boxed and re-wrapped on its way up, so it loses
its identity. To keep track of it, I tag it with an internal marker at
the one `DynResolver` point every resolver passes through, and `is_dns()`
looks for that marker in the source chain.

Side note: while working on this I noticed that on HTTP/3 `is_connect()`
never returns true for connection errors. It works by downcasting to
`hyper_util`'s legacy client error, which only the H1/H2 client produces;
the H3 client doesn't go through it. Not something this PR touches, just
flagging it. `is_dns()` still works on H3 since resolution goes through
`DynResolver`.