### PR TITLE
Use `LookupIpStrategy::Ipv6AndIpv4` to actually prefer IPv6 when using `hickory-dns`

### DIFF
--- a/src/dns/hickory.rs
+++ b/src/dns/hickory.rs
@@ -64,6 +64,6 @@ fn new_resolver() -> Result<TokioResolver, NetError> {
             TokioRuntimeProvider::default(),
         )
     });
-    builder.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+    builder.options_mut().ip_strategy = LookupIpStrategy::Ipv6AndIpv4;
     builder.build()
 }


### PR DESCRIPTION
Fixes https://github.com/seanmonstar/reqwest/issues/2679. With the new `Ipv6AndIpv4` strategy (https://github.com/hickory-dns/hickory-dns/pull/3449), IPv6 should now correctly be preferred over IPv4 in case both addresses are available. I tried it out locally using this script and it worked fine:

```rust
use color_eyre::Result;
use tracing::info;

#[tokio::main]
#[tracing::instrument]
async fn main() -> Result<()> {
    color_eyre::install()?;
    tracing_subscriber::fmt::init();

    let client = reqwest::Client::default();

    let result = client
        .get("https://icanhazip.com/")
        .send()
        .await?
        .text()
        .await?;
    info!(result);
    Ok(())
}
```

Should I add some test, perhaps by starting some hickory server locally, or is it overkill for this use case?