### PR TITLE
Fix blocking client timeout panic

### DIFF
--- a/src/blocking/wait.rs
+++ b/src/blocking/wait.rs
@@ -12,9 +12,17 @@ where
 {
     enter();
 
-    let deadline = timeout.map(|d| {
+    let deadline = timeout.and_then(|d| {
         log::trace!("wait at most {d:?}");
-        Instant::now() + d
+
+        let deadline = Instant::now().checked_add(d);
+
+        if deadline.is_none() {
+            log::warn!("timeout {d:?} overflows system clock, disabling timeout");
+        }
+
+        // Overflow means the deadline is effectively infinite, so None (no timeout) is correct.
+        deadline
     });
 
     let thread = ThreadWaker(thread::current());

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -279,6 +279,26 @@ async fn read_timeout_allows_slow_response_body() {
     assert_eq!(body, "012");
 }
 
+/// Tests that a big [`Duration`] does not overflow the system clock
+/// and instead behaves as if no timeout was set (the request completes normally).
+#[cfg(feature = "blocking")]
+#[test]
+fn big_timeout_duration_does_not_overflow() {
+    let _ = env_logger::try_init();
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::MAX)
+        .build()
+        .unwrap();
+
+    let server = server::http(move |_req| async { http::Response::default() });
+
+    let url = format!("http://{}/max-timeout", server.addr());
+    let res = client.get(&url).send().expect("request should succeed");
+
+    assert!(res.status().is_success());
+}
+
 /// Tests that internal client future cancels when the oneshot channel
 /// is canceled.
 #[cfg(feature = "blocking")]


### PR DESCRIPTION
## Description

So... I took down production today :sweat_smile:

### Problem

The blocking client uses `tokio::time::Instant` + `std::time::Duration` to compute a deadline for the request. However `tokio::time::Instant::add` just wraps around `std::time::Instant::add` while forgetting to add the panic doc in std which can be found on [std::time::Instant::add](https://doc.rust-lang.org/std/time/struct.Instant.html#method.add)

> Panics
> This function may panic if the resulting point in time cannot be represented by the underlying data structure. See [Instant::checked_add](https://doc.rust-lang.org/std/time/struct.Instant.html#method.checked_add) for a version without panic.

### Fix

If `Instant + Duration` overflows, disable timeout since the timeout is so big that it's effectively infinite.