### PR TITLE
Remove unnecessary clones and a cast

### DIFF
--- a/examples/connect_via_lower_priority_tokio_runtime.rs
+++ b/examples/connect_via_lower_priority_tokio_runtime.rs
@@ -73,7 +73,7 @@ mod background_threadpool {
             .spawn(move || {
                 let rt = tokio::runtime::Builder::new_multi_thread()
                     .thread_name("cpu-heavy-background-pool-thread")
-                    .worker_threads(num_cpus::get() as usize)
+                    .worker_threads(num_cpus::get())
                     // ref: https://github.com/tokio-rs/tokio/issues/4941
                     // consider uncommenting if seeing heavy task contention
                     // .disable_lifo_slot()

--- a/src/async_impl/client.rs
+++ b/src/async_impl/client.rs
@@ -756,7 +756,7 @@ impl ClientBuilder {
                         }
 
                         let verifier = if config.root_certs.is_empty() {
-                            rustls_platform_verifier::Verifier::new(provider.clone())
+                            rustls_platform_verifier::Verifier::new(provider)
                                 .map_err(crate::error::builder)?
                         } else {
                             #[cfg(any(
@@ -766,7 +766,7 @@ impl ClientBuilder {
                             {
                                 rustls_platform_verifier::Verifier::new_with_extra_roots(
                                     crate::tls::rustls_der(config.root_certs)?,
-                                    provider.clone(),
+                                    provider,
                                 )
                                 .map_err(crate::error::builder)?
                             }


### PR DESCRIPTION
As `num_cpus::get()` already returns a `usize`, the cast can be safely removed.
Moreover, I also found some redundant clones that could be removed.

CC @nunoplopes