### PR TITLE
fix(error): detect timeouts wrapped in body decode errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -123,6 +123,11 @@ impl Error {
             if err.is::<TimedOut>() {
                 return true;
             }
+            if let Some(err) = err.downcast_ref::<Error>() {
+                if err.is_timeout() {
+                    return true;
+                }
+            }
             #[cfg(not(all(
                 target_arch = "wasm32",
                 any(target_os = "unknown", target_os = "none")
@@ -498,6 +503,23 @@ mod tests {
             Kind::Decode => (),
             _ => panic!("{err:?}"),
         }
+    }
+
+    #[test]
+    fn decode_body_timeout_is_timeout() {
+        // A body timeout surfaced while decoding stays a decode error, but
+        // is_timeout still finds the timeout in the source chain.
+        let err = super::decode(super::body(super::TimedOut));
+        assert!(err.is_decode());
+        assert!(err.is_timeout());
+    }
+
+    #[test]
+    fn decode_wraps_other_errors() {
+        let io = io::Error::new(io::ErrorKind::Other, "boom");
+        let err = super::decode(io);
+        assert!(err.is_decode());
+        assert!(!err.is_timeout());
     }
 
     #[test]


### PR DESCRIPTION
Closes #2839.

When a read or total timeout fires while streaming the response body, the error is wrapped as a decode error (`Kind::Decode`), so `is_timeout()` didn't report it even though a timeout was the underlying cause — and `is_decode()` was true with the message "error decoding response body", which is misleading.

Per review feedback, this keeps the decode kind (the error did happen while decoding the body) and instead makes `is_timeout()` recurse into a nested `reqwest::Error` while walking the source chain. So a timeout wrapped in a decode error is now correctly reported by `is_timeout()`, while `is_decode()` stays true.

Added unit tests covering a body timeout wrapped by `decode` (both `is_decode()` and `is_timeout()` are true) and that an unrelated decode error is not a timeout.